### PR TITLE
Allow absolute path for dcm2niix to use the compiled version of it without installing

### DIFF
--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -18,14 +18,14 @@ INIT_MSG = "Running {packname} version {version}".format
 
 
 def is_interactive():
-   """Return True if all in/outs are tty"""
-   # TODO: check on windows if hasattr check would work correctly and add value:
-   return sys.stdin.isatty() and sys.stdout.isatty() and sys.stderr.isatty()
+    """Return True if all in/outs are tty."""
+    # TODO: check on windows if hasattr check would work correctly and add
+    # value:
+    return sys.stdin.isatty() and sys.stdout.isatty() and sys.stderr.isatty()
 
 
 def setup_exceptionhook():
-    """
-    Overloads default sys.excepthook with our exceptionhook handler.
+    """Overloads default sys.excepthook with our exceptionhook handler.
 
     If interactive, our exceptionhook handler will invoke pdb.post_mortem;
     if not interactive, then invokes default handler.
@@ -45,8 +45,9 @@ def setup_exceptionhook():
 
 
 def process_extra_commands(outdir, args):
-    """
-    Perform custom command instead of regular operations. Supported commands:
+    """Perform custom command instead of regular operations.
+
+    Supported commands:
     ['treat-json', 'ls', 'populate-templates']
 
     Parameters
@@ -55,6 +56,7 @@ def process_extra_commands(outdir, args):
         Output directory
     args : Namespace
         arguments
+
     """
     if args.command == 'treat-jsons':
         for f in args.files:
@@ -78,7 +80,8 @@ def process_extra_commands(outdir, args):
     elif args.command == 'populate-templates':
         heuristic = load_heuristic(args.heuristic)
         for f in args.files:
-            populate_bids_templates(f, getattr(heuristic, 'DEFAULT_FIELDS', {}))
+            populate_bids_templates(
+                f, getattr(heuristic, 'DEFAULT_FIELDS', {}))
     elif args.command == 'sanitize-jsons':
         tuneup_bids_json_files(args.files)
     elif args.command == 'heuristics':
@@ -86,7 +89,8 @@ def process_extra_commands(outdir, args):
         for name_desc in get_known_heuristics_with_descriptions().items():
             print("- %s: %s" % name_desc)
     elif args.command == 'heuristic-info':
-        from ..utils import get_heuristic_description, get_known_heuristic_names
+        from ..utils import (get_heuristic_description,
+                             get_known_heuristic_names)
         if not args.heuristic:
             raise ValueError("Specify heuristic using -f. Known are: %s"
                              % ', '.join(get_known_heuristic_names()))
@@ -127,104 +131,105 @@ def main(argv=None):
 
 def get_parser():
     docstr = ("""Example:
-             heudiconv -d rawdata/{subject} -o . -f heuristic.py -s s1 s2 s3""")
+             heudiconv -d rawdata/{subject} -o . -f heuristic.py -s s1 s2 s3"""
+              )
     parser = ArgumentParser(description=docstr)
     parser.add_argument('--version', action='version', version=__version__)
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-d', '--dicom_dir_template', dest='dicom_dir_template',
-                       help='location of dicomdir that can be indexed with '
+                       help='Location of dicomdir that can be indexed with '
                        'subject id {subject} and session {session}. Tarballs '
                        '(can be compressed) are supported in addition to '
                        'directory. All matching tarballs for a subject are '
