### PR TITLE
Fixing up the abomination -- the regex to remove multiple spaces before numbers

### DIFF
--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -52,3 +52,10 @@ def test_json_dumps_pretty():
         == '{\n  "a": -1,\n  "b": "123",\n  "c": [1, 2, 3],\n  "d": ["1.0", "2.0"]\n}'
     assert pretty({'a': ["0.3", "-1.9128906358217845e-12", "0.2"]}) \
         == '{\n  "a": ["0.3", "-1.9128906358217845e-12", "0.2"]\n}'
+    # original, longer string
+    tstr = 'f9a7d4be-a7d7-47d2-9de0-b21e9cd10755||' \
+          'Sequence: ve11b/master r/50434d5; ' \
+          'Mar  3 2017 10:46:13 by eja'
+    # just the date which reveals the issue
+    # tstr = 'Mar  3 2017 10:46:13 by eja'
+    assert pretty({'WipMemBlock': tstr}) == '{\n  "WipMemBlock": "%s"\n}' % tstr

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -217,8 +217,16 @@ def json_dumps_pretty(j, indent=2, sort_keys=True):
     # uniform no spaces before ]
     js_ = re.sub(" *\]", "]", js_)
     # uniform spacing before numbers
-    js_ = re.sub('  *("?[-+.0-9e]+"?)(?P<space> ?)[ \n]*',
-                 r' \1\g<space>', js_)
+    # But that thing could screw up dates within strings which would have 2 spaces
+    # in a date like Mar  3 2017, so we do negative lookahead to avoid changing
+    # in those cases
+    #import pdb; pdb.set_trace()
+    js_ = re.sub(
+        '(?<!\w{3})'    # negative lookbehind for the month
+        '  *("?[-+.0-9e]+"?)'
+        '(?! [123]\d{3})'  # negative lookahead for a year
+        '(?P<space> ?)[ \n]*',
+        r' \1\g<space>', js_)
     # no spaces after [
     js_ = re.sub('\[ ', '[', js_)
     # the load from the original dump and reload from tuned up


### PR DESCRIPTION
We should really consider stripping that ugly beast of mine from the code since it might cause more trouble than gain.  But for now just fixed up the regex to avoid 