### PR TITLE
Reproin fix for Philips 

### DIFF
--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -888,8 +888,9 @@ def parse_series_spec(series_spec):
 
         # sanitize values, which must not have _ and - is undesirable ATM as well
         # TODO: BIDSv2.0 -- allows "-" so replace with it instead
-        value = str(value).replace('_', 'X').replace('-', 'X')
-        value = str(value).replace('(', '{').replace(')', '}') # for Philips
+        value = str(value) \
+            .replace('_', 'X').replace('-', 'X') \
+            .replace('(', '{').replace(')', '}')  # for Philips
 
         if key in ['ses', 'run', 'task', 'acq']:
             # those we care about explicitly

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -426,16 +426,15 @@ def ls(study_session, seqinfo):
 # So we just need subdir and file_suffix!
 def infotodict(seqinfo):
     """Heuristic evaluator for determining which runs belong where
-    
-    allowed template fields - follow python string module: 
-    
+
+    allowed template fields - follow python string module:
+
     item: index within category 
     subject: participant id 
     seqitem: run number during scanning
     subindex: sub index within group
     session: scan index for longitudinal acq
     """
-
     seqinfo = fix_seqinfo(seqinfo)
     lgr.info("Processing %d seqinfo entries", len(seqinfo))
     and_dicom = ('dicom', 'nii.gz')
@@ -841,6 +840,7 @@ def parse_series_spec(series_spec):
     # https://github.com/ReproNim/reproin/issues/14
     # where PU: prefix is added by the scanner
     series_spec = re.sub("^[A-Z]*:", "", series_spec)
+    series_spec = re.sub("^WIP ", "", series_spec) # remove Philips WIP prefix
 
     # Remove possible suffix we don't care about after __
     series_spec = series_spec.split('__', 1)[0]
@@ -889,6 +889,7 @@ def parse_series_spec(series_spec):
         # sanitize values, which must not have _ and - is undesirable ATM as well
         # TODO: BIDSv2.0 -- allows "-" so replace with it instead
         value = str(value).replace('_', 'X').replace('-', 'X')
+        value = str(value).replace('(', '{').replace(')', '}') # for Philips
 
         if key in ['ses', 'run', 'task', 'acq']:
             # those we care about explicitly

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -28,10 +28,11 @@ per each session.
 Sequence names on the scanner must follow this specification to avoid manual
 conversion/handling:
 
-  [PREFIX:]<seqtype[-label]>[_ses-<SESID>][_task-<TASKID>][_acq-<ACQLABEL>][_run-<RUNID>][_dir-<DIR>][<more BIDS>][__<custom>]
+  [PREFIX:][WIP ]<seqtype[-label]>[_ses-<SESID>][_task-<TASKID>][_acq-<ACQLABEL>][_run-<RUNID>][_dir-<DIR>][<more BIDS>][__<custom>]
 
 where
  [PREFIX:] - leading capital letters followed by : are stripped/ignored
+ [WIP ] - prefix is stripped/ignored (added by Philips for patch sequences)
  <...> - value to be entered
  [...] - optional -- might be nearly mandatory for some modalities (e.g.,
          run for functional) and very optional for others
@@ -104,6 +105,16 @@ __<custom> (optional)
 
 Although we still support "-" and "+" used within SESID and TASKID, their use is
 not recommended, thus not listed here
+
+## Scanner specifics
+
+We perform following actions regardless of the type of scanner, but applied
+generally to accommodate limitations imposed by different manufacturers/models:
+
+### Philips
+
+- We replace all ( with { and ) with } to be able e.g. to specify session {date}
+- "WIP " prefix unconditionally added by the scanner is stripped
 """
 
 import os

--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -166,6 +166,7 @@ def test_parse_series_spec():
     assert \
         pdpn(" PREFIX:bids_func_ses+_task-boo_run+  ") == \
         pdpn("PREFIX:bids_func_ses+_task-boo_run+") == \
+        pdpn("WIP func_ses+_task-boo_run+") == \
         pdpn("bids_func_ses+_run+_task-boo") == \
            {
                'seqtype': 'func',
@@ -202,3 +203,9 @@ def test_parse_series_spec():
                 'acq': 'MPRAGE',
                 'seqtype_label': 'T1w'
            }
+
+    # Check for currently used {date}, which should also should get adjusted
+    # from (date) since Philips does not allow for {}
+    assert pdpn("func_ses-{date}") == \
+           pdpn("func_ses-(date)") == \
+           {'seqtype': 'func', 'session': '{date}'}


### PR DESCRIPTION
As discussed here [https://github.com/ReproNim/reproin/issues/32#issue-439932420]( https://github.com/ReproNim/reproin/issues/32#issue-439932420)

I modified the heuristics to remove the Philips WIP prefix and a substitution for (date) to {date} as session label.
The later will only work if heudiconv is called with --file ..., not if the -d flag is used.

- [x] adjust docstring to mention `()` -> `{}` replacement and WIP stripping
- [x] add to the tests to assure that stripping/mapping works 