### PR TITLE
BF:Change nipype required version to >=1.0.0

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -11,7 +11,7 @@ tarballs into collections of NIfTI files following pre-defined heuristic(s)."""
 REQUIRES = [
     'nibabel',
     'pydicom',
-    'nipype>=0.12.0',
+    'nipype>=1.0.0',
     'pathlib',
     'dcmstack>=0.7',
 ]


### PR DESCRIPTION
HeuDiConv requires the function nipype.utils.filemanip.which(), which first appears in nipype release 1.0.0 