### PR TITLE
Change how the expression used to find DICOM files is formatted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ structured directory layouts.
 - it's faster than parsesdicomdir or mri_convert if you use dcm2niix option
 - it tracks the provenance of the conversion from DICOM to NIfTI in W3C
   PROV format
-- the cmrr_heuristic example shows a conversion to [BIDS](http://bids.neuroimaging.io) 
+- the cmrr_heuristic example shows a conversion to [BIDS](http://bids.neuroimaging.io)
   layout structure
 
 ## Install
@@ -37,14 +37,15 @@ as long as the following dependencies are in your path you can use the script
 
 Call `heudiconv` like this:
 
-    heudiconv -d '%s*.tar*' -s xx05 -f ~/myheuristics/convertall.py
+    heudiconv -d '{participant}*.tar*' -s xx05 -f ~/myheuristics/convertall.py
 
-where `-d '%s*tar*'` is an expression used to find DICOM files (`%s` expands to
-a subject ID so that the expression will match any `.tar` files, compressed
-or not that start with the subject ID in their name). `-s od05` specifies a
-subject ID for the conversion (this could be a list of multiple IDs), and
-`-f ~/myheuristics/convertall.py` identifies a heuristic implementation for this
-conversion (see below) for details.
+where `-d '{participant}*tar*'` is an expression used to find DICOM files
+(`{participant}` expands to a subject ID so that the expression will match any
+`.tar` files, compressed or not that start with the subject ID in their name).
+An additional flag for session (`{session}`) can be included in the expression
+as well. `-s od05` specifies a subject ID for the conversion (this could be a
+list of multiple IDs), and `-f ~/myheuristics/convertall.py` identifies a
+heuristic implementation for this conversion (see below) for details.
 
 This call will locate the DICOMs (in any number of matching tarballs), extract
 them to a temporary directory, search for any DICOM series it can find, and
@@ -70,7 +71,7 @@ soon you'll be able to:
 ## The heuristic file
 
 The heuristic file controls how information about the dicoms is used to convert
-to a file system layout (e.g., BIDS). This is a python file that must have the 
+to a file system layout (e.g., BIDS). This is a python file that must have the
 function `infotodict`, which takes a single argument `seqinfo`.  
 
 ### `seqinfo` and the `s` variable
@@ -78,7 +79,7 @@ function `infotodict`, which takes a single argument `seqinfo`.
 Each item in `seqinfo` contains the following ordered elements.
 
 ```
-[total_files_till_now, example_dcm_file, series_number, unspecified, unspecified, 
+[total_files_till_now, example_dcm_file, series_number, unspecified, unspecified,
 unspecified, dim1, dim2, dim3,  dim4, TR, TE, SeriesDescription, MotionCorrectedOrNot]
 
 128     125000-1-1.dcm  1       -       -       
@@ -86,44 +87,44 @@ unspecified, dim1, dim2, dim3,  dim4, TR, TE, SeriesDescription, MotionCorrected
 ```
 
 ### The dictionary returned by `infotodict`
- 
+
 This dictionary contains as keys a 3-tuple `(template, a tuple of output types,
  annotation classes)`.
 
 template - how the file should be relative to the base directory
-tuple of output types - what format of output should be created - nii.gz, dicom, 
+tuple of output types - what format of output should be created - nii.gz, dicom,
  etc.,.
 annotation classes - unused
 
 ```
-Example: ('func/sub-{subject}_task-face_run-{item:02d}_acq-PA_bold', ('nii.gz', 
+Example: ('func/sub-{subject}_task-face_run-{item:02d}_acq-PA_bold', ('nii.gz',
         'dicom'), None)
 ```
 
 A few fields are defined by default and can be used in the template:
 
-- item: index within category 
-- subject: participant id 
+- item: index within category
+- subject: participant id
 - seqitem: run number during scanning
 - subindex: sub index within group
-- session: session info for multi-session studies and when session has been 
+- session: session info for multi-session studies and when session has been
   defined as a parameter for heudiconv
 
-Additional variables may be added and can be returned in the value of the 
+Additional variables may be added and can be returned in the value of the
 dictionary returned from the function.
 
-`info[some_3-tuple] = [12, 14, 16]` would assign dicom sequence groups 12, 14 
+`info[some_3-tuple] = [12, 14, 16]` would assign dicom sequence groups 12, 14
 and 16 to be converted using the template specified in `some_3-tuple`.
 
-if the template contained a non-sanctioned variable, it would have to be 
+if the template contained a non-sanctioned variable, it would have to be
 provided in the values for that key.
 
 ```
-some_3_tuple = ('func/sub-{subject}_task-face_run-{item:02d}_acq-{acq}_bold', ('nii.gz', 
+some_3_tuple = ('func/sub-{subject}_task-face_run-{item:02d}_acq-{acq}_bold', ('nii.gz',
         'dicom'), None)
 ```
 
-In the above example `{acq}` is not a standard variable. In this case, values 
+In the above example `{acq}` is not a standard variable. In this case, values
 for this variable needs to be added.
 
 ```
@@ -131,4 +132,3 @@ info[some_3-tuple] = [{'item': 12, 'acq': 'AP'},
                       {'item': 14, 'acq': 'AP'},
                       {'item': 16, 'acq': 'PA'}]
 ```
-

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ as long as the following dependencies are in your path you can use the script
 
 Call `heudiconv` like this:
 
-    heudiconv -d '{participant}*.tar*' -s xx05 -f ~/myheuristics/convertall.py
+    heudiconv -d '{subject}*.tar*' -s xx05 -f ~/myheuristics/convertall.py
 
-where `-d '{participant}*tar*'` is an expression used to find DICOM files
-(`{participant}` expands to a subject ID so that the expression will match any
+where `-d '{subject}*tar*'` is an expression used to find DICOM files
+(`{subject}` expands to a subject ID so that the expression will match any
 `.tar` files, compressed or not that start with the subject ID in their name).
 An additional flag for session (`{session}`) can be included in the expression
 as well. `-s od05` specifies a subject ID for the conversion (this could be a

--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -816,7 +816,7 @@ s3
                         dest='dicom_dir_template',
                         required=True,
                         help='''location of dicomdir that can be indexed with
-                        subject id {participant} and session {session}. 
+                        subject id {subject} and session {session}.
                         Tarballs (can be compressed) are supported
                         in addition to directory. All matching tarballs for a
                         subject are extracted and their content processed in

--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -573,6 +573,12 @@ def convert_dicoms(subjs, dicom_dir_template, outdir, heuristic_file, converter,
                    queue=None, anon_sid_cmd=None, anon_outdir=None, with_prov=False,
                    ses=None, is_bids=False, sbatch_args='-N1 -c2 --mem=20G -t 01:00:00',
                    min_meta=False):
+    
+    if '%s' in dicom_dir_template:
+        raise ValueError("Formatting DICOM search pattern with '%s' is "
+                         "deprecated. Please indicate participant ID with "
+                         "'{subject}' and (optionally) timepoint with '{session}'.")
+    
     for sid in subjs:
         tmpdir = None
         if queue:

--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -599,7 +599,7 @@ def convert_dicoms(subjs, dicom_dir_template, outdir, heuristic_file, converter,
         # TODO: RF into a function
         # expand the input template
         if sid:
-            sdir = dicom_dir_template.format(participant=sid, session=ses)
+            sdir = dicom_dir_template.format(subject=sid, session=ses)
             # and see what matches
             fl = sorted(glob(sdir))
         else:

--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -599,7 +599,7 @@ def convert_dicoms(subjs, dicom_dir_template, outdir, heuristic_file, converter,
         # TODO: RF into a function
         # expand the input template
         if sid:
-            sdir = dicom_dir_template % sid
+            sdir = dicom_dir_template.format(participant=sid, session=ses)
             # and see what matches
             fl = sorted(glob(sdir))
         else:
@@ -695,7 +695,7 @@ def convert_dicoms(subjs, dicom_dir_template, outdir, heuristic_file, converter,
         if anon_sid_cmd is not None:
             from subprocess import check_output
             anon_sid = check_output([anon_sid_cmd, sid]).strip()
-            lgr.info("Annonimized sid %s into %s", sid, anon_sid)
+            lgr.info("Anonymized sid %s into %s", sid, anon_sid)
         else:
             anon_outdir = idir
 
@@ -816,8 +816,9 @@ s3
                         dest='dicom_dir_template',
                         required=True,
                         help='''location of dicomdir that can be indexed with
-                        subject id. Tarballs (can be compressed) are supported
-                        in additions to directory. All matching tarballs for a
+                        subject id {participant} and session {session}. 
+                        Tarballs (can be compressed) are supported
+                        in addition to directory. All matching tarballs for a
                         subject are extracted and their content processed in
                         a single pass''')
     parser.add_argument('-s', '--subjects', dest='subjs', required=True,


### PR DESCRIPTION
This new format allows users to include both subject id and session in
the search expression. Session is optional.

Also, Atom automatically cleaned up some of the whitespace in the
README file.