### PR TITLE
remove reference to non-existent path: examples/heuristics/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	install -t $(DESTDIR)$(PREFIX)/bin bin/heudiconv
 	install -m 644 -t $(DESTDIR)$(PREFIX)/share/heudiconv/heuristics heuristics/*
-	install -m 644 -t $(DESTDIR)$(PREFIX)/share/doc/heudiconv/examples/heuristics/  examples/heuristics/*
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/heudiconv


### PR DESCRIPTION
make install was broken for me until I dropped this line from Makefile.