### PR TITLE
RF: embed_nifti to extract_more_metadata_for_nifti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ TODO Summary
 
 ### Changed
 
+- RF `embed_nifti` into `extract_more_metadata_for_nifti` and
+  drop functionality for embedding using dcmstack.  This code was not reachable
+  from cmdline, and collides with the use of `--converter` which ATM supports
+  only dcm2niix and none. 
+
 ### Deprecated
 
 ### Fixed

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -385,7 +385,8 @@ def convert_dicom(item_dicoms, bids, prefix,
                 shutil.copyfile(filename, outfile)
 
 
-def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, dcmconfig=None):
+def nipype_convert(item_dicoms, prefix,
+                   with_prov=False, bids=False, tmpdir=None, dcmconfig=None):
     """
     Converts DICOMs grouped from heuristic using Nipype's Dcm2niix interface.
 
@@ -394,7 +395,7 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, dcmconfig=None)
     item_dicoms : List
         DICOM files to convert
     prefix : String
-        Heuristic output path
+        Only the base (filename) pointed by the prefix is used as output prefix
     with_prov : Bool
         Store provenance information
     bids : Bool
@@ -410,6 +411,9 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, dcmconfig=None)
         config.enable_provenance()
     from nipype import Node
     from nipype.interfaces.dcm2nii import Dcm2niix
+
+    if not tmpdir:
+        raise ValueError("tmpdir argument is mandatory")
 
     item_dicoms = list(map(op.abspath, item_dicoms)) # absolute paths
 
@@ -428,7 +432,8 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, dcmconfig=None)
     else:
         convertnode.terminal_output = 'allatonce'
     convertnode.inputs.bids_format = bids
-    eg = convertnode.run()
+
+    res = convertnode.run()
 
     # prov information
     prov_file = prefix + '_prov.ttl' if with_prov else None
@@ -438,7 +443,7 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, dcmconfig=None)
                               'provenance.ttl'),
                       prov_file)
 
-    return eg, prov_file
+    return res, prov_file
 
 
 def save_converted_files(res, item_dicoms, bids, outtype, prefix, outname_bids, overwrite):


### PR DESCRIPTION
That functionality was not used as far as I see it. More detail in the CHANGELOG change

Was reviewing #306 (better later than never) and just couldn't make it why we still have that additional "make nifti from dicoms" functionality if not actually used, or was I wrong?  Since nothing is embedded, I renamed that function, and ideally need to rename `embed_metadata_from_dicoms`.
So I wondered, what prov info we are collecting in there while running that function? may be `embed_metadata_from_dicoms` should just be melded with `extract_more_metadata_for_nifti`? @satra ?