### PR TITLE
BF: bidify sid and remove lingering dicom tempdirs

### DIFF
--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -267,8 +267,8 @@ def process_args(args):
         # the outdir -> study_outdir datasets if not yet there
         if args.datalad:
             from ..external.dlad import prepare_datalad
-            anon_sid = sid if not anon_sid else anon_sid
-            dl_msg = prepare_datalad(anon_study_outdir, anon_outdir, anon_sid,
+            dlad_sid = sid if not anon_sid else anon_sid
+            dl_msg = prepare_datalad(anon_study_outdir, anon_outdir, dlad_sid,
                                      args.session, seqinfo, dicoms, args.bids)
 
         lgr.info("PROCESSING STARTS: {0}".format(

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -255,7 +255,7 @@ def process_args(args):
                              args.bids)
             continue
 
-        anon_sid = anonymize_sid(sid, args.anon_cmd) if args.anon_cmd else sid
+        anon_sid = anonymize_sid(sid, args.anon_cmd) if args.anon_cmd else None
         if args.anon_cmd:
             lgr.info('Anonymized {} to {}'.format(sid, anon_sid))
 
@@ -267,6 +267,7 @@ def process_args(args):
         # the outdir -> study_outdir datasets if not yet there
         if args.datalad:
             from ..external.dlad import prepare_datalad
+            anon_sid = sid if not anon_sid else anon_sid
             dl_msg = prepare_datalad(anon_study_outdir, anon_outdir, anon_sid,
                                      args.session, seqinfo, dicoms, args.bids)
 

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -3,8 +3,9 @@ import os.path as op
 import logging
 import shutil
 
-from .utils import (read_config, load_json, save_json, write_config,
-                    TempDirs, safe_copyfile, treat_infofile, set_readonly)
+from .utils import (read_config, load_json, save_json, write_config, TempDirs,
+                    safe_copyfile, treat_infofile, set_readonly,
+                    clear_temp_dicoms)
 from .bids import (convert_sid_bids, populate_bids_templates, save_scans_key,
                    tuneup_bids_json_files, add_participant_record)
 from .dicoms import (group_dicoms_into_seqinfos, embed_metadata_from_dicoms,
@@ -143,6 +144,10 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
                 outdir=tdir,
                 min_meta=min_meta,
                 overwrite=overwrite,)
+
+    for item_dicoms in filegroup.values():
+        clear_temp_dicoms(item_dicoms)
+
     if bids:
         if seqinfo:
             keys = list(seqinfo)
@@ -255,14 +260,6 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
         # will address after refactor
         if op.exists(outname):
             set_readonly(outname)
-
-    if items:
-        common = op.commonprefix(item_dicoms)
-        tmp = '/'.join(common.split(op.sep)[:3])
-        if (op.dirname(tmp) == '/tmp'
-            and op.basename(tmp).startswith('heudiconvDCM')):
-            # clean up directory holding dicoms
-            shutil.rmtree(tmp)
 
     if custom_callable is not None:
         custom_callable(*item)

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -11,6 +11,7 @@ REQUIRES = [
     'nibabel',
     'pydicom',
     'nipype',
+    'pathlib',
 ]
 
 TESTS_REQUIRES = [

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -332,4 +332,4 @@ def clear_temp_dicoms(item_dicoms):
         and str(tmp.stem).startswith('heudiconvDCM')
         and op.exists(str(tmp))):
         # clean up directory holding dicoms
-        shutil.rmtree(tmp)
+        shutil.rmtree(str(tmp))

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -328,8 +328,8 @@ def clear_temp_dicoms(item_dicoms):
         tmp = Path(op.commonprefix(item_dicoms).parents[1])
     except IndexError:
         return
-    if (op.dirname(tmp) == tempfile.gettempdir()
-        and op.basename(tmp).startswith('heudiconvDCM')
-        and op.exists(tmp)):
+    if (str(tmp.parent) == tempfile.gettempdir()
+        and str(tmp.stem).startswith('heudiconvDCM')
+        and op.exists(str(tmp))):
         # clean up directory holding dicoms
         shutil.rmtree(tmp)

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -325,7 +325,7 @@ def is_readonly(path):
 def clear_temp_dicoms(item_dicoms):
     """Ensures DICOM temporary directories are safely cleared"""
     try:
-        tmp = Path(op.commonprefix(item_dicoms).parents[1])
+        tmp = Path(op.commonprefix(item_dicoms)).parents[1]
     except IndexError:
         return
     if (str(tmp.parent) == tempfile.gettempdir()

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -1,17 +1,18 @@
 """Utility objects and functions"""
 
 import os
-import os.path as op
-from tempfile import mkdtemp
-from glob import glob
+import tempfile
 import json
 import re
 import sys
 import shutil
-from collections import namedtuple
 import copy
 import logging
 import stat
+import os.path as op
+from pathlib import Path
+from collections import namedtuple
+from glob import glob
 
 SeqInfo = namedtuple(
     'SeqInfo',
@@ -64,7 +65,7 @@ class TempDirs(object):
         self.lgr = logging.getLogger('tempdirs')
 
     def __call__(self, prefix=None):
-        tmpdir = mkdtemp(prefix=prefix)
+        tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.dirs.append(tmpdir)
         return tmpdir
 
@@ -319,3 +320,16 @@ def is_readonly(path):
     perms = stat.S_IMODE(os.lstat(os.path.realpath(path)).st_mode)
     # should be true if anyone is allowed to write
     return not bool(perms & ALL_CAN_WRITE)
+
+
+def clear_temp_dicoms(item_dicoms):
+    """Ensures DICOM temporary directories are safely cleared"""
+    try:
+        tmp = Path(op.commonprefix(item_dicoms).parents[1])
+    except IndexError:
+        return
+    if (op.dirname(tmp) == tempfile.gettempdir()
+        and op.basename(tmp).startswith('heudiconvDCM')
+        and op.exists(tmp)):
+        # clean up directory holding dicoms
+        shutil.rmtree(tmp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-.[full]
+.[all]
 # This is a dcmstack branch with changes for Python 3
 # sent PR to main repo, TODO: check if merged
 # https://github.com/ghisvail/dcmstack/pull/1


### PR DESCRIPTION

* revert `anon_sid` default to `None` in `run.py`, but log `sid` in datalad message
  * currently, setting `anon_sid` is superceeding the BIDS cleaned `sid`
* remove lingering dicom tempdir when running with `-c none`
  * add pathlib as a requirement