### PR TITLE
Few small fixes from using ReproIn @ DBIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented (for humans) in this file
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - Date
+
+TODO Summary
+
+### Added
+### Changed
+
+- Reproin heuristic: `__dup` indices would now be assigned incrementally
+  individually per each sequence, so there is a chance to properly treat
+  associate for multi-file (e.g. `fmap`) sequences
+
+### Deprecated
+### Fixed
+### Removed
+### Security
+
+
 ## [0.5.1] - 2018-07-05
 Bugfix release
 

--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -9,12 +9,25 @@ def test_get_dups_marked():
     no_dups = {('some',): [1]}
     assert get_dups_marked(no_dups) == no_dups
 
-    assert get_dups_marked(
-        OrderedDict([
+    info = OrderedDict(
+        [
             (('bu', 'du'), [1, 2]),
             (('smth',), [3]),
             (('smth2',), ['a', 'b', 'c'])
-        ])) == \
+         ]
+    )
+
+    assert get_dups_marked(info) == get_dups_marked(info, True) == \
+        {
+            ('bu__dup-01', 'du'): [1],
+            ('bu', 'du'): [2],
+            ('smth',): [3],
+            ('smth2__dup-01',): ['a'],
+            ('smth2__dup-02',): ['b'],
+            ('smth2',): ['c']
+        }
+
+    assert get_dups_marked(info, per_series=False) == \
         {
             ('bu__dup-01', 'du'): [1],
             ('bu', 'du'): [2],


### PR DESCRIPTION
- allow for a space to be used as a separator within `locator`
- provide details while throwing error on detecting multiple session markers

above will be merged locally/pushed, here is the next change:

- Reproin: make __dups indexes be per series (by default, not tunable ATM)

TODO:
- [x] test on some real case with lots of _dups
