### PR TITLE
ReproIn: make specification of protocols2fix more flexible + do not bind fixup structs in func signatures

### DIFF
--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -412,10 +412,12 @@ def fix_dbic_protocol(seqinfo):
             fixed_kwargs = dict()
             # need to replace both protocol_name series_description
             for key in series_spec_fields:
-                value = getattr(s, key)
+                oldvalue = value = getattr(s, key)
                 # replace all I need to replace
                 for substring, replacement in substitutions:
                     value = re.sub(substring, replacement, value)
+                if oldvalue != value:
+                    lgr.info(" %s: %r -> %r", key, oldvalue, value)
                 fixed_kwargs[key] = value
             # namedtuples are immutable
             seqinfo[i] = s._replace(**fixed_kwargs)

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -372,14 +372,14 @@ def get_study_hash(seqinfo):
     return md5sum(get_study_description(seqinfo))
 
 
-def fix_canceled_runs(seqinfo, accession2run=fix_accession2run):
+def fix_canceled_runs(seqinfo):
     """Function that adds cancelme_ to known bad runs which were forgotten
     """
     accession_number = get_unique(seqinfo, 'accession_number')
-    if accession_number in accession2run:
+    if accession_number in fix_accession2run:
         lgr.info("Considering some runs possibly marked to be "
                  "canceled for accession %s", accession_number)
-        badruns = accession2run[accession_number]
+        badruns = fix_accession2run[accession_number]
         badruns_pattern = '|'.join(badruns)
         for i, s in enumerate(seqinfo):
             if re.match(badruns_pattern, s.series_id):
@@ -391,13 +391,9 @@ def fix_canceled_runs(seqinfo, accession2run=fix_accession2run):
     return seqinfo
 
 
-def fix_dbic_protocol(seqinfo, keys=None, subsdict=None):
+def fix_dbic_protocol(seqinfo):
     """Ad-hoc fixup for existing protocols
     """
-    if subsdict is None:
-        subsdict = protocols2fix
-    if keys is None:
-        keys = series_spec_fields
 
     study_hash = get_study_hash(seqinfo)
 
@@ -408,14 +404,14 @@ def fix_dbic_protocol(seqinfo, keys=None, subsdict=None):
         ('global', ''),
     )
     for subs_scope, subs_key in candidate_substitutions:
-        if subs_key not in subsdict:
+        if subs_key not in protocols2fix:
             continue
-        substitutions = subsdict[subs_key]
+        substitutions = protocols2fix[subs_key]
         lgr.info("Considering %s substitutions", subs_scope)
         for i, s in enumerate(seqinfo):
             fixed_kwargs = dict()
             # need to replace both protocol_name series_description
-            for key in keys:
+            for key in series_spec_fields:
                 value = getattr(s, key)
                 # replace all I need to replace
                 for substring, replacement in substitutions:

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -126,6 +126,10 @@ from glob import glob
 import logging
 lgr = logging.getLogger('heudiconv')
 
+# pythons before 3.7 didn't have re.Pattern, it was some protected
+# _sre.SRE_Pattern, so let's just sample a class of the compiled regex
+re_Pattern = re.compile('.').__class__
+
 # Terminology to harmonise and use to name variables etc
 # experiment
 #  subject
@@ -416,7 +420,7 @@ def fix_dbic_protocol(seqinfo):
     # Then go through all regexps returning regex "search" result
     # on study_description
     for sub, substitutions in protocols2fix.items():
-        if isinstance(sub, re.Pattern) and sub.search(study_description):
+        if isinstance(sub, re_Pattern) and sub.search(study_description):
             _apply_substitutions(seqinfo,
                                  substitutions,
                                  '%r regex matching' % sub.pattern)

--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -2,6 +2,9 @@
 # Tests for reproin.py
 #
 from collections import OrderedDict
+from mock import patch
+
+from . import reproin
 from .reproin import (
     filter_files,
     fix_canceled_runs,
@@ -78,7 +81,8 @@ def test_fix_canceled_runs():
         'accession1': ['^01-', '^03-']
     }
 
-    seqinfo_ = fix_canceled_runs(seqinfo, fake_accession2run)
+    with patch.object(reproin, 'fix_accession2run', fake_accession2run):
+        seqinfo_ = fix_canceled_runs(seqinfo)
 
     for i, s in enumerate(seqinfo_, 1):
         output = runname
@@ -108,14 +112,15 @@ def test_fix_dbic_protocol():
 
 
     seqinfos = [seq1, seq2]
