### PR TITLE
DOC: Clarify tarball session handling

### DIFF
--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -140,8 +140,11 @@ def get_parser():
                        '(can be compressed) are supported in addition to '
                        'directory. All matching tarballs for a subject are '
                        'extracted and their content processed in a single '
-                       'pass. Note that you might need to surround the value '
-                       'with quotes to avoid {...} being considered by shell')
+                       'pass. If multiple tarballs are found, each is '
+                       'assumed to be a separate session and the --ses '
+                       'argument is ignored. Note that you might need to '
+                       'surround the value with quotes to avoid {...} being '
+                       'considered by shell')
     group.add_argument('--files', nargs='*',
                        help='Files (tarballs, dicoms) or directories '
                        'containing files to process. Cannot be provided if '


### PR DESCRIPTION
Makes explicit that the --dicom_dir_template argument will assign each tarball to a separate session and ignore the --ses flag if multiple are found

Fixes #383 