### PR TITLE
search heuristic file path first

### DIFF
--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -319,7 +319,7 @@ def load_heuristic(heuristic):
         path, fname = op.split(heuristic_file)
         try:
             old_syspath = sys.path[:]
-            sys.path.append(path)
+            sys.path.append(0, path)
             mod = __import__(fname.split('.')[0])
             mod.filename = heuristic_file
         finally:

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -319,7 +319,7 @@ def load_heuristic(heuristic):
         path, fname = op.split(heuristic_file)
         try:
             old_syspath = sys.path[:]
-            sys.path.append(0, path)
+            sys.path.insert(0, path)
             mod = __import__(fname.split('.')[0])
             mod.filename = heuristic_file
         finally:


### PR DESCRIPTION
I modified the code per your recommendation and then rebased the repository so you don't get a noisy commit.

This allows heuristic modules names that conflict with existing module
names, such as using a heuristic module named "heudiconv.py"