### PR TITLE
Make randstr field in _scans files deterministic

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -292,13 +292,9 @@ def get_formatted_scans_key_row(dcm_fn):
         [ISO acquisition time, performing physician name, random string]
 
     """
-    from heudiconv.external.dcmstack import ds
-    mw = ds.wrapper_from_data(dcm.read_file(dcm_fn,
-                                            stop_before_pixels=True,
-                                            force=True))
+    dcm_data = dcm.read_file(dcm_fn, stop_before_pixels=True, force=True)
     # we need to store filenames and acquisition times
     # parse date and time and get it into isoformat
-    dcm_data = mw.dcm_data
     try:
         date = dcm_data.ContentDate
         time = dcm_data.ContentTime.split('.')[0]

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -307,7 +307,7 @@ def get_formatted_scans_key_row(dcm_fn):
     # But let's make it reproducible by using all UIDs
     # (might change across versions?)
     randcontent = u''.join(
-        [getattr(dcm_data, f) for f in sorted(dir(dcm_data))
+        [getattr(dcm_data, f) or '' for f in sorted(dir(dcm_data))
          if f.endswith('UID')]
     )
     randstr = hashlib.md5(randcontent.encode()).hexdigest()[:8]

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -1,5 +1,6 @@
 """Handle BIDS specific operations"""
 
+import hashlib
 import os
 import os.path as op
 import logging
@@ -196,7 +197,7 @@ def save_scans_key(item, bids_files):
     """
     Parameters
     ----------
-    items:
+    item:
     bids_files: str or list
 
     Returns
@@ -214,7 +215,7 @@ def save_scans_key(item, bids_files):
         # get filenames
         f_name = '/'.join(bids_file.split('/')[-2:])
         f_name = f_name.replace('json', 'nii.gz')
-        rows[f_name] = get_formatted_scans_key_row(item)
+        rows[f_name] = get_formatted_scans_key_row(item[-1][0])
         subj_, ses_ = find_subj_ses(f_name)
         if not subj_:
             lgr.warning(
@@ -279,7 +280,7 @@ def add_rows_to_scans_keys_file(fn, newrows):
         writer.writerows([header] + data_rows_sorted)
 
 
-def get_formatted_scans_key_row(item):
+def get_formatted_scans_key_row(dcm_fn):
     """
     Parameters
     ----------
@@ -291,25 +292,31 @@ def get_formatted_scans_key_row(item):
         [ISO acquisition time, performing physician name, random string]
 
     """
-    dcm_fn = item[-1][0]
     from heudiconv.external.dcmstack import ds
     mw = ds.wrapper_from_data(dcm.read_file(dcm_fn,
                                             stop_before_pixels=True,
                                             force=True))
     # we need to store filenames and acquisition times
     # parse date and time and get it into isoformat
+    dcm_data = mw.dcm_data
     try:
-        date = mw.dcm_data.ContentDate
-        time = mw.dcm_data.ContentTime.split('.')[0]
+        date = dcm_data.ContentDate
+        time = dcm_data.ContentTime.split('.')[0]
         td = time + date
         acq_time = datetime.strptime(td, '%H%M%S%Y%m%d').isoformat()
     except AttributeError as exc:
         lgr.warning("Failed to get date/time for the content: %s", str(exc))
         acq_time = None
     # add random string
-    randstr = ''.join(map(chr, sample(k=8, population=range(33, 127))))
+    # But let's make it reproducible by using all UIDs
+    # (might change across versions?)
+    randcontent = u''.join(
+        [getattr(dcm_data, f) for f in sorted(dir(dcm_data))
+         if f.endswith('UID')]
+    )
+    randstr = hashlib.md5(randcontent.encode()).hexdigest()[:8]
     try:
-        perfphys = mw.dcm_data.PerformingPhysicianName
+        perfphys = dcm_data.PerformingPhysicianName
     except AttributeError:
         perfphys = ''
     row = [acq_time, perfphys, randstr]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -153,23 +153,31 @@ def test_prepare_for_datalad(tmpdir):
 
 
 def test_get_formatted_scans_key_row():
-    item = [
-         ('%s/01-fmap_acq-3mm/1.3.12.2.1107.5.2.43.66112.2016101409263663466202201.dcm'
-          % TESTS_DATA_PATH,
-         ('nii.gz', 'dicom'),
-         ['%s/01-fmap_acq-3mm/1.3.12.2.1107.5.2.43.66112.2016101409263663466202201.dcm'
-          % TESTS_DATA_PATH])
-    ]
-    outname_bids_file = '/a/path/Halchenko/Yarik/950_bids_test4/sub-phantom1sid1/fmap/sub-phantom1sid1_acq-3mm_phasediff.json'
+    dcm_fn = \
+        '%s/01-fmap_acq-3mm/1.3.12.2.1107.5.2.43.66112.2016101409263663466202201.dcm' \
+         % TESTS_DATA_PATH
 
-    row = get_formatted_scans_key_row(item)
-    assert len(row) == 3
-    assert row[0] == '2016-10-14T09:26:36'
-    assert row[1] == 'n/a'
-    randstr1 = row[2]
-    row = get_formatted_scans_key_row(item)
-    randstr2 = row[2]
-    assert(randstr1 != randstr2)
+    row1 = get_formatted_scans_key_row(dcm_fn)
+    assert len(row1) == 3
+    assert row1[0] == '2016-10-14T09:26:36'
+    assert row1[1] == 'n/a'
+    prandstr1 = row1[2]
+
+    # if we rerun - should be identical!
+    row2 = get_formatted_scans_key_row(dcm_fn)
+    prandstr2 = row2[2]
+    assert(prandstr1 == prandstr2)
+    assert(row1 == row2)
+    # So it is consistent across pythons etc, we use explicit value here
+    assert(prandstr1 == "437fe57c")
+
+    # but the prandstr should change when we consider another DICOM file
+    row3 = get_formatted_scans_key_row(
+        "%s/01-anat-scout/0001.dcm" % TESTS_DATA_PATH)
+    assert(row3 != row1)
+    prandstr3 = row3[2]
+    assert(prandstr1 != prandstr3)
+    assert(prandstr3 == "fae3befb")
 
 
 # TODO: finish this


### PR DESCRIPTION
Closes #240 

generate  randstr's in _scans files deterministically based on the content of the DICOM header (UIDs) so it would be difficult if not impossible to guess that random string. That should make those _scans.tsv reproducible even if done from scratch