### PR TITLE
BF: do not chmod files using hardcoded mode number

### DIFF
--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -53,6 +53,14 @@ from random import sample
 MIN_VERSIONS = {
     'datalad': '0.7'
 }
+
+# Some variables for reuse
+import stat
+
+ALL_CAN_WRITE = (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+ALL_CAN_READ = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+assert ALL_CAN_READ >> 1 == ALL_CAN_WRITE  # Assumption in the code
+
 PY3 = sys.version_info[0] >= 3
 
 import logging
@@ -303,6 +311,35 @@ def find_files(regex, topdir=curdir, exclude=None, exclude_vcs=True, dirs=False)
                 continue
             yield path
 find_files.__doc__ %= (_VCS_REGEX,)
+
+
+def set_readonly(path, read_only=True):
+    """Make file read only or writeable while preserving "access levels"
+
+    So if file was not readable by "others" it should remain not readable
+    by others
+
+    Parameters
+    ----------
+    path : str
+    read_only : bool, optional
+      If True (default) - would make it read-only. If False, would make it
+      writeable for levels where it is readable
+    """
+    # get current permissions
+    perms = stat.S_IMODE(os.lstat(path).st_mode)
+    # set new permissions
+    if read_only:
+        new_perms = perms & (~ALL_CAN_WRITE)
+    else:
+        # need to set only for those which had read bit set
+        # read bit is <<1 away from write bit
+        whocanread = perms & ALL_CAN_READ
+        thosecanwrite = whocanread >> 1
+        new_perms = perms | thosecanwrite
+    # apply and return those target permissions
+    os.chmod(path, new_perms)
+    return new_perms
 
 
 def group_dicoms_into_seqinfos(

--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -997,7 +997,7 @@ def convert(items, symlink=True, converter=None,
                 if exists(scaninfo):
                     lgr.info("Post-treating %s file", scaninfo)
                     treat_infofile(scaninfo)
-                os.chmod(outname, 0o0440)
+                set_readonly(outname)
 
         if custom_callable is not None:
             custom_callable(*item)
@@ -1168,9 +1168,9 @@ def tuneup_bids_json_files(json_files):
                     lgr.error("Failed to open magnitude file: %s", exc)
 
             # might have been made R/O already
-            os.chmod(json_phasediffname, 0o0664)
+            set_readonly(json_phasediffname, False)
             json.dump(json_, open(json_phasediffname, 'w'), indent=2)
-            os.chmod(json_phasediffname, 0o0444)
+            set_readonly(json_phasediffname)
 
         # phasediff one should contain two PhaseDiff's
         #  -- one for original amplitude and the other already replicating what is there
@@ -1244,15 +1244,15 @@ in that one though
         if global_options['overwrite'] and os.path.lexists(scaninfo):
             # TODO: handle annexed file case
             if not os.path.islink(scaninfo):
-                os.chmod(scaninfo, 0o0660)
+                set_readonly(scaninfo, False)
         res = embedfunc.run()
-        os.chmod(scaninfo, 0o0444)
+        set_readonly(scaninfo)
         if with_prov:
             g = res.provenance.rdf()
             g.parse(prov_file,
                     format='turtle')
             g.serialize(prov_file, format='turtle')
-            os.chmod(prov_file, 0o0440)
+            set_readonly(prov_file)
     except Exception as exc:
         lgr.error("Embedding failed: %s", str(exc))
         os.chdir(cwd)
@@ -1269,10 +1269,10 @@ def treat_infofile(filename):
     j_slim = slim_down_info(j)
     j_pretty = json_dumps_pretty(j_slim, indent=2, sort_keys=True)
 
-    os.chmod(filename, 0o0664)
+    set_readonly(filename, False)
     with open(filename, 'wt') as fp:
         fp.write(j_pretty)
-    os.chmod(filename, 0o0444)
+    set_readonly(filename)
 
 
 def convert_dicoms(sid,

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -11,7 +11,10 @@ import re
 
 import pytest
 
-from datalad.api import Dataset
+try:
+    from datalad.api import Dataset
+except ImportError:
+    Dataset = None
 
 
 def test_smoke_converall(tmpdir):
@@ -28,6 +31,7 @@ def test_smoke_converall(tmpdir):
         "-d tests/data/{subject}/* -s 01-fmap_acq-3mm" # "old" way specifying subject
         # should produce the same results
     ])
+@pytest.mark.skipif(Dataset is None, reason="no datalad")
 def test_dbic_bids_largely_smoke(tmpdir, heuristic, invocation):
     is_bids = True if heuristic == 'dbic_bids' else False
     arg = "-f heuristics/%s.py -c dcm2niix -o %s" % (heuristic, tmpdir)

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -13,7 +13,7 @@ import pytest
 
 try:
     from datalad.api import Dataset
-except ImportError:
+except ImportError:  # pragma: no cover
     Dataset = None
 
 


### PR DESCRIPTION
It was resulting in ignoring umask etc, and making files non-readable by others where they should have been.  Now it should be more consistent and only make files not writable, and if making writeable only for levels where they are also readable.

While at it also marked a test to be skipped if there is no datalad