### PR TITLE
Empty acq_time results in empty cell not 'n/a'

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -425,11 +425,11 @@ def get_formatted_scans_key_row(dcm_fn):
     try:
         perfphys = dcm_data.PerformingPhysicianName
     except AttributeError:
-        perfphys = ''
+        perfphys = None
     row = [acq_time, perfphys, randstr]
     # empty entries should be 'n/a'
     # https://github.com/dartmouth-pbs/heudiconv/issues/32
-    row = ['n/a' if not str(e) else e for e in row]
+    row = ['n/a' if e is None else e for e in row]
     return row
 
 


### PR DESCRIPTION
BIDS validator gives me this error for acq_time: `[ERR] Empty cell in TSV file detected: The proper way of labeling missing values is "n/a"`

This is because `str(None)` in Python gives 'None' which has True boolean value. Fortunately, the fix is simple.