### PR TITLE
fix: embedding issue

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -353,7 +353,7 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
     return outtar
 
 
-def embed_nifti(dcmfiles, niftifile, infofile, bids_info, force, min_meta):
+def embed_nifti(dcmfiles, niftifile, infofile, bids_info, min_meta):
     """
 
     If `niftifile` doesn't exist, it gets created out of the `dcmfiles` stack,
@@ -370,7 +370,6 @@ def embed_nifti(dcmfiles, niftifile, infofile, bids_info, force, min_meta):
     niftifile
     infofile
     bids_info
-    force
     min_meta
 
     Returns
@@ -387,10 +386,11 @@ def embed_nifti(dcmfiles, niftifile, infofile, bids_info, force, min_meta):
 
     if not min_meta:
         import dcmstack as ds
-        stack = ds.parse_and_stack(dcmfiles, force=force).values()
+        stack = ds.parse_and_stack(dcmfiles, force=True).values()
         if len(stack) > 1:
             raise ValueError('Found multiple series')
-        stack = stack[0]
+        # may be odict now - iter to be safe
+        stack = next(iter(stack))
 
         #Create the nifti image using the data array
         if not op.exists(niftifile):
@@ -458,7 +458,7 @@ def embed_metadata_from_dicoms(bids, item_dicoms, outname, outname_bids,
     item_dicoms = list(map(op.abspath, item_dicoms))
 
     embedfunc = Node(Function(input_names=['dcmfiles', 'niftifile', 'infofile',
-                                           'bids_info', 'force', 'min_meta'],
+                                           'bids_info', 'min_meta'],
                               output_names=['outfile', 'meta'],
                               function=embed_nifti),
                      name='embedder')
@@ -466,13 +466,10 @@ def embed_metadata_from_dicoms(bids, item_dicoms, outname, outname_bids,
     embedfunc.inputs.niftifile = op.abspath(outname)
     embedfunc.inputs.infofile = op.abspath(scaninfo)
     embedfunc.inputs.min_meta = min_meta
-    if bids:
-        embedfunc.inputs.bids_info = load_json(op.abspath(outname_bids))
-    else:
-        embedfunc.inputs.bids_info = None
-    embedfunc.inputs.force = True
+    embedfunc.inputs.bids_info = load_json(op.abspath(outname_bids)) if bids else None
     embedfunc.base_dir = tmpdir
     cwd = os.getcwd()
+
     lgr.debug("Embedding into %s based on dicoms[0]=%s for nifti %s",
               scaninfo, item_dicoms[0], outname)
     try:

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -1,10 +1,11 @@
 import os.path as op
+import json
 
 import pytest
 
 from heudiconv.external.pydicom import dcm
 from heudiconv.cli.run import main as runner
-from heudiconv.dicoms import parse_private_csa_header
+from heudiconv.dicoms import parse_private_csa_header, embed_nifti
 from .utils import TESTS_DATA_PATH
 
 # Public: Private DICOM tags
@@ -23,3 +24,37 @@ def test_private_csa_header(tmpdir):
         assert parse_private_csa_header(dcm_data, pub, priv) != ''
         # and quickly run heudiconv with no conversion
         runner(['--files', dcm_file, '-c' 'none', '-f', 'reproin'])
+
+
+def test_nifti_embed(tmpdir):
+    """Test dcmstack's additional fields"""
+    tmpdir.chdir()
+    # set up testing files
+    dcmfiles = [op.join(TESTS_DATA_PATH, 'axasc35.dcm')]
+    infofile = 'infofile.json'
+
+    # 1) nifti does not exist
+    out = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', None, False)
+    # string -> json
+    out = json.loads(out)
+    # should have created nifti file
+    assert op.exists('nifti.nii')
+
+    # 2) nifti exists
+    nifti, info = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', None, False)
+    assert op.exists(nifti)
+    assert op.exists(info)
+    with open(info) as fp:
+        out2 = json.load(fp)
+
+    assert out == out2
+
+    # 3) with existing metadata
+    bids = {"existing": "data"}
+    nifti, info = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', bids, False)
+    with open(info) as fp:
+        out3 = json.load(fp)
+
+    assert out3["existing"]
+    del out3["existing"]
+    assert out3 == out2 == out


### PR DESCRIPTION
Closes #291.

Fixes an issue where dcmstack output was not indexed properly (due to the change in https://github.com/moloney/dcmstack/commit/3815ea225e641af7c6c3a4c454b7dcd1bd2ede66). This "silent" error was avoided when using the `--minmeta` flag.

### Changes
* `stack` is set as the first iterated item of dcmstack's `parse_and_stack()`
* Parameter `force` of `embed_nifti()` was removed and automatically applied within.
* Test for various uses of `embed_nifti()`