-                       'extracted and their content processed in a single pass')
+                       'extracted and their content processed in a single '
+                       'pass.')
     group.add_argument('--files', nargs='*',
                        help='Files (tarballs, dicoms) or directories '
                        'containing files to process. Cannot be provided if '
-                       'using --dicom_dir_template or --subjects')
+                       'using --dicom_dir_template or --subjects.')
     parser.add_argument('-s', '--subjects', dest='subjs', type=str, nargs='*',
-                        help='list of subjects - required for dicom template. '
+                        help='List of subjects - required for dicom template. '
                         'If not provided, DICOMS would first be "sorted" and '
-                        'subject IDs deduced by the heuristic')
+                        'subject IDs deduced by the heuristic.')
     parser.add_argument('-c', '--converter',
                         default='dcm2niix',
-                        help='tool to use for DICOM conversion. Setting to '
+                        help='Tool to use for DICOM conversion. Setting to '
                         '"none" disables the actual conversion step -- useful'
                         'for testing heuristics. Absolute path to dcm2niix can'
                         'be given (e.g. /home/johndoe/mricrogl/dcm2niix).')
     parser.add_argument('-o', '--outdir', default=os.getcwd(),
-                        help='output directory for conversion setup (for '
+                        help='Output directory for conversion setup (for '
                         'further customization and future reference. This '
                         'directory will refer to non-anonymized subject IDs')
     parser.add_argument('-l', '--locator', default=None,
-                        help='study path under outdir.  If provided, '
+                        help='Study path under outdir.  If provided, '
                         'it overloads the value provided by the heuristic. '
                         'If --datalad is enabled, every directory within '
                         'locator becomes a super-dataset thus establishing a '
-                        'hierarchy. Setting to "unknown" will skip that dataset')
+                        'hierarchy. Setting to "unknown" will skip that '
+                        'dataset.')
     parser.add_argument('-a', '--conv-outdir', default=None,
-                        help='output directory for converted files. By default '
-                        'this is identical to --outdir. This option is most '
-                        'useful in combination with --anon-cmd')
+                        help='Output directory for converted files. By '
+                        'default this is identical to --outdir. This option '
+                        'is most useful in combination with --anon-cmd.')
     parser.add_argument('--anon-cmd', default=None,
-                        help='command to run to convert subject IDs used for '
+                        help='Command to run to convert subject IDs used for '
                         'DICOMs to anonymized IDs. Such command must take a '
-                        'single argument and return a single anonymized ID. '
-                        'Also see --conv-outdir')
+                        'single argument and return a single anonymized ID '
+                        '(also see --conv-outdir).')
     parser.add_argument('-f', '--heuristic', dest='heuristic',
                         # some commands might not need heuristic
                         # required=True,
                         help='Name of a known heuristic or path to the Python'
-                             'script containing heuristic')
+                             'script containing heuristic.')
     parser.add_argument('-p', '--with-prov', action='store_true',
                         help='Store additional provenance information. '
                         'Requires python-rdflib.')
     parser.add_argument('-ss', '--ses', dest='session', default=None,
-                        help='session for longitudinal study_sessions, default '
-                        'is none')
+                        help='Session for longitudinal study_sessions '
+                        '(default is none).')
     parser.add_argument('-b', '--bids', action='store_true',
-                        help='flag for output into BIDS structure')
+                        help='Flag for output into BIDS structure.')
     parser.add_argument('--overwrite', action='store_true', default=False,
-                        help='flag to allow overwriting existing converted files')
+                        help='Flag to allow overwriting existing converted '
+                        'files.')
     parser.add_argument('--datalad', action='store_true',
                         help='Store the entire collection as DataLad '
-                        'dataset(s). Small files will be committed directly to '
-                        'git, while large to annex. New version (6) of annex '
-                        'repositories will be used in a "thin" mode so it '
-                        'would look to mortals as just any other regular '
+                        'dataset(s). Small files will be committed directly '
+                        'to git, while large to annex. New version (6) of '
+                        'annex repositories will be used in a "thin" mode so '
+                        'it would look to mortals as just any other regular '
                         'directory (i.e. no symlinks to under .git/annex).  '
                         'For now just for BIDS mode.')
     parser.add_argument('--dbg', action='store_true', dest='debug',
                         help='Do not catch exceptions and show exception '
                         'traceback')
     parser.add_argument('--command',
-                        choices=(
-                            'heuristics', 'heuristic-info',
-                            'ls', 'populate-templates',
-                            'sanitize-jsons', 'treat-jsons',
-                        ),
-                        help='custom actions to be performed on provided '
+                        choices=('heuristics', 'heuristic-info', 'ls',
+                                 'populate-templates', 'sanitize-jsons',
+                                 'treat-jsons'),
+                        help='Custom actions to be performed on provided '
                         'files instead of regular operation.')
     parser.add_argument('-g', '--grouping', default='studyUID',
                         choices=('studyUID', 'accession_number'),
-                        help='How to group dicoms (default: by studyUID)')
+                        help='How to group dicoms (default: by studyUID).')
     parser.add_argument('--minmeta', action='store_true',
                         help='Exclude dcmstack meta information in sidecar '
-                        'jsons')
+                        'jsons.')
     parser.add_argument('--random-seed', type=int, default=None,
-                        help='Random seed to initialize RNG')
+                        help='Random seed to initialize RNG.')
     submission = parser.add_argument_group('Conversion submission options')
     submission.add_argument('-q', '--queue', default=None,
-                            help='select batch system to submit jobs to instead'
-                                 ' of running the conversion serially')
+                            help='Select batch system to submit jobs to '
+                                 'instead of running the conversion serially.')
     submission.add_argument('--sbargs', dest='sbatch_args', default=None,
                             help='Additional sbatch arguments if running with '
-                                 'queue arg')
+                                 'queue arg.')
     return parser
 
 
 def process_args(args):
