### PR TITLE
Acquire a lock prior to top level bids file modification

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -14,6 +14,7 @@ REQUIRES = [
     'nipype>=0.12.0',
     'pathlib',
     'dcmstack>=0.7',
+    'filelock>=3.0.12',
 ]
 
 TESTS_REQUIRES = [


### PR DESCRIPTION
Uses SoftLockFile from py-filelock. Potentially addresses #340, although I'm not sure if SoftFileLock is guaranteed to work on distributed filesystems.

Currently the timeout is hardcoded, but if #344 gets merged then we can use the new method of specifying bids options to make the timeout configurable.