### PR TITLE
RF: embed_nifti -> embed_dicom_and_nifti_metadata  and not invoke it if min_meta

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -333,10 +333,9 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                         "multiple files")
         elif not bids_outfiles:
             lgr.debug("No BIDS files were produced, nothing to embed to then")
-        elif outname:
+        elif outname and not min_meta:
             embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
-                                       prov_file, scaninfo, tempdirs, with_prov,
-                                       min_meta)
+                                       prov_file, scaninfo, tempdirs, with_prov)
         if scaninfo and op.exists(scaninfo):
             lgr.info("Post-treating %s file", scaninfo)
             treat_infofile(scaninfo)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -325,7 +325,7 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                     )
 
         # add the taskname field to the json file(s):
-        add_taskname_to_infofile( bids_outfiles )
+        add_taskname_to_infofile(bids_outfiles)
 
         if len(bids_outfiles) > 1:
             lgr.warning("For now not embedding BIDS and info generated "

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -6,7 +6,13 @@ from collections import OrderedDict
 import tarfile
 
 from .external.pydicom import dcm
-from .utils import load_json, get_typed_attr, set_readonly, SeqInfo
+from .utils import (
+    get_typed_attr,
+    load_json,
+    save_json,
+    SeqInfo,
+    set_readonly,
+)
 
 import warnings
 with warnings.catch_warnings():
@@ -410,6 +416,7 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
     import os.path as op
     import json
     import re
+    from heudiconv.utils import save_json
 
     from heudiconv.external.dcmstack import ds
     stack = ds.parse_and_stack(dcmfiles, force=True).values()
@@ -440,8 +447,7 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
         meta_info.update(bids_info)
 
     # write to outfile
-    with open(infofile, 'wt') as fp:
-        json.dump(meta_info, fp, indent=3, sort_keys=True)
+    save_json(infofile, meta_info)
 
 
 def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -442,8 +442,6 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
     meta_info = json.loads(meta_info)
 
     if bids_info:
-        # make nice with python 3 - same behavior?
-        meta_info = meta_info.copy()
         meta_info.update(bids_info)
 
     # write to outfile

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -5,7 +5,8 @@ import pytest
 
 from heudiconv.external.pydicom import dcm
 from heudiconv.cli.run import main as runner
-from heudiconv.dicoms import parse_private_csa_header, embed_nifti
+from heudiconv.convert import nipype_convert
+from heudiconv.dicoms import parse_private_csa_header, embed_dicom_and_nifti_metadata
 from .utils import TESTS_DATA_PATH
 
 # Public: Private DICOM tags
@@ -26,35 +27,33 @@ def test_private_csa_header(tmpdir):
         runner(['--files', dcm_file, '-c' 'none', '-f', 'reproin'])
 
 
-def test_nifti_embed(tmpdir):
+def test_embed_dicom_and_nifti_metadata(tmpdir):
     """Test dcmstack's additional fields"""
     tmpdir.chdir()
     # set up testing files
     dcmfiles = [op.join(TESTS_DATA_PATH, 'axasc35.dcm')]
     infofile = 'infofile.json'
 
-    # 1) nifti does not exist
-    out = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', None, False)
-    # string -> json
-    out = json.loads(out)
-    # should have created nifti file
-    assert op.exists('nifti.nii')
+    # 1) nifti does not exist -- no longer supported
+    # we should produce nifti using our "standard" ways
+    out_prefix = str(tmpdir / "nifti")
+    nipype_out, prov_file = nipype_convert(
+        dcmfiles, prefix=out_prefix, with_prov=False,
+        bids_options=None, tmpdir=str(tmpdir))
+    niftifile = nipype_out.outputs.converted_files
 
+    assert op.exists(niftifile)
     # 2) nifti exists
-    nifti, info = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', None, False)
-    assert op.exists(nifti)
-    assert op.exists(info)
-    with open(info) as fp:
+    embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, None)
+    assert op.exists(infofile)
+    with open(infofile) as fp:
         out2 = json.load(fp)
-
-    assert out == out2
 
     # 3) with existing metadata
     bids = {"existing": "data"}
-    nifti, info = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', bids, False)
-    with open(info) as fp:
+    embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids)
+    with open(infofile) as fp:
         out3 = json.load(fp)
 
-    assert out3["existing"]
-    del out3["existing"]
-    assert out3 == out2 == out
+    assert out3.pop("existing") == "data"
+    assert out3 == out2

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -38,9 +38,12 @@ def test_embed_dicom_and_nifti_metadata(tmpdir):
     dcmfiles = [op.join(TESTS_DATA_PATH, 'axasc35.dcm')]
     infofile = 'infofile.json'
 
