### PR TITLE
BF: do not set readonly on the sidecar phasediff.json if not yet set read-only

### DIFF
--- a/bin/heudiconv
+++ b/bin/heudiconv
@@ -314,6 +314,14 @@ def find_files(regex, topdir=curdir, exclude=None, exclude_vcs=True, dirs=False)
 find_files.__doc__ %= (_VCS_REGEX,)
 
 
+def is_readonly(path):
+    """Return True if it is a fully read-only file (dereferences the symlink)
+    """
+    # get current permissions
+    perms = stat.S_IMODE(os.lstat(os.path.realpath(path)).st_mode)
+    return not bool(perms & ALL_CAN_WRITE)  # should be true if anyone is allowed to write
+
+
 def set_readonly(path, read_only=True):
     """Make file read only or writeable while preserving "access levels"
 
@@ -1179,10 +1187,14 @@ def tuneup_bids_json_files(json_files):
                 except IOError as exc:
                     lgr.error("Failed to open magnitude file: %s", exc)
 
-            # might have been made R/O already
-            set_readonly(json_phasediffname, False)
+            # might have been made R/O already, but if not -- it will be set
+            # only later in the pipeline, so we must not make it read-only yet
+            was_readonly = is_readonly(json_phasediffname)
+            if was_readonly:
+                set_readonly(json_phasediffname, False)
             json.dump(json_, open(json_phasediffname, 'w'), indent=2)
-            set_readonly(json_phasediffname)
+            if was_readonly:
+                set_readonly(json_phasediffname)
 
         # phasediff one should contain two PhaseDiff's
         #  -- one for original amplitude and the other already replicating what is there
@@ -1236,23 +1248,6 @@ def embed_metadata_from_dicoms(converter, is_bids, item_dicoms, outname,
     embedfunc.base_dir = tmpdir
     cwd = os.getcwd()
     try:
-        """
-        Ran into
-INFO: Executing node embedder in dir: /tmp/heudiconvdcm2W3UQ7/embedder
-ERROR: Embedding failed: [Errno 13] Permission denied: '/inbox/BIDS/tmp/test2-jessie/Wheatley/Beau/1007_personality/sub-sid000138/fmap/sub-sid000138_3mm_run-01_phasediff.json'
-while
-HEUDICONV_LOGLEVEL=WARNING time bin/heudiconv -f heuristics/dbic_bids.py -c dcm2niix -o /inbox/BIDS/tmp/test2-jessie --bids --datalad /inbox/DICOM/2017/01/28/A000203
-
-so it seems that there is a filename collision so it tries to save into the same file name
-and there was a screw up for that A
-
-/mnt/btrfs/dbic/inbox/DICOM/2017/01/28/A000203
-        StudySessionInfo(locator='Wheatley/Beau/1007_personality', session=None, subject='sid000138') 16 sequences
-        StudySessionInfo(locator='Wheatley/Beau/1007_personality', session=None, subject='a000203') 2 sequences
-
-
-in that one though
-        """
         if global_options['overwrite'] and os.path.lexists(scaninfo):
             # TODO: handle annexed file case
             if not os.path.islink(scaninfo):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -205,13 +205,18 @@ def test_make_readonly(tmpdir):
     pathname = str(path)
     with open(pathname, 'w'):
         pass
+    symname = pathname + 'link'
+    os.symlink(pathname, symname)
     for orig, ro, rw in [
         (0o600, 0o400, 0o600),  # fully returned
         (0o624, 0o404, 0o606),  # it will not get write bit where it is not readable
         (0o1777, 0o1555, 0o1777),  # and other bits should be preserved
     ]:
         os.chmod(pathname, orig)
+        assert not heudiconv.is_readonly(pathname)
         assert heudiconv.set_readonly(pathname) == ro
+        assert heudiconv.is_readonly(pathname)
         assert stat.S_IMODE(os.lstat(pathname).st_mode) == ro
         # and it should go back if we set it back to non-read_only
         assert heudiconv.set_readonly(pathname, read_only=False) == rw
+        assert not heudiconv.is_readonly(pathname)


### PR DESCRIPTION
Finally I got annoyed with that issue enough and figured it out ;)  Due to need to specify those EchoTime[12] "manually", we turned them "read-only" way too early, which lead the "embedder" to fail to embed later in the process.  Now tune up of EchoTime's would only change permissions if file is already set read-only