### PR TITLE
Provide SeriesInstanceUID in SeqInfo

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -216,6 +216,7 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
             dcminfo.get('PatientAge'),
             dcminfo.get('PatientSex'),
             dcminfo.get('AcquisitionDate'),
+            dcminfo.get('SeriesInstanceUID')
         )
         # candidates
         # dcminfo.AccessionNumber

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -38,7 +38,8 @@ seqinfo_fields = [
     'accession_number',      # 21
     'patient_age',           # 22
     'patient_sex',           # 23
-    'date'                   # 24
+    'date',                  # 24
+    'uid'                    # 25
  ]
 
 SeqInfo = namedtuple('SeqInfo', seqinfo_fields)


### PR DESCRIPTION
If one wants to implement a "deterministic" (as opposed to a heuristic), it is necessary that heudiconv provides a unique identifiers for an image series, so that conversion/naming parameters can be preconfigured specifically for a given series. Ideally that ID is unique not just within a session (e.g. series number), but globally unique (such as the `SeriesInstanceUID` used here).

Why do this? Because tools like datalad can perform a substantial part of the sorting and metadata inspection implemented in heudiconv, so their results would already be known before heudiconv sees DICOMs for the first time, and it could be instructed specifically what to do.

This PR enables the development of such deterministic heuristics.

Ping @bpoldrack -- PR to eliminate the upstream diff.