-    """Given a structure of arguments from the parser perform computation"""
-
+    """Given a structure of arguments from the parser perform computation."""
     # Deal with provided files or templates
     # pre-process provided list of files and possibly sort into groups/sessions
     # Group files per each study/sid/session
@@ -243,7 +248,8 @@ def process_args(args):
     # Load heuristic -- better do it asap to make sure it loads correctly
     #
     if not args.heuristic:
-        raise RuntimeError("No heuristic specified - add to arguments and rerun")
+        raise RuntimeError(
+            "No heuristic specified - add to arguments and rerun")
 
     heuristic = load_heuristic(args.heuristic)
 
@@ -312,8 +318,8 @@ def process_args(args):
         anon_outdir = args.conv_outdir or outdir
         anon_study_outdir = op.join(anon_outdir, locator or '')
 
-        # TODO: --datalad  cmdline option, which would take care about initiating
-        # the outdir -> study_outdir datasets if not yet there
+        # TODO: --datalad  cmdline option, which would take care about
+        # initiating the outdir -> study_outdir datasets if not yet there
         if args.datalad:
             from ..external.dlad import prepare_datalad
             dlad_sid = sid if not anon_sid else anon_sid
@@ -356,7 +362,8 @@ def process_args(args):
     #         populate_bids_templates(study_outdir)
     #
     # TODO: record_collection of the sid/session although that information
-    # is pretty much present in .heudiconv/SUBJECT/info so we could just poke there
+    # is pretty much present in .heudiconv/SUBJECT/info so we could just poke
+    # there
 
 
 if __name__ == "__main__":

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -147,10 +147,10 @@ def get_parser():
                         'subject IDs deduced by the heuristic')
     parser.add_argument('-c', '--converter',
                         default='dcm2niix',
-                        choices=('dcm2niix', 'none'),
                         help='tool to use for DICOM conversion. Setting to '
                         '"none" disables the actual conversion step -- useful'
-                        'for testing heuristics.')
+                        'for testing heuristics. Absolute path to dcm2niix can'
+                        'be given (e.g. /home/johndoe/mricrogl/dcm2niix).')
     parser.add_argument('-o', '--outdir', default=os.getcwd(),
                         help='output directory for conversion setup (for '
                         'further customization and future reference. This '

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -35,6 +35,7 @@ lgr = logging.getLogger(__name__)
 
 
 def conversion_info(subject, outdir, info, filegroup, ses):
+    """Conversion information."""
     convert_info = []
     for key, items in info.items():
         if not items:
@@ -59,10 +60,10 @@ def conversion_info(subject, outdir, info, filegroup, ses):
                     seqitem=item,
                     subindex=subindex + 1,
                     session='ses-' + str(ses),
-                    bids_subject_session_prefix=
-                        'sub-%s' % subject + (('_ses-%s' % ses) if ses else ''),
-                    bids_subject_session_dir=
-                        'sub-%s' % subject + (('/ses-%s' % ses) if ses else ''),
+                    bids_subject_session_prefix='sub-{}_ses-{}'.format(
+                        subject, ses if ses else ''),
+                    bids_subject_session_dir='sub-{}/ses-{}'.format(
+                        subject, ses if ses else ''),
                     # referring_physician_name
                     # study_description
                     ))
@@ -78,8 +79,9 @@ def conversion_info(subject, outdir, info, filegroup, ses):
 
 
 def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
-                   anon_outdir, with_prov, ses, bids, seqinfo, min_meta,
-                   overwrite):
+                    anon_outdir, with_prov, ses, bids, seqinfo, min_meta,
+                    overwrite):
+    """Prepare conversion."""
     if dicoms:
         lgr.info("Processing %d dicoms", len(dicoms))
     elif seqinfo:
@@ -212,8 +214,9 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
 
 def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
             bids, outdir, min_meta, overwrite, symlink=True, prov_file=None):
-    """Perform actual conversion (calls to converter etc) given info from
-    heuristic's `infotodict`
+    """Perform actual conversion (calls to converter etc).
+
+    Given info from heuristic's `infotodict`.
 
     Parameters
     ----------
@@ -231,6 +234,7 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
     Returns
     -------
     None
