### PR TITLE
BF: convert - move out resetting of outname and scaninfo outside of the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ TODO Summary
 
 ### Fixed
 
+- correctly handle the case when `outtype` of heuristic has "dicom"
+  before '.nii.gz'. Previously would have lead to absent additional metadata
+  extraction etc
+
 ### Removed
 
 ### Security

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -261,8 +261,6 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                      len(item_dicoms), outtype, overwrite)
             lgr.debug("Includes the following dicoms: %s", item_dicoms)
 
-            seqtype = op.basename(op.dirname(prefix)) if bids else None
-
             # set empty outname and scaninfo in case we only want dicoms
             outname = ''
             scaninfo = ''

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -247,6 +247,9 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
         prefix_dirname = op.dirname(prefix)
         outname_bids = prefix + '.json'
         bids_outfiles = []
+        # set empty outname and scaninfo in case we only want dicoms
+        outname = ''
+        scaninfo = ''
         lgr.info('Converting %s (%d DICOMs) -> %s . '
                  'Converter: %s . Output types: %s',
                  prefix, len(item_dicoms), prefix_dirname, converter, outtypes)
@@ -261,9 +264,6 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                      len(item_dicoms), outtype, overwrite)
             lgr.debug("Includes the following dicoms: %s", item_dicoms)
 
-            # set empty outname and scaninfo in case we only want dicoms
-            outname = ''
-            scaninfo = ''
             if outtype == 'dicom':
                 convert_dicom(item_dicoms, bids, prefix,
                               outdir, tempdirs, symlink, overwrite)


### PR DESCRIPTION
Otherwise, if outtype had nii.gz BEFORE dicom by the heuristic (or like it is done in our tests)
- embedding etc simply would be skipped altogether since those variables get reset!

also removed an unused variable

edit 1: trigger was -- I just couldn't figure out - why am I not getting into that embed_ call while running the tests?!!! ;-)