### PR TITLE
Heudiconv needlessly radicalizes its users

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -51,7 +51,7 @@ def populate_bids_templates(path, defaults={}):
                   ('DatasetDOI', 'TODO: eventually a DOI for the dataset')
         ]))
     sourcedata_README = op.join(path, 'sourcedata', 'README')
-    if not op.lexists(op.dirname(sourcedata_README)):
+    if op.exists(op.dirname(sourcedata_README)):
         create_file_if_missing(sourcedata_README,
             ("TODO: Provide description about source data, e.g. \n"
             "Directory below contains DICOMS compressed into tarballs per "

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -29,7 +29,7 @@ def populate_bids_templates(path, defaults={}):
 
     lgr.info("Populating template files under %s", path)
     descriptor = op.join(path, 'dataset_description.json')
-    if not op.exists(descriptor):
+    if not op.lexists(descriptor):
         save_json(descriptor,
               OrderedDict([
                   ('Name', "TODO: name of the dataset"),
@@ -51,7 +51,7 @@ def populate_bids_templates(path, defaults={}):
                   ('DatasetDOI', 'TODO: eventually a DOI for the dataset')
         ]))
     sourcedata_README = op.join(path, 'sourcedata', 'README')
-    if op.exists(op.dirname(sourcedata_README)):
+    if not op.lexists(op.dirname(sourcedata_README)):
         create_file_if_missing(sourcedata_README,
             ("TODO: Provide description about source data, e.g. \n"
             "Directory below contains DICOMS compressed into tarballs per "
@@ -89,18 +89,22 @@ def populate_bids_templates(path, defaults={}):
         suf = '_bold.json'
         assert fpath.endswith(suf)
         events_file = fpath[:-len(suf)] + '_events.tsv'
-        lgr.debug("Generating %s", events_file)
-        with open(events_file, 'w') as f:
-            f.write("onset\tduration\ttrial_type\tresponse_time\tstim_file\tTODO -- fill in rows and add more tab-separated columns if desired")
+        # do not touch any existing thing, it may be precious
+        if not op.lexists(events_file):
+            lgr.debug("Generating %s", events_file)
+            with open(events_file, 'w') as f:
+                f.write("onset\tduration\ttrial_type\tresponse_time\tstim_file\tTODO -- fill in rows and add more tab-separated columns if desired")
     # extract tasks files stubs
     for task_acq, fields in tasks.items():
         task_file = op.join(path, task_acq + '_bold.json')
-        lgr.debug("Generating %s", task_file)
-        fields["TaskName"] = ("TODO: full task name for %s" %
-                              task_acq.split('_')[0].split('-')[1])
-        fields["CogAtlasID"] = "TODO"
-        with open(task_file, 'w') as f:
-            f.write(json_dumps_pretty(fields, indent=2, sort_keys=True))
+        # do not touch any existing thing, it may be precious
+        if not op.lexists(task_file):
+            lgr.debug("Generating %s", task_file)
+            fields["TaskName"] = ("TODO: full task name for %s" %
+                                  task_acq.split('_')[0].split('-')[1])
+            fields["CogAtlasID"] = "TODO"
+            with open(task_file, 'w') as f:
+                f.write(json_dumps_pretty(fields, indent=2, sort_keys=True))
 
 
 def tuneup_bids_json_files(json_files):

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -110,7 +110,7 @@ def anonymize_sid(sid, anon_sid_cmd):
 def create_file_if_missing(filename, content):
     """Create file if missing, so we do not
     override any possibly introduced changes"""
-    if op.exists(filename):
+    if op.lexists(filename):
         return False
     dirname = op.dirname(filename)
     if not op.exists(dirname):


### PR DESCRIPTION
Here is a demo
```bash
# scanned me some data
git clone https://github.com/datalad/example-dicom-functional.git 
# use just a little to make the demo quicker
git -C example-dicom-functional checkout 1block
# use heudiconv to get BIDS, great
heudiconv -s my1 -f reproin -o out -b -a anon -l '' --minmeta --file example-dicom-functional/dicoms
# simulate hours of hand-composing events.tsv
cp example-dicom-functional/events.tsv anon/sub-my1/func/sub-my1_task-oneback_run-01_events.tsv
# I am no idiot: protect my assets!
chmod 444 anon/sub-my1/func/sub-my1_task-oneback_run-01_events.tsv
```

Spent summer outside, but now back to scanning: a structural for the same dataset and subject as above (and no, this is not a longitudinal dataset).
```bash
# data
git clone https://github.com/datalad/example-dicom-structural.git

# and coversion
heudiconv -s my1 -f reproin -o out2 -b -a anon -l '' --minmeta --file example-dicom-structural/dicoms  
INFO: Running heudiconv version 0.5.dev1
INFO: Analyzing 384 dicoms
INFO: Filtering out 0 dicoms based on their filename
INFO: Generated sequence info for 1 studies with 1 entries total
INFO: Processing sequence infos to deduce study/session
INFO: Study session for {'locator': 'Hanke/Stadler/0024_transrep', 'session': None, 'subject': '02'}
INFO: Need to process 1 study sessions
INFO: PROCESSING STARTS: {'subject': 'my1', 'outdir': '/tmp/heudemo/out2/', 'session': None}
INFO: Processing 1 pre-sorted seqinfo entries
INFO: Processing 1 seqinfo entries
INFO: Doing conversion using dcm2niix
INFO: Converting anon/sub-my1/anat/sub-my1_T1w (384 DICOMs) -> anon/sub-my1/anat . Converter: dcm2niix . Output types: ('nii.gz', 'dicom')
INFO: [Node] Setting-up "convert" in "/tmp/dcm2niixqphv_gie/convert".
INFO: [Node] Running "convert" ("nipype.interfaces.dcm2nii.Dcm2niix"), a CommandLine Interface with command:
dcm2niix -b y -z y -x n -t n -m n -f anat -o . -s n -v n /tmp/heudemo/example-dicom-structural/dicoms
INFO: stdout 2018-04-27T10:25:57.076601:Chris Rorden's dcm2niiX version v1.0.20170923 (OpenJPEG build) GCC6.3.0 (64-bit Linux)
INFO: stdout 2018-04-27T10:25:57.076601:Found 384 DICOM image(s)
INFO: stdout 2018-04-27T10:25:57.076601:Convert 384 DICOM as ./anat (274x384x384x1)
INFO: stdout 2018-04-27T10:25:58.641259:compress: "/usr/bin/pigz" -n -f -6 "./anat.nii"
INFO: stdout 2018-04-27T10:25:58.641259:Conversion required 1.637938 seconds (0.139293 for core code).
INFO: [Node] Finished "convert".
INFO: Populating template files under anon/
Traceback (most recent call last):
  File "/home/mih/env/datalad3-dev/bin/heudiconv", line 11, in <module>
    load_entry_point('heudiconv', 'console_scripts', 'heudiconv')()
  File "/home/mih/hacking/heudiconv/heudiconv/cli/run.py", line 120, in main
    process_args(args)
  File "/home/mih/hacking/heudiconv/heudiconv/cli/run.py", line 330, in process_args
    overwrite=args.overwrite,)
  File "/home/mih/hacking/heudiconv/heudiconv/convert.py", line 211, in prep_conversion
    getattr(heuristic, 'DEFAULT_FIELDS', {}))
  File "/home/mih/hacking/heudiconv/heudiconv/bids.py", line 93, in populate_bids_templates
    with open(events_file, 'w') as f:
PermissionError: [Errno 13] Permission denied: 'anon/sub-my1/func/sub-my1_task-oneback_run-01_events.tsv'
```

heudiconv wanted to replace my precious data with a template for a scan that it didn't even touch in this call. I am calling the cops...