-    keys = ['field1']
-    subsdict = {
+    protocols2fix = {
         md5sum('mystudy'):
             [('scout_run\+', 'scout'),
              ('run-life[0-9]', 'run+_task-life')],
     }
 
-    seqinfos_ = fix_dbic_protocol(seqinfos, keys=keys, subsdict=subsdict)
+    with patch.object(reproin, 'protocols2fix', protocols2fix), \
+            patch.object(reproin, 'series_spec_fields', ['field1']):
+        seqinfos_ = fix_dbic_protocol(seqinfos)
     assert(seqinfos[1] == seqinfos_[1])
     # field2 shouldn't have changed since I didn't pass it
     assert(seqinfos_[0] == FakeSeqInfo(accession_number,
@@ -124,8 +129,9 @@ def test_fix_dbic_protocol():
                                        seq1.field2))
 
     # change also field2 please
-    keys = ['field1', 'field2']
-    seqinfos_ = fix_dbic_protocol(seqinfos, keys=keys, subsdict=subsdict)
+    with patch.object(reproin, 'protocols2fix', protocols2fix), \
+            patch.object(reproin, 'series_spec_fields', ['field1', 'field2']):
+        seqinfos_ = fix_dbic_protocol(seqinfos)
     assert(seqinfos[1] == seqinfos_[1])
     # now everything should have changed
     assert(seqinfos_[0] == FakeSeqInfo(accession_number,

--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -114,8 +114,10 @@ def test_fix_dbic_protocol():
     seqinfos = [seq1, seq2]
     protocols2fix = {
         md5sum('mystudy'):
-            [('scout_run\+', 'scout'),
+            [('scout_run\+', 'THESCOUT'),
              ('run-life[0-9]', 'run+_task-life')],
+        # rely on 'catch-all' to fix up above scout
+        '': [('THESCOUT', 'scout')]
     }
 
     with patch.object(reproin, 'protocols2fix', protocols2fix), \

--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -3,6 +3,7 @@
 #
 from collections import OrderedDict
 from mock import patch
+import re
 
 from . import reproin
 from .reproin import (
@@ -110,12 +111,13 @@ def test_fix_dbic_protocol():
                        'nochangeplease',
                        'nochangeeither')
 
-
     seqinfos = [seq1, seq2]
     protocols2fix = {
         md5sum('mystudy'):
-            [('scout_run\+', 'THESCOUT'),
+            [('scout_run\+', 'THESCOUT-runX'),
              ('run-life[0-9]', 'run+_task-life')],
+        re.compile('^my.*'):
+            [('THESCOUT-runX', 'THESCOUT')],
         # rely on 'catch-all' to fix up above scout
         '': [('THESCOUT', 'scout')]
     }


### PR DESCRIPTION
First commit in the series describes problem at large

    For some data we cannot rely on reliable presence of consistent study_description
    across scans.  That results in the necessity to duplicate the same protocols2fix
    records for multiple (not known in advance) study descriptions (actually -- their
    hashes, which makes it even more difficult).  But in the cases with custom
    overloads of protocols2fix, it is desired to just provide global rewrite rules,
    which could be applied to any collection since they did follow some convention.
    
    Now, with an empty "hash", those rules would be applied last, i.e. after possible
    study-specific fixups applied.
    
    As part of the solution I removed preliminary check to skip a call to
    fix_dbic_protocol altogether.  It should be better this way.
    
    I also removed binding of series_spec_fields and protocols2fix within function
    signature.  It should allow easier overloading at the module level when needed

and subsequent commits improved it even further, but altogether removing function signature level bindings, adding matching `study_description` using regular expression (so it could then be crafted per lab etc).

Example log output on the adjusted tests:
```shell
INFO: Considering study (0e4497bdaae2608324a85be1f54f60ed) specific substitutions
INFO:  field1: '02-anat-scout_run+_MPR_sag' -> '02-anat-THESCOUT-runX_MPR_sag'
INFO: Considering '^my.*' regex matching substitutions
INFO:  field1: '02-anat-THESCOUT-runX_MPR_sag' -> '02-anat-THESCOUT_MPR_sag'
INFO: Considering global substitutions
INFO:  field1: '02-anat-THESCOUT_MPR_sag' -> '02-anat-scout_MPR_sag'
INFO: Considering study (0e4497bdaae2608324a85be1f54f60ed) specific substitutions
INFO:  field2: '11-func_run-life2_acq-2mm692' -> '11-func_run+_task-life_acq-2mm692'
INFO: Considering '^my.*' regex matching substitutions
INFO: Considering global substitutions
```