### PR TITLE
fix: dcm2niix outname

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -418,7 +418,7 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids, tmpdir, dcmconfig=None)
     convertnode = Node(Dcm2niix(from_file=fromfile), name='convert')
     convertnode.base_dir = tmpdir
     convertnode.inputs.source_names = item_dicoms
-    convertnode.inputs.out_filename = op.basename(op.dirname(prefix))
+    convertnode.inputs.out_filename = prefix
 
     if nipype.__version__.split('.')[0] == '0':
         # deprecated since 1.0, might be needed(?) before


### PR DESCRIPTION
This changes the `dcm2niix` outname from an erroneous substring to the heuristic prefix. Specifically, it will change the call from
```
dcm2niix -b y -f func ...
```
to
```
dcm2niix -b y -f /path/to/bids/sub-1/func/sub-1_task-blah_bold ...
```
