### PR TITLE
BF: use datalad 0.12, drop PY2, include workaround for dcmstack installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # vim ft=yaml
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -72,8 +72,7 @@ def conversion_info(subject, outdir, info, filegroup, ses):
                 try:
                     files = filegroup[item]
                 except KeyError:
-                    PY3 = sys.version_info[0] >= 3
-                    files = filegroup[(str if PY3 else unicode)(item)]
+                    files = filegroup[str(item)]
                 outprefix = template.format(**parameters)
                 convert_info.append((op.join(outpath, outprefix),
                                     outtype, files))

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -43,7 +43,7 @@ TESTS_REQUIRES = [
 EXTRA_REQUIRES = {
     'tests': TESTS_REQUIRES,
     'extras': [],  # Requires patched version ATM ['dcmstack'],
-    'datalad': ['datalad']
+    'datalad': ['datalad >=0.12.2']
 }
 
 # Flatten the lists

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -12,14 +12,13 @@ CLASSIFIERS = [
     'Environment :: Console',
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Topic :: Scientific/Engineering'
 ]
 
-PYTHON_REQUIRES = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+PYTHON_REQUIRES = ">=3.5"
 
 REQUIRES = [
     'nibabel',

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -35,8 +35,7 @@ def test_main_help(stdout):
     assert stdout.getvalue().startswith("usage: ")
 
 
-@patch('sys.stderr' if sys.version_info[:2] <= (3, 3) else
-       'sys.stdout', new_callable=StringIO)
+@patch('sys.stdout', new_callable=StringIO)
 def test_main_version(std):
     with pytest.raises(SystemExit):
         runner(['--version'])

--- a/heudiconv/tests/utils.py
+++ b/heudiconv/tests/utils.py
@@ -52,9 +52,9 @@ def fetch_data(tmpdir, dataset, getpath=None):
     """
     from datalad import api
     targetdir = op.join(tmpdir, op.basename(dataset))
-    api.install(path=targetdir,
+    ds = api.install(path=targetdir,
                 source='http://datasets-tests.datalad.org/{}'.format(dataset))
 
     getdir = targetdir + (op.sep + getpath if getpath is not None else '')
-    api.get(getdir)
+    ds.get(getdir)
     return targetdir

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -19,10 +19,7 @@ from nipype.utils.filemanip import which
 import logging
 lgr = logging.getLogger(__name__)
 
-if sys.version_info[0] > 2:
-    from json.decoder import JSONDecodeError
-else:
-    JSONDecodeError = ValueError
+from json.decoder import JSONDecodeError
 
 
 seqinfo_fields = [
@@ -115,9 +112,7 @@ def anonymize_sid(sid, anon_sid_cmd):
     cmd = [anon_sid_cmd, sid]
     shell_return = check_output(cmd)
 
-    if all([sys.version_info[0] > 2,
-            isinstance(shell_return, bytes),
-            isinstance(sid, str)]):
+    if isinstance(shell_return, bytes) and isinstance(sid, str):
         anon_sid = shell_return.decode()
     else:
         anon_sid = shell_return
@@ -490,8 +485,6 @@ def create_tree(path, tree, archives_leading_dir=True):
             create_tree(full_name, load, archives_leading_dir=archives_leading_dir)
         else:
             with open(full_name, 'w') as f:
-                if sys.version_info[0] == 2 and not isinstance(load, str):
-                    load = load.encode('utf-8')
                 f.write(load)
         if executable:
             os.chmod(full_name, os.stat(full_name).st_mode | stat.S_IEXEC)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 .[all]
+git+git://github.com/moloney/dcmstack@master


### PR DESCRIPTION
0.12 series introduced a good number of API changes. To avoid per-version special handling, I am just boosting minimal requirement to be datalad 0.12.2.

I also dropped bothering with annex.thin setting since IMHO it did nothing really in a typical use case.