### PR TITLE
Add --skiptop flag to prevent writing top level bids files

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,11 +43,12 @@ DICOMs as an independent ``heudiconv`` execution.
 The first script aggregates the DICOM directories and submits them to
 ``run_heudiconv.sh`` with SLURM as a job array.
 
-If using bids, the ``--skiptop`` flag suppresses creation of top-level
-files in the bids directory (e.g., ``dataset_description.json``) to
-avoid possible race conditions.  These files may be generated later
-with ``populate_templates.sh`` below (except for ``participants.tsv``,
-which must be create manually).
+If using bids, the ``notop`` bids option suppresses creation of
+top-level files in the bids directory (e.g.,
+``dataset_description.json``) to avoid possible race conditions.
+These files may be generated later with ``populate_templates.sh``
+below (except for ``participants.tsv``, which must be create
+manually).
 
 .. code:: shell
 
@@ -82,7 +83,7 @@ The second script processes a DICOM directory with ``heudiconv`` using the built
     echo Submitted directory: ${DCMDIR}
 
     IMG="/singularity-images/heudiconv-0.5.4-dev.sif"
-    CMD="singularity run -B ${DCMDIR}:/dicoms:ro -B ${OUTDIR}:/output -e ${IMG} --files /dicoms/ -o /output -f reproin -c dcm2niix -b --minmeta -l . --skiptop"
+    CMD="singularity run -B ${DCMDIR}:/dicoms:ro -B ${OUTDIR}:/output -e ${IMG} --files /dicoms/ -o /output -f reproin -c dcm2niix -b notop --minmeta -l ."
 
     printf "Command:\n${CMD}\n"
     ${CMD}

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,6 +43,12 @@ DICOMs as an independent ``heudiconv`` execution.
 The first script aggregates the DICOM directories and submits them to
 ``run_heudiconv.sh`` with SLURM as a job array.
 
+If using bids, the ``--skiptop`` flag suppresses creation of top-level
+files in the bids directory (e.g., ``dataset_description.json``) to
+avoid possible race conditions.  These files may be generated later
+with ``populate_templates.sh`` below (except for ``participants.tsv``,
+which must be create manually).
+
 .. code:: shell
 
     #!/bin/bash
@@ -76,7 +82,22 @@ The second script processes a DICOM directory with ``heudiconv`` using the built
     echo Submitted directory: ${DCMDIR}
 
     IMG="/singularity-images/heudiconv-0.5.4-dev.sif"
-    CMD="singularity run -B ${DCMDIR}:/dicoms:ro -B ${OUTDIR}:/output -e ${IMG} --files /dicoms/ -o /output -f reproin -c dcm2niix -b --minmeta -l ."
+    CMD="singularity run -B ${DCMDIR}:/dicoms:ro -B ${OUTDIR}:/output -e ${IMG} --files /dicoms/ -o /output -f reproin -c dcm2niix -b --minmeta -l . --skiptop"
+
+    printf "Command:\n${CMD}\n"
+    ${CMD}
+    echo "Successful process"
+
+This script creates the top-level bids files (e.g.,
+``dataset_description.json``)
+
+..code:: shell
+    #!/bin/bash
+    set -eu
+
+    OUTDIR=${1}
+    IMG="/singularity-images/heudiconv-0.5.4-dev.sif"
+    CMD="singularity run -B ${OUTDIR}:/output -e ${IMG} --files /output -f reproin --command populate-templates"
 
     printf "Command:\n${CMD}\n"
     ${CMD}

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -138,6 +138,7 @@ def main(argv=None):
         args.bids_options = args.bids
         args.bids = True
     else:
+        args.bids_options = []
         args.bids = False
     if args.debug:
         lgr.setLevel(logging.DEBUG)

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -18,7 +18,8 @@ lgr = logging.getLogger(__name__)
 
 INIT_MSG = "Running {packname} version {version}".format
 
-BIDS_OPTIONS = [('notop', 'Skip creating of top-level bids files. '
+BIDS_OPTIONS = [('help', 'Display this help message'),
+                ('notop', 'Skip creating of top-level bids files. '
                           'Useful when running in batch mode to prevent '
                           'possible race conditions.')]
 
@@ -113,7 +114,7 @@ def help_bids():
 def main(argv=None):
     parser = get_parser()
     args = parser.parse_args(argv)
-    if args.help_bids:
+    if 'help' in args.bids:
         help_bids()
         sys.exit(1)
     # exit if nothing to be done
@@ -212,7 +213,7 @@ def get_parser():
     parser.add_argument('-b', '--bids', nargs='*',
                         metavar=('BIDSOPTION1', 'BIDSOPTION2'),
                         help='flag for output into BIDS structure. '
-                        'Can also take bids specific options. Use --help-bids '
+                        'Can also take bids specific options. Use --bids help '
                         'for more information.')
     parser.add_argument('--overwrite', action='store_true', default=False,
                         help='flag to allow overwriting existing converted files')
@@ -253,8 +254,6 @@ def get_parser():
                             help='Additional queue arguments passed as '
                             'single string of Argument=Value pairs space '
                             'separated.')
-    parser.add_argument('--help-bids', action='store_true', dest='help_bids',
-                        help='Display bids specific help.')
     return parser
 
 

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -103,11 +103,11 @@ def process_extra_commands(outdir, args):
 
 
 def help_bids():
-    print('bids specific options can be passed after the bids flag.', file=sys.stdout)
-    print('For example, "--bids notop".', file=sys.stdout)
-    print('The currently supported options are:', file=sys.stdout)
+    sys.stderr.write('bids specific options can be passed after the bids flag.\n'
+                     'For example, "--bids notop".\n'
+                     'The currently supported options are:\n')
     for option, helpstr in BIDS_OPTIONS:
-        print('{}: {}'.format(option, helpstr), file=sys.stdout)
+        sys.stderr.write('{}: {}\n'.format(option, helpstr))
 
 
 def main(argv=None):

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -222,6 +222,10 @@ def get_parser():
                             help='Additional queue arguments passed as '
                             'single string of Argument=Value pairs space '
                             'separated.')
