### PR TITLE
added subprocess string decoding for anonymization use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN export PATH="/opt/miniconda-latest/bin:$PATH" \
            'traits>=4.6.0' \
            'scipy' \
            'numpy' \
+           'pandas' \
            'nomkl' \
     && sync && conda clean -tipsy && sync \
     && bash -c "source activate base \

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -100,7 +100,7 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
         anon_outdir = outdir
 
     # Generate heudiconv info folder
-    idir = op.join(outdir, '.heudiconv', sid)
+    idir = op.join(outdir, '.heudiconv', anon_sid)
     if bids and ses:
         idir = op.join(idir, 'ses-%s' % str(ses))
     if anon_outdir == outdir:

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -105,7 +105,7 @@ def docstring_parameter(*sub):
 def anonymize_sid(sid, anon_sid_cmd):
     from subprocess import check_output
     cmd = [anon_sid_cmd, sid]
-    return check_output(cmd).strip()
+    return check_output(cmd).decode().strip()
 
 
 def create_file_if_missing(filename, content):


### PR DESCRIPTION
Three changes related to the anonymization use case.
1 - The bytes literal string returned by subprocess.check_output is decoded to utf-8. Fixes #282 
2 - Many anonymization use cases are likely to involve parsing tabular files with a python script, for which pandas is a common strategy. Including it in the docker file of the vanilla build saves people from needing to roll their own.
3 - The user info in the .heudiconv directory is now anonymized if an anon_sid is present. Fixes #246 