### PR TITLE
Siemens CSA header limit

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -55,6 +55,8 @@ def group_dicoms_into_seqinfos(files, file_filter, dcmfilter, grouping):
         nfl_after = len(files)
         lgr.info('Filtering out {0} dicoms based on their filename'.format(
             nfl_before-nfl_after))
+    import nibabel.nicom.csareader
+    nibabel.nicom.csareader.MAX_CSA_ITEMS = 400
     for fidx, filename in enumerate(files):
         from heudiconv.external.dcmstack import ds
         # TODO after getting a regression test check if the same behavior


### PR DESCRIPTION
Increase item limit to 400 to allow parsing larger headers. Resolves #212