### PR TITLE
Add dcm_dir_name to dicominfo (+ uc_bids heuristic)

### DIFF
--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -41,7 +41,7 @@ lgr.debug("Starting the abomination")  # just to "run-test" logging
 seqinfo_fields = ['total_files_till_now',  # 0
                   'example_dcm_file',      # 1
                   'series_number',         # 2
-                  'unspecified1',          # 3
+                  'dcm_dir_name',          # 3
                   'unspecified2',          # 4
                   'unspecified3',          # 5
                   'dim1', 'dim2', 'dim3', 'dim4', # 6, 7, 8, 9
@@ -273,7 +273,8 @@ def process_dicoms(fl, dcmsession=None, basedir=None, dcmfilter=None):
             total,
             os.path.split(files[0])[1],
             series,
-            '-', '-', '-',
+            os.path.basename(os.path.dirname(files[0])),
+            '-', '-',
             size[0], size[1], size[2], size[3],
             TR, TE,
             dcminfo.ProtocolName,

--- a/heuristics/uc_bids.py
+++ b/heuristics/uc_bids.py
@@ -1,0 +1,51 @@
+import os
+
+def create_key(template, outtype=('nii.gz',), annotation_classes=None):
+    if template is None or not template:
+        raise ValueError('Template must be a valid format string')
+    return template, outtype, annotation_classes
+
+def infotodict(seqinfo):
+    """Heuristic evaluator for determining which runs belong where
+    
+    allowed template fields - follow python string module: 
+    
+    item: index within category 
+    subject: participant id 
+    seqitem: run number during scanning
+    subindex: sub index within group
+    """
+    t1w = create_key('anat/sub-{subject}_T1w')
+    t2w = create_key('anat/sub-{subject}_acq-{acq}_T2w')
+    flair = create_key('anat/sub-{subject}_acq-{acq}_FLAIR')
+    rest = create_key('func/sub-{subject}_task-rest_acq-{acq}_run-{item:02d}_bold')
+
+    info = {t1w: [], t2w: [], flair: [], rest: []}
+
+    for idx, seq in enumerate(seqinfo):
+        x,y,z,n_vol,protocol = (seq[6], seq[7], seq[8], seq[9], seq[12])
+        # t1_mprage --> T1w
+        if (z == 160) and (n_vol == 1) and ('t1_mprage' in protocol):
+            info[t1w] = [seq[2]]
+        # t2_tse --> T2w
+        if (z == 35) and (n_vol == 1) and ('t2_tse' in protocol):
+            info[t2w].append({'item': seq[2], 'acq': 'TSE'})
+        # T2W --> T2w
+        if (z == 192) and (n_vol == 1) and ('T2W' in protocol):
+            info[t2w].append({'item': seq[2], 'acq': 'highres'})
+        # t2_tirm --> FLAIR
+        if (z == 35) and (n_vol == 1) and ('t2_tirm' in protocol):
+            info[flair].append({'item': seq[2], 'acq': 'TIRM'}) 
+        # t2_flair --> FLAIR
+        if (z == 160) and (n_vol == 1) and ('t2_flair' in protocol):
+            info[flair].append({'item': seq[2], 'acq': 'highres'})
+        # T2FLAIR --> FLAIR
+        if (z == 192) and (n_vol == 1) and ('T2-FLAIR' in protocol):
+            info[flair].append({'item': seq[2], 'acq': 'highres'})
+        # EPI (physio-matched) --> bold
+        if (x == 128) and (z == 28) and (n_vol == 300) and ('EPI' in protocol):
+            info[rest].append({'item': seq[2], 'acq': '128px'})
+        # EPI (physio-matched_NEW) --> bold
+        if (x == 64) and (z == 34) and (n_vol == 300) and ('EPI' in protocol):
+            info[rest].append({'item': seq[2], 'acq': '64px'})
+    return info

--- a/heuristics/uc_bids.py
+++ b/heuristics/uc_bids.py
@@ -23,29 +23,29 @@ def infotodict(seqinfo):
     info = {t1w: [], t2w: [], flair: [], rest: []}
 
     for idx, seq in enumerate(seqinfo):
-        x,y,z,n_vol,protocol = (seq[6], seq[7], seq[8], seq[9], seq[12])
+        x,y,z,n_vol,protocol,dcm_dir = (seq[6], seq[7], seq[8], seq[9], seq[12], seq[3])
         # t1_mprage --> T1w
-        if (z == 160) and (n_vol == 1) and ('t1_mprage' in protocol):
+        if (z == 160) and (n_vol == 1) and ('t1_mprage' in protocol) and ('XX' not in dcm_dir):
             info[t1w] = [seq[2]]
         # t2_tse --> T2w
-        if (z == 35) and (n_vol == 1) and ('t2_tse' in protocol):
+        if (z == 35) and (n_vol == 1) and ('t2_tse' in protocol) and ('XX' not in dcm_dir):
             info[t2w].append({'item': seq[2], 'acq': 'TSE'})
         # T2W --> T2w
-        if (z == 192) and (n_vol == 1) and ('T2W' in protocol):
+        if (z == 192) and (n_vol == 1) and ('T2W' in protocol) and ('XX' not in dcm_dir):
             info[t2w].append({'item': seq[2], 'acq': 'highres'})
         # t2_tirm --> FLAIR
-        if (z == 35) and (n_vol == 1) and ('t2_tirm' in protocol):
+        if (z == 35) and (n_vol == 1) and ('t2_tirm' in protocol) and ('XX' not in dcm_dir):
             info[flair].append({'item': seq[2], 'acq': 'TIRM'}) 
         # t2_flair --> FLAIR
-        if (z == 160) and (n_vol == 1) and ('t2_flair' in protocol):
+        if (z == 160) and (n_vol == 1) and ('t2_flair' in protocol) and ('XX' not in dcm_dir):
             info[flair].append({'item': seq[2], 'acq': 'highres'})
         # T2FLAIR --> FLAIR
-        if (z == 192) and (n_vol == 1) and ('T2-FLAIR' in protocol):
+        if (z == 192) and (n_vol == 1) and ('T2-FLAIR' in protocol) and ('XX' not in dcm_dir):
             info[flair].append({'item': seq[2], 'acq': 'highres'})
         # EPI (physio-matched) --> bold
-        if (x == 128) and (z == 28) and (n_vol == 300) and ('EPI' in protocol):
+        if (x == 128) and (z == 28) and (n_vol == 300) and ('EPI' in protocol) and ('XX' not in dcm_dir):
             info[rest].append({'item': seq[2], 'acq': '128px'})
         # EPI (physio-matched_NEW) --> bold
-        if (x == 64) and (z == 34) and (n_vol == 300) and ('EPI' in protocol):
+        if (x == 64) and (z == 34) and (n_vol == 300) and ('EPI' in protocol) and ('XX' not in dcm_dir):
             info[rest].append({'item': seq[2], 'acq': '64px'})
     return info


### PR DESCRIPTION
It's not uncommon when scanning participants to have to re-run a scan due to motion/confusion/claustrophobia/etc. In these cases, our lab adds "XX" to the name of the folder containing DICOMS for the failed/incomplete scan. I've added a field to `dicominfo` (`dcm_dir_name`) to store this information so these scans can be easily excluded from conversion using `heudiconv`. 

Not sure what the policy is on adding new heuristics to the main repo, but I've included mine for now.