### PR TITLE
FIX: Blacklist nipype 1.2.1, 1.2.2 in Python 2.7 to avoid TraitError

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -11,7 +11,7 @@ tarballs into collections of NIfTI files following pre-defined heuristic(s)."""
 REQUIRES = [
     'nibabel',
     'pydicom',
-    'nipype>=1.0.0',
+    'nipype @ git+https://github.com/nipy/nipype.git@23379ebd997b0cca3a1feb2c2d7085d4ee9cf717',
     'pathlib',
     'dcmstack>=0.7',
 ]

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -11,7 +11,7 @@ tarballs into collections of NIfTI files following pre-defined heuristic(s)."""
 REQUIRES = [
     'nibabel',
     'pydicom',
-    'nipype @ git+https://github.com/nipy/nipype.git@23379ebd997b0cca3a1feb2c2d7085d4ee9cf717',
+    'nipype @ git+https://github.com/effigies/nipype.git@0196beac33d0c8c992bcc07b83c0b368810be02d',
     'pathlib',
     'dcmstack>=0.7',
 ]

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -11,7 +11,8 @@ tarballs into collections of NIfTI files following pre-defined heuristic(s)."""
 REQUIRES = [
     'nibabel',
     'pydicom',
-    'nipype @ git+https://github.com/effigies/nipype.git@0196beac33d0c8c992bcc07b83c0b368810be02d',
+    'nipype >=1.0.0; python_version > "3.0"',
+    'nipype >=1.0.0,!=1.2.1,!=1.2.2; python_version == "2.7"',
     'pathlib',
     'dcmstack>=0.7',
 ]


### PR DESCRIPTION
First checking whether we've already fixed this in nipype `master`.

Fixes #374 
Related nipy/nipype#3037