### PR TITLE
New utility: heudiconv_infodump

### DIFF
--- a/bin/heudiconv_infodump
+++ b/bin/heudiconv_infodump
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import imp
+from glob import glob
+
+# Use the specified file-path template to glob DICOM files
+fpt = sys.argv[1]
+
+# Import heudiconv
+heudi_bin = os.path.dirname(os.path.realpath(__file__))
+heudi_bin = os.path.join(heudi_bin, 'heudiconv')
+heudiconv = imp.load_source('heudiconv', heudi_bin)
+
+# Use heudiconv to get SeqInfo for each scan in the globbed DICOM files.
+si_store = heudiconv.group_dicoms_into_seqinfos(glob(fpt))
+
+# For each scan, write SeqInfo to a text file.
+n_scans = len(si_store.items()[0][1].items())
+
+for scan_id in xrange(n_scans):
+    si = si_store.items()[0][1].items()[scan_id][0]
+    with open('{0}.txt'.format(si.unspecified1), 'w') as f:
+        for i, j in si._asdict().items():
+            f.write("{0}: {1}\n".format(i, j))
+    print("Wrote SeqInfo for {0}".format(si.unspecified1))


### PR DESCRIPTION
Much of the time when I go to create a new heuristic, I'm not super familiar with the scans I need to convert, so I don't have a good idea of what information to use to set up my heuristics. For a while, I was opening the DICOM headers using `pydicom` and manually matching the header fields to the heudiconv `SeqInfo` items. I realized it would be much easier to just have `heudiconv` generate a `SeqInfo` object for me and then write it to disk, so that's what this script does.

Call `heudiconv_infodump` with a `glob`-compatible file path template of the same kind used to call the main `heudiconv` script. For each scan that `heudiconv` finds, `heudiconv_infodump` will write the `SeqInfo` array to disk in the current working directory.

I thought this might be helpful for other people too. If so, I can do a proper docstring, etc. Let me know.