### PR TITLE
MNT: Add Python support metadata to package

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -8,6 +8,19 @@ __longdesc__ = """Convert DICOM dirs based on heuristic info - HeuDiConv
 uses the dcmstack package and dcm2niix tool to convert DICOM directories or
 tarballs into collections of NIfTI files following pre-defined heuristic(s)."""
 
+CLASSIFIERS = [
+    'Environment :: Console',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: Apache Software License',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Topic :: Scientific/Engineering'
+]
+
+PYTHON_REQUIRES = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
 REQUIRES = [
     'nibabel',
     'pydicom',

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,13 @@ def main():
         description=ldict['__description__'],
         long_description=ldict['__longdesc__'],
         license=ldict['__license__'],
+        classifiers=ldict['CLASSIFIERS'],
         packages=heudiconv_pkgs,
         entry_points={'console_scripts': [
             'heudiconv=heudiconv.cli.run:main',
             'heudiconv_monitor=heudiconv.cli.monitor:main',
         ]},
+        python_requires=ldict['PYTHON_REQUIRES'],
         install_requires=ldict['REQUIRES'],
         extras_require=ldict['EXTRA_REQUIRES'],
         package_data={


### PR DESCRIPTION
Got the currently supported versions from `.travis.yml`. This will advertise better and keep `pip > 9.0.0` from installing on unsupported Python installations.

Also added in some basic classifiers.

Inspired by going to comment on a PR and not knowing what language features I could assume.