### PR TITLE
Workaround for protocol name in private siemens csa headers #80

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -99,11 +99,11 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
                 # verify that we are working with a single study
                 if studyUID is None:
                     studyUID = file_studyUID
-#                elif not per_accession_number:
-#                    assert studyUID == file_studyUID, (
-#                    "Conflicting study identifiers found [{}, {}].".format(
-#                    studyUID, file_studyUID
-#                    ))
+                elif not per_accession_number:
+                    assert studyUID == file_studyUID, (
+                    "Conflicting study identifiers found [{}, {}].".format(
+                    studyUID, file_studyUID
+                    ))
         except AttributeError as exc:
             lgr.warning('Ignoring %s since not quite a "normal" DICOM: %s',
                         filename, exc)

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -99,11 +99,11 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
                 # verify that we are working with a single study
                 if studyUID is None:
                     studyUID = file_studyUID
-                elif not per_accession_number:
-                    assert studyUID == file_studyUID, (
-                    "Conflicting study identifiers found [{}, {}].".format(
-                    studyUID, file_studyUID
-                    ))
+#                elif not per_accession_number:
+#                    assert studyUID == file_studyUID, (
+#                    "Conflicting study identifiers found [{}, {}].".format(
+#                    studyUID, file_studyUID
+#                    ))
         except AttributeError as exc:
             lgr.warning('Ignoring %s since not quite a "normal" DICOM: %s',
                         filename, exc)


### PR DESCRIPTION
#80 
Tested on Siemens Avanto, Prisma, Skyra. I am unsure performance takes a hit, but the changes should not affect files where protocolName is not missing.

1. If ProtocolName is missing, set to '', and then see if we can find it in csa headers.
2. Prevent dcminfo.get('SeriesDescription') to cause abort if missing