### PR TITLE
BF: handle error if ContentDate and ContentTime are empty

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -370,7 +370,7 @@ def get_formatted_scans_key_row(dcm_fn):
         time = dcm_data.ContentTime.split('.')[0]
         td = time + date
         acq_time = datetime.strptime(td, '%H%M%S%Y%m%d').isoformat()
-    except AttributeError as exc:
+    except (AttributeError, ValueError) as exc:
         lgr.warning("Failed to get date/time for the content: %s", str(exc))
         acq_time = None
     # add random string


### PR DESCRIPTION
I have a dicom with empty strings for date and time fields, which generated a ValueError in bids.py . This PR allows heudiconv to catch the exception and continue, setting `acq_time=None`. This is my desired behavior, and I think it's what others would like to have happen as well.