### PR TITLE
BF: requires nipype at least 0.12 where Dcm2niix interface was added

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -11,7 +11,7 @@ tarballs into collections of NIfTI files following pre-defined heuristic(s)."""
 REQUIRES = [
     'nibabel',
     'pydicom',
-    'nipype',
+    'nipype>=0.12.0',
     'pathlib',
     'dcmstack>=0.7',
 ]


### PR DESCRIPTION
Some older neurodebian systems still have prior releases of nipype