### PR TITLE
FIX: SLURM queue support

### DIFF
--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -293,7 +293,7 @@ def process_args(args):
 
             queue_conversion(progname,
                              args.queue,
-                             study_outdir,
+                             outdir,
                              heuristic.filename,
                              dicoms,
                              sid,

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -4,7 +4,6 @@ import os.path as op
 import logging
 from collections import OrderedDict
 import tarfile
-from nibabel.nicom import csareader
 from heudiconv.external.pydicom import dcm
 
 from .utils import SeqInfo, load_json, set_readonly

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -186,7 +186,7 @@ def get_study_sessions(dicom_dir_template, files_opt, heuristic, outdir,
                                           "`infotoids` to heuristic file or "
                                           "provide `--subjects` option")
             lgr.warn("Heuristic is missing an `infotoids` method, assigning "
-                     "empty method and using provided subject id %s."
+                     "empty method and using provided subject id %s. "
                      "Provide `session` and `locator` fields for best results."
                      , sid)
             def infotoids(seqinfos, outdir):

--- a/heudiconv/queue.py
+++ b/heudiconv/queue.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 
 import logging
 
@@ -32,7 +33,6 @@ def queue_conversion(pyscript, queue, studyid, queue_args=None):
             raise NotImplementedError("Queuing with %s is not supported", queue)
 
         args = sys.argv[1:]
-        print(sys.argv)
         # search args for queue flag
         for i, arg in enumerate(args):
             if arg in ["-q", "--queue"]:
@@ -51,7 +51,7 @@ def queue_conversion(pyscript, queue, studyid, queue_args=None):
         convertcmd = " ".join(args)
 
         # will overwrite across subjects
-        queue_file = 'heudiconv-%s.sh' % queue
+        queue_file = os.path.abspath('heudiconv-%s.sh' % queue)
         with open(queue_file, 'wt') as fp:
             fp.writelines(['#!/bin/bash\n', convertcmd, '\n'])
 

--- a/heudiconv/queue.py
+++ b/heudiconv/queue.py
@@ -1,35 +1,62 @@
-import os
-import os.path as op
+import subprocess
+import sys
 
 import logging
 
 lgr = logging.getLogger(__name__)
 
-# start with SLURM but extend past that #TODO
-def queue_conversion(progname, queue, outdir, heuristic, dicoms, sid,
-                     anon_cmd, converter, session,with_prov, bids):
+def queue_conversion(pyscript, queue, studyid, queue_args=None):
+        """
+        Write out conversion arguments to file and submit to a job scheduler.
+        Parses `sys.argv` for heudiconv arguments.
 
-        # Rework this...
-        convertcmd = ' '.join(['python', progname,
-                               '-o', outdir,
-                               '-f', heuristic,
-                               '-s', sid,
-                               '--anon-cmd', anon_cmd,
-                               '-c', converter])
-        if session:
-            convertcmd += " --ses '%s'" % session
-        if with_prov:
-            convertcmd += " --with-prov"
-        if bids:
-            convertcmd += " --bids"
-        if dicoms:
-            convertcmd += " --files"
-            convertcmd += [" '%s'" % f for f in dicoms]
+        Parameters
+        ----------
+        pyscript: file
+            path to `heudiconv` script
+        queue: string
+            batch scheduler to use
+        studyid: string
+            identifier for conversion
+        queue_args: string (optional)
+            additional queue arguments for job submission
 
-        script_file = 'dicom-%s.sh' % sid
-        with open(script_file, 'wt') as fp:
-            fp.writelines(['#!/bin/bash\n', convertcmd])
-        outcmd = 'sbatch -J dicom-%s -p %s -N1 -c2 --mem=20G %s' \
-                 % (sid, queue, script_file)
+        Returns
+        -------
+        proc: int
+            Queue submission exit code
+        """
 
-        os.system(outcmd)
+        SUPPORTED_QUEUES = {'SLURM': 'sbatch'}
+        if queue not in SUPPORTED_QUEUES:
+            raise NotImplementedError("Queuing with %s is not supported", queue)
+
+        args = sys.argv[1:]
+        print(sys.argv)
+        # search args for queue flag
+        for i, arg in enumerate(args):
+            if arg in ["-q", "--queue"]:
+                break
+        if i == len(args) - 1:
+            raise RuntimeError(
+                "Queue flag not found (must be provided as a command-line arg)"
+            )
+        # remove queue flag and value
+        del args[i:i+2]
+
+        # make arguments executable again
+        args.insert(0, pyscript)
+        pypath = sys.executable or "python"
+        args.insert(0, pypath)
+        convertcmd = " ".join(args)
+
+        # will overwrite across subjects
+        queue_file = 'heudiconv-%s.sh' % queue
+        with open(queue_file, 'wt') as fp:
+            fp.writelines(['#!/bin/bash\n', convertcmd, '\n'])
+
+        cmd = [SUPPORTED_QUEUES[queue], queue_file]
+        if queue_args:
+            cmd.insert(1, queue_args)
+        proc = subprocess.call(cmd)
+        return proc

--- a/heudiconv/tests/test_queue.py
+++ b/heudiconv/tests/test_queue.py
@@ -17,17 +17,16 @@ def test_queue_no_slurm(tmpdir, invocation):
     tmpdir.chdir()
     hargs = invocation.split(" ")
     hargs.extend(["-f", "reproin", "-b", "--minmeta", "--queue", "SLURM"])
-    print(hargs)
 
     # simulate command-line call
     _sys_args = sys.argv
     sys.argv = ['heudiconv'] + hargs
 
     try:
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(OSError):
             runner(hargs)
         # should have generated a slurm submission script
-        slurm_cmd_file = tmpdir / 'heudiconv-SLURM.sh'
+        slurm_cmd_file = (tmpdir / 'heudiconv-SLURM.sh').strpath
         assert slurm_cmd_file
         # check contents and ensure args match
         with open(slurm_cmd_file) as fp:

--- a/heudiconv/tests/test_queue.py
+++ b/heudiconv/tests/test_queue.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import subprocess
+
+from heudiconv.cli.run import main as runner
+from .utils import TESTS_DATA_PATH
+import pytest
+from nipype.utils.filemanip import which
+
+@pytest.mark.skipif(which("sbatch"), reason="skip a real slurm call")
+@pytest.mark.parametrize(
+    'invocation', [
+        "--files %s/01-fmap_acq-3mm" % TESTS_DATA_PATH,    # our new way with automated groupping
+        "-d %s/{subject}/* -s 01-fmap_acq-3mm" % TESTS_DATA_PATH # "old" way specifying subject
+    ])
+def test_queue_no_slurm(tmpdir, invocation):
+    tmpdir.chdir()
+    hargs = invocation.split(" ")
+    hargs.extend(["-f", "reproin", "-b", "--minmeta", "--queue", "SLURM"])
+    print(hargs)
+
+    # simulate command-line call
+    _sys_args = sys.argv
+    sys.argv = ['heudiconv'] + hargs
+
+    try:
+        with pytest.raises(FileNotFoundError):
+            runner(hargs)
+        # should have generated a slurm submission script
+        slurm_cmd_file = tmpdir / 'heudiconv-SLURM.sh'
+        assert slurm_cmd_file
+        # check contents and ensure args match
+        with open(slurm_cmd_file) as fp:
+            lines = fp.readlines()
+        assert lines[0] == "#!/bin/bash\n"
+        cmd = lines[1]
+
+        # check that all flags we gave still being called
+        for arg in hargs:
+            # except --queue <queue>
+            if arg in ['--queue', 'SLURM']:
+                assert arg not in cmd
+            else:
+                assert arg in cmd
+    finally:
+        # revert before breaking something
+        sys.argv = _sys_args


### PR DESCRIPTION
Closes #302.

Since this was forgotten/neglected after #87, re-enables support for SLURM submission.

`queue_conversion` was refactored to read command line arguments, and pass them to the SLURM call script. This will help with less maintenance as options are changed or added, with the trade-off of requiring a command-line submission.

`--sbargs` was renamed to `--queue-args` to allow for additional queue support down the line.