### PR TITLE
enh: allow additional dcm2niix configuration

### DIFF
--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -231,6 +231,9 @@ def process_args(args):
     lgr.info(INIT_MSG(packname=__packagename__,
                       version=__version__))
 
+    if args.command:
+        process_extra_commands(outdir, args)
+        return
     #
     # Load heuristic -- better do it asap to make sure it loads correctly
     #

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -207,6 +207,8 @@ def get_parser():
                         'jsons')
     parser.add_argument('--random-seed', type=int, default=None,
                         help='Random seed to initialize RNG')
+    parser.add_argument('--dcmconfig', default=None,
+                        help='JSON file for additional dcm2niix configuration')
     submission = parser.add_argument_group('Conversion submission options')
     submission.add_argument('-q', '--queue', default=None,
                             help='select batch system to submit jobs to instead'
@@ -226,13 +228,8 @@ def process_args(args):
 
     outdir = op.abspath(args.outdir)
 
-    if args.command:
-        process_extra_commands(outdir, args)
-        return
-
     lgr.info(INIT_MSG(packname=__packagename__,
                       version=__version__))
-
 
     #
     # Load heuristic -- better do it asap to make sure it loads correctly
@@ -327,7 +324,8 @@ def process_args(args):
                         bids=args.bids,
                         seqinfo=seqinfo,
                         min_meta=args.minmeta,
-                        overwrite=args.overwrite,)
+                        overwrite=args.overwrite,
+                        dcmconfig=args.dcmconfig,)
 
         lgr.info("PROCESSING DONE: {0}".format(
             str(dict(subject=sid, outdir=study_outdir, session=session))))


### PR DESCRIPTION
Fixes #206 

* allow passing of an interface config through the use of `Nipype`'s `BaseInterface.__init__(from_file)`