### PR TITLE
WiP: ReproIn heuristic - support usecase from @mih et al.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - pip install --upgrade virtualenv
   - virtualenv --python=python venv
   - source venv/bin/activate
+  - pip --version # check again since seems that python_requires='>=3.5' in secretstorage is not in effect
   - python --version # just to check
   - pip install -r dev-requirements.txt
   - pip install requests # below installs pyld but that assumes we have requests already

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -293,10 +293,14 @@ def get_formatted_scans_key_row(item):
                                             force=True))
     # we need to store filenames and acquisition times
     # parse date and time and get it into isoformat
-    date = mw.dcm_data.ContentDate
-    time = mw.dcm_data.ContentTime.split('.')[0]
-    td = time + date
-    acq_time = datetime.strptime(td, '%H%M%S%Y%m%d').isoformat()
+    try:
+        date = mw.dcm_data.ContentDate
+        time = mw.dcm_data.ContentTime.split('.')[0]
+        td = time + date
+        acq_time = datetime.strptime(td, '%H%M%S%Y%m%d').isoformat()
+    except AttributeError as exc:
+        lgr.warning("Failed to get date/time for the content: %s", str(exc))
+        acq_time = None
     # add random string
     randstr = ''.join(map(chr, sample(k=8, population=range(33, 127))))
     try:

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -326,6 +326,10 @@ def convert_sid_bids(subject_id):
     """
     cleaner = lambda y: ''.join([x for x in y if x.isalnum()])
     sid = cleaner(subject_id)
+    if not sid:
+        raise ValueError(
+            "Subject ID became empty after cleanup.  Please provide manually "
+            "a suitable alphanumeric subject ID")
     lgr.warning('{0} contained nonalphanumeric character(s), subject '
                 'ID was cleaned to be {1}'.format(subject_id, sid))
     return sid, subject_id

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -87,8 +87,12 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
     else:
         raise ValueError("neither dicoms nor seqinfo dict was provided")
 
-    if bids and not sid.isalnum(): # alphanumeric only
-        sid, old_sid = convert_sid_bids(sid)
+    if bids:
+        if not sid:
+            raise ValueError(
+                "BIDS requires alphanumeric subject ID. Got an empty value")
+        if not sid.isalnum():  # alphanumeric only
+            sid, old_sid = convert_sid_bids(sid)
 
     if not anon_sid:
         anon_sid = sid

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -455,6 +455,12 @@ def infotodict(seqinfo):
             dcm_image_iod_spec = image_type_seqtype = None
 
         protocol_name_tuned = s.protocol_name
+        if not protocol_name_tuned:
+            protocol_name_tuned = s.series_description
+        if not protocol_name_tuned:
+            lgr.warning(
+                "Could not determine the series name by looking at "
+                "protocol_name and series_description - both were empty")
         # Few common replacements
         if protocol_name_tuned in {'AAHead_Scout'}:
             protocol_name_tuned = 'anat-scout'

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -787,6 +787,9 @@ def parse_series_spec(series_spec):
 
     # Parse the name according to our convention/specification
 
+    # leading or trailing spaces do not matter
+    series_spec = series_spec.strip(' ')
+
     # Strip off leading CAPITALS: prefix to accommodate some reported usecases:
     # https://github.com/ReproNim/reproin/issues/14
     # where PU: prefix is added by the scanner
@@ -988,8 +991,9 @@ def test_parse_series_spec():
            {'seqtype': 'func', 'seqtype_label': 'bold'}
 
     # pdpn("bids_func_ses+_task-boo_run+") == \
-    # order and PREFIX: should not matter
+    # order and PREFIX: should not matter, as well as trailing spaces
     assert \
+        pdpn(" PREFIX:bids_func_ses+_task-boo_run+  ") == \
         pdpn("PREFIX:bids_func_ses+_task-boo_run+") == \
         pdpn("bids_func_ses+_run+_task-boo") == \
            {


### PR DESCRIPTION
- allow/strip any leading CAPITALS followed by a column with the series/protocol name (see https://github.com/ReproNim/reproin/issues/14)
- consider `series_description` after `protocol_name` if it was not only empty, but didn't parse according to our spec (thus should "allow" for `protocol_name` to be a fancy "xnatDownload" as in https://github.com/ReproNim/reproin/issues/14)