-    # 1) nifti does not exist -- no longer supported
-    # we should produce nifti using our "standard" ways
     out_prefix = str(tmpdir / "nifti")
+    # 1) nifti does not exist -- no longer supported
+    with pytest.raises(NotImplementedError):
+        embed_dicom_and_nifti_metadata(dcmfiles, out_prefix + '.nii.gz', infofile, None)
+
+    # we should produce nifti using our "standard" ways
     nipype_out, prov_file = nipype_convert(
         dcmfiles, prefix=out_prefix, with_prov=False,
         bids_options=None, tmpdir=str(tmpdir))

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -7,7 +7,10 @@ from heudiconv.external.pydicom import dcm
 from heudiconv.cli.run import main as runner
 from heudiconv.convert import nipype_convert
 from heudiconv.dicoms import parse_private_csa_header, embed_dicom_and_nifti_metadata
-from .utils import TESTS_DATA_PATH
+from .utils import (
+    assert_cwd_unchanged,
+    TESTS_DATA_PATH,
+)
 
 # Public: Private DICOM tags
 DICOM_FIELDS_TO_TEST = {
@@ -27,6 +30,7 @@ def test_private_csa_header(tmpdir):
         runner(['--files', dcm_file, '-c' 'none', '-f', 'reproin'])
 
 
+@assert_cwd_unchanged(ok_to_chdir=True)  # so we cd back after tmpdir.chdir
 def test_embed_dicom_and_nifti_metadata(tmpdir):
     """Test dcmstack's additional fields"""
     tmpdir.chdir()

--- a/heudiconv/tests/utils.py
+++ b/heudiconv/tests/utils.py
@@ -1,8 +1,16 @@
+from functools import wraps
+import os
 import os.path as op
+import sys
+
 import heudiconv.heuristics
+
 
 HEURISTICS_PATH = op.join(heudiconv.heuristics.__path__[0])
 TESTS_DATA_PATH = op.join(op.dirname(__file__), 'data')
+
+import logging
+lgr = logging.getLogger(__name__)
 
 
 def gen_heudiconv_args(datadir, outdir, subject, heuristic_file,
@@ -58,3 +66,51 @@ def fetch_data(tmpdir, dataset, getpath=None):
     getdir = targetdir + (op.sep + getpath if getpath is not None else '')
     ds.get(getdir)
     return targetdir
+
+
+def assert_cwd_unchanged(ok_to_chdir=False):
+    """Decorator to test whether the current working directory remains unchanged
+
+    Provenance: based on the one in datalad, but simplified.
+
+    Parameters
+    ----------
+    ok_to_chdir: bool, optional
+      If True, allow to chdir, so this decorator would not then raise exception
+      if chdir'ed but only return to original directory
+    """
+
+    def decorator(func=None):  # =None to avoid pytest treating it as a fixture
+        @wraps(func)
+        def newfunc(*args, **kwargs):
+            cwd_before = os.getcwd()
+            exc = None
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc_:
+                exc = exc_
+            finally:
+                try:
+                    cwd_after = os.getcwd()
+                except OSError as e:
+                    lgr.warning("Failed to getcwd: %s" % e)
+                    cwd_after = None
+
+                if cwd_after != cwd_before:
+                    os.chdir(cwd_before)
+                    if not ok_to_chdir:
+                        lgr.warning(
+                            "%s changed cwd to %s. Mitigating and changing back to %s"
+                            % (func, cwd_after, cwd_before))
+                        # If there was already exception raised, we better reraise
+                        # that one since it must be more important, so not masking it
+                        # here with our assertion
+                        if exc is None:
+                            assert cwd_before == cwd_after, \
+                                     "CWD changed from %s to %s" % (cwd_before, cwd_after)
+
+                if exc is not None:
+                    raise exc
+        return newfunc
+
+    return decorator


### PR DESCRIPTION
Follow up to #420 

- `embed_dicom_and_nifti_metadata` will not produce nifti file if that one doesn't exist yet . This functionality (hopefully) was not used for a while, and we should rely on dcm2niix for all such conversions
- it also changes how json's dumped by that function -- it will use the same `save_json` instead of ad-hoc `json.dump` call with `indent=3`.  So with this PR we would end up changing .json files formatting a bit, which could complicate regression testing, but I think consistency is worth it
- `@assert_cwd_unchanged` now can be used to assure that tests do not jump to some other directories, or force their return (note that if directory has symlinks in the path -- we would return to dereferenced path)