### PR TITLE
Handles multi-echo data.

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -88,6 +88,22 @@ def populate_bids_templates(path, defaults={}):
         # create a stub onsets file for each one of those
         suf = '_bold.json'
         assert fpath.endswith(suf)
+        # specify the name of the '_events.tsv' file:
+        if ( '_echo-' in fpath ):
+            # multi-echo sequence: bids (1.1.0) specifies just one '_events.tsv'
+            #   file, common for all echoes.  The name will not include _echo-.
+            # So, find out the echo number:
+            fpath_split = fpath.split('_echo-')         # split fpath using '_echo-'
+            fpath_split_2 = fpath_split[1].split('_')   # split the second part of fpath_split using '_'
+            echoNo = fpath_split_2[0]                   # get echo number
+            if ( echoNo == '1' ):
+                # we modify fpath to exclude '_echo-' + echoNo:
+                fpath = fpath_split[0] + '_' + fpath_split_2[1]
+            else:
+                # for echoNo greater than 1, don't create the events file, so go to
+                #   the next for loop iteration:
+                continue
+
         events_file = fpath[:-len(suf)] + '_events.tsv'
         # do not touch any existing thing, it may be precious
         if not op.lexists(events_file):


### PR DESCRIPTION
It handles both ME-EPI and ME-MPRAGE.
For multi-echo functional data, it generates a single _events.tsv file (following BIDS spec 1.1.0).
It addresses issues #162 , #203 , #255 and maybe some others.
It has been tested on CMRR multi-band multi-echo EPI and MGH multi-echo MPRAGE data from a Prisma (VE11C), in both cases with magnitude and phase images.