### PR TITLE
Make calls to import pydicom compatible with pydicom 1.0

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -10,7 +10,12 @@ import csv
 from random import sample
 from glob import glob
 
-import dicom as dcm
+try:
+    # for pydicom < 1.0
+    import dicom as dcm
+except:
+    # pydicom >= 1.0
+    import pydicom as dcm
 import dcmstack as ds
 
 from .parser import find_files

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -5,7 +5,12 @@ import logging
 from collections import OrderedDict
 import tarfile
 
-import dicom as dcm
+try:
+    # for pydicom < 1.0
+    import dicom as dcm
+except:
+    # pydicom >= 1.0
+    import pydicom as dcm
 import dcmstack as ds
 
 from .utils import SeqInfo, load_json, set_readonly
@@ -41,8 +46,8 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
     per_studyUID = grouping == 'studyUID'
     per_accession_number = grouping == 'accession_number'
     lgr.info("Analyzing %d dicoms", len(files))
-    import dcmstack as ds
-    import dicom as dcm
+    #import dcmstack as ds
+    #import dicom as dcm
 
     groups = [[], []]
     mwgroup = []


### PR DESCRIPTION
In the newly released pydicom 1.0 the name of the module is
now 'pydicom', so modify the code accordingly.

I'm also removing the import of pydicom and dcmstack inside
group_dicoms_into_seqinfos because I think it is redundant
(although I'm not 100% sure).