### PR TITLE
fix: allow non-bids dcm2niix conversion

### DIFF
--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -492,7 +492,10 @@ def convert(items, symlink=True, converter=None,
                         if converter == 'dcm2nii':
                             convertnode.inputs.gzip_output = outtype == 'nii.gz'
                         else:
-                            convertnode.inputs.out_filename = os.path.basename(dirname +'_%e')
+                            if not is_bids:
+                                convertnode.inputs.bids_format = False
+                            convertnode.inputs.out_filename = os.path.basename(
+                                                                 dirname +'_%e')
                         convertnode.inputs.terminal_output = 'allatonce'
                         res = convertnode.run()
                         if isinstance(res.outputs.converted_files, list):


### PR DESCRIPTION
since nipype's Dcm2niix interface defaults `bids_format` to True, there were sometimes problems with lists of json sidecars. This change explicitly sets this to False when not `is_bids`