+    parser.add_argument('--skiptop', action='store_true',
+                        help='Skip creating of top-level bids files. '
+                        'Useful when running in batch mode to prevent '
+                        'possible race conditions.')
     return parser
 
 
@@ -320,7 +324,8 @@ def process_args(args):
                         seqinfo=seqinfo,
                         min_meta=args.minmeta,
                         overwrite=args.overwrite,
-                        dcmconfig=args.dcmconfig,)
+                        dcmconfig=args.dcmconfig,
+                        skiptop=args.skiptop,)
 
         lgr.info("PROCESSING DONE: {0}".format(
             str(dict(subject=sid, outdir=study_outdir, session=session))))

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -80,7 +80,7 @@ def conversion_info(subject, outdir, info, filegroup, ses):
 
 def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
                    anon_outdir, with_prov, ses, bids, seqinfo, min_meta,
-                   overwrite, dcmconfig, skiptop):
+                   overwrite, dcmconfig, bids_options):
     if dicoms:
         lgr.info("Processing %d dicoms", len(dicoms))
     elif seqinfo:
@@ -201,7 +201,7 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
     for item_dicoms in filegroup.values():
         clear_temp_dicoms(item_dicoms)
 
-    if bids and not skiptop:
+    if bids and 'notop' not in bids_options:
         if seqinfo:
             keys = list(seqinfo)
             add_participant_record(anon_outdir,

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -80,7 +80,7 @@ def conversion_info(subject, outdir, info, filegroup, ses):
 
 def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
                    anon_outdir, with_prov, ses, bids, seqinfo, min_meta,
-                   overwrite, dcmconfig):
+                   overwrite, dcmconfig, skiptop):
     if dicoms:
         lgr.info("Processing %d dicoms", len(dicoms))
     elif seqinfo:
@@ -201,7 +201,7 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
     for item_dicoms in filegroup.values():
         clear_temp_dicoms(item_dicoms)
 
-    if bids:
+    if bids and not skiptop:
         if seqinfo:
             keys = list(seqinfo)
             add_participant_record(anon_outdir,

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -429,7 +429,7 @@ def embed_nifti(dcmfiles, niftifile, infofile, bids_info, min_meta):
     return niftifile, infofile
 
 
-def embed_metadata_from_dicoms(bids, item_dicoms, outname, outname_bids,
+def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
                                prov_file, scaninfo, tempdirs, with_prov,
                                min_meta):
     """
@@ -437,7 +437,7 @@ def embed_metadata_from_dicoms(bids, item_dicoms, outname, outname_bids,
 
     Parameters
     ----------
-    bids
+    bids_options
     item_dicoms
     outname
     outname_bids
@@ -466,7 +466,7 @@ def embed_metadata_from_dicoms(bids, item_dicoms, outname, outname_bids,
     embedfunc.inputs.niftifile = op.abspath(outname)
     embedfunc.inputs.infofile = op.abspath(scaninfo)
     embedfunc.inputs.min_meta = min_meta
-    embedfunc.inputs.bids_info = load_json(op.abspath(outname_bids)) if bids else None
+    embedfunc.inputs.bids_info = load_json(op.abspath(outname_bids)) if (bids_options is not None) else None
     embedfunc.base_dir = tmpdir
     cwd = os.getcwd()
 

--- a/heudiconv/tests/test_heuristics.py
+++ b/heudiconv/tests/test_heuristics.py
@@ -150,3 +150,23 @@ def test_scout_conversion(tmpdir):
         'ses-localizer/anat/sub-phantom1sid1_ses-localizer_scout.dicom.tgz'
     )
     )
+
+
+@pytest.mark.parametrize(
+    'bidsoptions', [
+        ['notop'], [],
+    ])
+def test_notop(tmpdir, bidsoptions):
+    tmppath = tmpdir.strpath
+    args = (
+        "-f reproin --files %s"
+        % (TESTS_DATA_PATH)
+    ).split(' ') + ['-o', tmppath] + ['-b'] + bidsoptions
+    runner(args)
+
+    assert op.exists(pjoin(tmppath, 'Halchenko/Yarik/950_bids_test4'))
+    for fname in ['CHANGES', 'dataset_description.json', 'participants.tsv', 'README']:
+        if 'notop' in bidsoptions:
+            assert not op.exists(pjoin(tmppath, 'Halchenko/Yarik/950_bids_test4', fname))
+        else:
+            assert op.exists(pjoin(tmppath, 'Halchenko/Yarik/950_bids_test4', fname))


### PR DESCRIPTION
This is useful in batch processing to prevent potential race
conditions. The batch processing example has also been
modified to use this flag.

See #340 