### PR TITLE
RF: use http://datasets-tests.datalad.org instead of /// for a test

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,6 +28,6 @@ def fetch_data(tmpdir, subject):
     """Fetches some test dicoms using datalad"""
     from datalad import api
     targetdir = op.join(tmpdir, 'QA')
-    api.install(path=targetdir, source='///dbic/QA')
+    api.install(path=targetdir, source='http://datasets-tests.datalad.org/dbic/QA')
     api.get('{}/sourcedata/{}'.format(targetdir, subject))
     return targetdir


### PR DESCRIPTION
To help datalad folks in a blind fight against windmills of apache logs
trying to figure out some reasonable usage statistics

That url points to the same files as ///, just that apache logs then saved separately and there is otherwise no easy reliable way to tell which accesses come from CI platforms vs regular folks in the cloud(s)