### PR TITLE
sty: readme formatting, link to condensed slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ You can clone this directory and use `pip install .[all]` (with `--user`,
 
 ## Dependencies
 
-- pydicom
-- dcmstack
-- nipype
-- nibabel
-- dcm2niix
+* `pydicom`
+* `dcmstack`
+* `nipype`
+* `nibabel`
+* `dcm2niix`
 
 and should be checked/installed during `pip install` call, all but `dcm2niix`
 which should be installed directly from upstream or using the distribution
@@ -64,7 +64,7 @@ manager appropriate for your OS.
 ## Tutorial with example conversion to BIDS format using Docker
 Please read this tutorial to understand how heudiconv works in practice.
 
-[Slides here](http://nipy.org/workshops/2017-03-boston/lectures/bids-heudiconv/#1)
+### [Slides here](http://mgxd.github.io/heudiconv/#1)
 
 To generate lean BIDS output, consider using both the `-b` and the `--minmeta` flags 
 to your heudiconv command. The `-b` flag generates a json file with BIDS keys, while


### PR DESCRIPTION
* currently hosting new tutorial slides on my fork, but would be great if we could host on `nipy.github.io/heudiconv`