+
     """
     prov_files = []
     tempdirs = TempDirs()
@@ -255,7 +259,7 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
 
         for outtype in outtypes:
             lgr.debug("Processing %d dicoms for output type %s. Overwrite=%s",
-                     len(item_dicoms), outtype, overwrite)
+                      len(item_dicoms), outtype, overwrite)
             lgr.debug("Includes the following dicoms: %s", item_dicoms)
 
             seqtype = op.basename(op.dirname(prefix)) if bids else None
@@ -285,8 +289,8 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                                                     with_prov, bids, tmpdir,
                                                     cmddir=converter_dir)
 
-                    bids_outfiles = save_converted_files(res, item_dicoms, bids,
-                                                         outtype, prefix,
+                    bids_outfiles = save_converted_files(res, item_dicoms,
+                                                         bids, outtype, prefix,
                                                          outname_bids,
                                                          overwrite=overwrite)
 
@@ -303,9 +307,8 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                     tempdirs.rmtree(tmpdir)
                 else:
                     raise RuntimeError(
-                        "was asked to convert into %s but destination already exists"
-                        % (outname)
-                    )
+                        "was asked to convert into {} but destination already \
+                        exists".format(outname))
 
         if len(bids_outfiles) > 1:
             lgr.warning("For now not embedding BIDS and info generated "
@@ -314,9 +317,9 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
         elif not bids_outfiles:
             lgr.debug("No BIDS files were produced, nothing to embed to then")
         elif outname:
-            embed_metadata_from_dicoms(bids, item_dicoms, outname, outname_bids,
-                                       prov_file, scaninfo, tempdirs, with_prov,
-                                       min_meta)
+            embed_metadata_from_dicoms(bids, item_dicoms, outname,
+                                       outname_bids, prov_file, scaninfo,
+                                       tempdirs, with_prov, min_meta)
         if scaninfo and op.exists(scaninfo):
             lgr.info("Post-treating %s file", scaninfo)
             treat_infofile(scaninfo)
@@ -332,7 +335,7 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
 
 def convert_dicom(item_dicoms, bids, prefix,
                   outdir, tempdirs, symlink, overwrite):
-    """Save DICOMs as output (default is by symbolic link)
+    """Save DICOMs as output (default is by symbolic link).
 
     Parameters
     ----------
@@ -355,6 +358,7 @@ def convert_dicom(item_dicoms, bids, prefix,
     Returns
     -------
     None
+
     """
     if bids:
         # mimic the same hierarchy location as the prefix
@@ -396,7 +400,7 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, cmddir):
     from nipype import Node
     from nipype.interfaces.dcm2nii import Dcm2niix
 
-    item_dicoms = list(map(op.abspath, item_dicoms)) # absolute paths
+    item_dicoms = list(map(op.abspath, item_dicoms))  # absolute paths
 
     dicom_dir = op.dirname(item_dicoms[0]) if item_dicoms else None
 
@@ -427,8 +431,10 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, cmddir):
     return eg, prov_file
 
 
-def save_converted_files(res, item_dicoms, bids, outtype, prefix, outname_bids, overwrite):
+def save_converted_files(res, item_dicoms, bids, outtype, prefix, outname_bids,
+                         overwrite):
     """Copy converted files from tempdir to output directory.
+
     Will rename files if necessary.
 
     Parameters
@@ -466,7 +472,7 @@ def save_converted_files(res, item_dicoms, bids, outtype, prefix, outname_bids, 
         # dwi etc which might spit out multiple files
 
         suffixes = ([str(i+1) for i in range(len(res_files))]
-                     if bids else None)
+                    if bids else None)
 
         if not suffixes:
             lgr.warning("Following series files likely have "
@@ -496,6 +502,6 @@ def save_converted_files(res, item_dicoms, bids, outtype, prefix, outname_bids, 
             try:
                 safe_copyfile(res.outputs.bids, outname_bids, overwrite)
                 bids_outfiles.append(outname_bids)
-            except TypeError as exc:  ##catch lists
+            except TypeError as exc:  # catch lists
                 raise TypeError("Multiple BIDS sidecars detected.")
     return bids_outfiles


### PR DESCRIPTION
Hi,

This is a really great tool, so thanks to all the contributors.

I have came across a scenario where the user could not install dcm2niix (due to system permission rules of the institute). Upon consideration of many options, it was clear that the only practical way was to use heudiconv with compiled version of dcm2niix. I have made minimal changes to the code to accomplish this goal while not changing the default behavior. For example now the users can use:
```heudiconv -d /path/to/{subject}/*dcm -o /path/to/output -f /path/to/convertall.py -c /path/to/dcm2niix -s s1``` (see that depending on the absolute path any compiled version of dcm2niix can be used, which is now consistent with the rest of the syntax).

I think this would also free heudiconv from the necessitiy of manually installing dcm2niix as suggested in the readme. If this PR is accepted I think the readme and the related suggestions of manually installing dcm2niix can be updated.

Btw, I took the liberty of fixing PEP8 and PEP257 issues where possible in the files that I have edited. I have also made the help instructions in command line interface to have more consistent capitalization and punctuation, I think it looks a bit nicer. I have kept these as separate commits just in case anyway.
