### PR TITLE
BF: ReproIn - Support pipolar fieldmaps by providing them with _epi not _magnitude

### DIFF
--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -209,3 +209,6 @@ def test_parse_series_spec():
     assert pdpn("func_ses-{date}") == \
            pdpn("func_ses-(date)") == \
            {'seqtype': 'func', 'session': '{date}'}
+
+    assert pdpn("fmap_dir-AP_ses-01") == \
+           {'seqtype': 'fmap', 'session': '01', 'dir': 'AP'}


### PR DESCRIPTION
There is also internal small ReproIn RF to minimize code duplication for common
functionality.

This change might result in slightly different naming due to now enforced order
of _dir- to come before the leftover BIDS suffixes.  So if previously there were
some other BIDS _key-value pairs which we did not treat in ReproIn, and they
were listed BEFORE _dir- - they might now be added AFTER it.  Some subsequent
PR should probably add treatment for other BIDS _key's (e.g. _ce) and place them
in the order listed within BIDS specification

Closes #357 

Unfortunately I believe we do not have any phantom SE scan with _dir- to provide some basic integration test for this fix ATM.