### PR TITLE
TEMP: rebased #424

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -333,10 +333,9 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                         "multiple files")
         elif not bids_outfiles:
             lgr.debug("No BIDS files were produced, nothing to embed to then")
-        elif outname:
+        elif outname and not min_meta:
             embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
-                                       prov_file, scaninfo, tempdirs, with_prov,
-                                       min_meta)
+                                       prov_file, scaninfo, tempdirs, with_prov)
         if scaninfo and op.exists(scaninfo):
             lgr.info("Post-treating %s file", scaninfo)
             treat_infofile(scaninfo)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -239,7 +239,7 @@ def update_complex_name(fileinfo, this_prefix_basename, suffix):
     with magnitude/phase reconstruction.
     """
     unsupported_types = ['_bold', '_phase']
-    if suffix in unsupported_types:
+    if any(ut in this_prefix_basename for ut in unsupported_types):
         return this_prefix_basename
 
     # Check to see if it is magnitude or phase reconstruction:
@@ -252,7 +252,6 @@ def update_complex_name(fileinfo, this_prefix_basename, suffix):
 
     # Insert reconstruction label
     if not ('_part-%s' % mag_or_phase) in this_prefix_basename:
-
         # If "_part-" is specified, prepend the 'mag_or_phase' value.
         if '_part-' in this_prefix_basename:
             raise BIDSError(
@@ -261,7 +260,7 @@ def update_complex_name(fileinfo, this_prefix_basename, suffix):
             )
 
         # If not, insert "_part-" + 'mag_or_phase' into the prefix_basename
-        #   **before** "_run", "_echo" or "_sbref", whichever appears first:
+        # **before** "_run", "_echo" or "_sbref", whichever appears first:
         for label in ['_run', '_echo', '_sbref']:
             if (label in this_prefix_basename):
                 this_prefix_basename = this_prefix_basename.replace(
@@ -277,7 +276,7 @@ def update_multiecho_name(fileinfo, this_prefix_basename, echo_times, suffix):
     sequence.
     """
     unsupported_types = ['_magnitude1', '_magnitude2', '_phasediff', '_phase1', '_phase2']
-    if suffix in unsupported_types:
+    if any(ut in this_prefix_basename for ut in unsupported_types):
         return this_prefix_basename
 
     # Get the EchoNumber from json file info.  If not present, use EchoTime
@@ -285,38 +284,45 @@ def update_multiecho_name(fileinfo, this_prefix_basename, echo_times, suffix):
         echo_number = fileinfo['EchoNumber']
     else:
         echo_number = echo_times.index(fileinfo['EchoTime']) + 1
+    filetype = '_' + this_prefix_basename.split('_')[-1]
 
-    # Now, decide where to insert it.
     # Insert it **before** the following string(s), whichever appears first.
-    for imgtype in supported_multiecho:
-        if (imgtype in this_prefix_basename):
+    for label in ['_run', filetype]:
+        if label == filetype:
             this_prefix_basename = this_prefix_basename.replace(
-                imgtype, "_echo-%d%s" % (echo_number, imgtype)
+                filetype, "_echo-%s%s" % (echo_number, filetype)
             )
             break
+        elif (label in this_prefix_basename):
+            this_prefix_basename = this_prefix_basename.replace(
+                label, "_echo-%s%s" % (echo_number, label)
+            )
+            break
+
     return this_prefix_basename
 
 
-def update_uncombined_name(fileinfo, this_prefix_basename, coil_names, suffix):
+def update_uncombined_name(fileinfo, this_prefix_basename, channel_names, suffix):
     """
     Insert `_channel-<num>` entity into filename if data are from a sequence
     with "save uncombined".
     """
     # Determine the channel number
-    channel_number = coil_names.index(fileinfo['CoilString']) + 1
+    channel_number = ''.join([c for c in fileinfo['CoilString'] if c.isdigit()])
+    if not channel_number:
+        channel_number = channel_names.index(fileinfo['CoilString']) + 1
+    filetype = '_' + this_prefix_basename.split('_')[-1]
 
     # Insert it **before** the following string(s), whichever appears first.
-    for label in ['_run', '_echo', suffix]:
-        if label == suffix:
-            prefix_suffix = this_prefix_basename.split('_')[-1]
+    for label in ['_run', '_echo', filetype]:
+        if label == filetype:
             this_prefix_basename = this_prefix_basename.replace(
-                prefix_suffix, "_channel-%s_%s" % (channel_number, prefix_suffix)
+                filetype, "_channel-%s%s" % (channel_number, filetype)
             )
             break
-
-        if (label in this_prefix_basename):
+        elif (label in this_prefix_basename):
             this_prefix_basename = this_prefix_basename.replace(
-                label, "_channel-%s%s" % (coil_number, label)
+                label, "_channel-%s%s" % (channel_number, label)
             )
             break
     return this_prefix_basename
@@ -636,14 +642,13 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
         channel_names = [v for v in channel_names if v]
         channel_names = sorted(list(set(channel_names)))
         image_types = [v for v in image_types if v]
-        image_types = sorted(list(set(image_types)))
 
         is_multiecho = len(echo_times) > 1  # Check for varying echo times
-        is_uncombined = len(coil_names) > 1  # Check for uncombined data
+        is_uncombined = len(channel_names) > 1  # Check for uncombined data
 
         # Determine if data are complex (magnitude + phase)
-        magnitude_found = ['M' in it for it in image_types]
-        phase_found = ['P' in it for it in image_types]
+        magnitude_found = any(['M' in it for it in image_types])
+        phase_found = any(['P' in it for it in image_types])
         is_complex = magnitude_found and phase_found
 
         ### Loop through the bids_files, set the output name and save files
@@ -655,12 +660,6 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
             # and we don't want to modify it for all the bids_files):
             this_prefix_basename = prefix_basename
 
-            # Update name if complex data
-            if bids_file and is_complex:
-                this_prefix_basename = update_complex_name(
-                    bids_meta, this_prefix_basename, suffix
-                )
-
             # Update name if multi-echo
             # (Note: it can be _sbref and multiecho, so don't use "elif"):
             # For multi-echo sequences, we have to specify the echo number in
@@ -670,10 +669,16 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
                     bids_meta, this_prefix_basename, echo_times, suffix
                 )
 
+            # Update name if complex data
+            if bids_file and is_complex:
+                this_prefix_basename = update_complex_name(
+                    bids_meta, this_prefix_basename, suffix
+                )
+
             # Update name if uncombined (channel-level) data
             if bids_file and is_uncombined:
                 this_prefix_basename = update_uncombined_name(
-                    bids_meta, this_prefix_basename, channel_names
+                    bids_meta, this_prefix_basename, channel_names, suffix
                 )
 
             # Fallback option:

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -325,7 +325,7 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                     )
 
         # add the taskname field to the json file(s):
-        add_taskname_to_infofile( bids_outfiles )
+        add_taskname_to_infofile(bids_outfiles)
 
         if len(bids_outfiles) > 1:
             lgr.warning("For now not embedding BIDS and info generated "

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -233,6 +233,95 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
                                     getattr(heuristic, 'DEFAULT_FIELDS', {}))
 
 
+def update_complex_name(fileinfo, this_prefix_basename, suffix):
+    """
+    Insert `_part-<mag|phase>` entity into filename if data are from a sequence
+    with magnitude/phase reconstruction.
+    """
+    unsupported_types = ['_bold', '_phase']
+    if suffix in unsupported_types:
+        return this_prefix_basename
+
+    # Check to see if it is magnitude or phase reconstruction:
+    if 'M' in fileinfo.get('ImageType'):
+        mag_or_phase = 'mag'
+    elif 'P' in fileinfo.get('ImageType'):
+        mag_or_phase = 'phase'
+    else:
+        mag_or_phase = suffix
+
+    # Insert reconstruction label
+    if not ('_part-%s' % mag_or_phase) in this_prefix_basename:
+
+        # If "_part-" is specified, prepend the 'mag_or_phase' value.
+        if '_part-' in this_prefix_basename:
+            raise BIDSError(
+                "Part label for images will be automatically set, remove "
+                "from heuristic"
+            )
+
+        # If not, insert "_part-" + 'mag_or_phase' into the prefix_basename
+        #   **before** "_run", "_echo" or "_sbref", whichever appears first:
+        for label in ['_run', '_echo', '_sbref']:
+            if (label in this_prefix_basename):
+                this_prefix_basename = this_prefix_basename.replace(
+                    label, "_part-%s%s" % (mag_or_phase, label)
+                )
+                break
+    return this_prefix_basename
+
+
+def update_multiecho_name(fileinfo, this_prefix_basename, echo_times, suffix):
+    """
+    Insert `_echo-<num>` entity into filename if data are from a multi-echo
+    sequence.
+    """
+    unsupported_types = ['_magnitude1', '_magnitude2', '_phasediff', '_phase1', '_phase2']
+    if suffix in unsupported_types:
+        return this_prefix_basename
+
+    # Get the EchoNumber from json file info.  If not present, use EchoTime
+    if 'EchoNumber' in fileinfo.keys():
+        echo_number = fileinfo['EchoNumber']
+    else:
+        echo_number = echo_times.index(fileinfo['EchoTime']) + 1
+
+    # Now, decide where to insert it.
+    # Insert it **before** the following string(s), whichever appears first.
+    for imgtype in supported_multiecho:
+        if (imgtype in this_prefix_basename):
+            this_prefix_basename = this_prefix_basename.replace(
+                imgtype, "_echo-%d%s" % (echo_number, imgtype)
+            )
+            break
+    return this_prefix_basename
+
+
+def update_uncombined_name(fileinfo, this_prefix_basename, coil_names, suffix):
+    """
+    Insert `_channel-<num>` entity into filename if data are from a sequence
+    with "save uncombined".
+    """
+    # Determine the channel number
+    channel_number = coil_names.index(fileinfo['CoilString']) + 1
+
+    # Insert it **before** the following string(s), whichever appears first.
+    for label in ['_run', '_echo', suffix]:
+        if label == suffix:
+            prefix_suffix = this_prefix_basename.split('_')[-1]
+            this_prefix_basename = this_prefix_basename.replace(
+                prefix_suffix, "_channel-%s_%s" % (channel_number, prefix_suffix)
+            )
+            break
+
+        if (label in this_prefix_basename):
+            this_prefix_basename = this_prefix_basename.replace(
+                label, "_channel-%s%s" % (coil_number, label)
+            )
+            break
+    return this_prefix_basename
+
+
 def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
             bids_options, outdir, min_meta, overwrite, symlink=True, prov_file=None,
             dcmconfig=None):
@@ -534,14 +623,28 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
         #   series. To do that, the most straightforward way is to read the
         #   echo times for all bids_files and see if they are all the same or not.
 
-        # Check for varying echo times
-        echo_times = sorted(list(set(
-            b.get('EchoTime', nan)
-            for b in bids_metas
-            if b
-        )))
+        # Collect some metadata across all images
+        echo_times, channel_names, image_types = [], [], []
+        for metadata in bids_metas:
+            if not metadata:
+                continue
+            echo_times.append(metadata.get('EchoTime', None))
+            channel_names.append(metadata.get('CoilString', None))
+            image_types.append(metadata.get('ImageType', None))
+        echo_times = [v for v in echo_times if v]
+        echo_times = sorted(list(set(echo_times)))
+        channel_names = [v for v in channel_names if v]
+        channel_names = sorted(list(set(channel_names)))
+        image_types = [v for v in image_types if v]
+        image_types = sorted(list(set(image_types)))
 
-        is_multiecho = len(echo_times) > 1
+        is_multiecho = len(echo_times) > 1  # Check for varying echo times
+        is_uncombined = len(coil_names) > 1  # Check for uncombined data
+
+        # Determine if data are complex (magnitude + phase)
+        magnitude_found = ['M' in it for it in image_types]
+        phase_found = ['P' in it for it in image_types]
+        is_complex = magnitude_found and phase_found
 
         ### Loop through the bids_files, set the output name and save files
         for fl, suffix, bids_file, bids_meta in zip(res_files, suffixes, bids_files, bids_metas):
@@ -552,65 +655,26 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
             # and we don't want to modify it for all the bids_files):
             this_prefix_basename = prefix_basename
 
-            # _sbref sequences reconstructing magnitude and phase generate
-            # two NIfTI files IN THE SAME SERIES, so we cannot just add
-            # the suffix, if we want to be bids compliant:
-            if bids_meta and this_prefix_basename.endswith('_sbref') \
-                    and len(suffixes) > len(echo_times):
-                if len(suffixes) != len(echo_times)*2:
-                    lgr.warning(
-                        "Got %d suffixes for %d echo times, which isn't "
-                        "multiple of two as if it was magnitude + phase pairs",
-                        len(suffixes), len(echo_times)
-                    )
-                # Check to see if it is magnitude or phase reconstruction:
-                if 'M' in bids_meta.get('ImageType'):
-                    mag_or_phase = 'magnitude'
-                elif 'P' in bids_meta.get('ImageType'):
-                    mag_or_phase = 'phase'
-                else:
-                    mag_or_phase = suffix
+            # Update name if complex data
+            if bids_file and is_complex:
+                this_prefix_basename = update_complex_name(
+                    bids_meta, this_prefix_basename, suffix
+                )
 
-                # Insert reconstruction label
-                if not ("_rec-%s" % mag_or_phase) in this_prefix_basename:
-
-                    # If "_rec-" is specified, prepend the 'mag_or_phase' value.
-                    if ('_rec-' in this_prefix_basename):
-                        raise BIDSError(
-                        "Reconstruction label for multi-echo single-band"
-                        " reference images will be automatically set, remove"
-                        " from heuristic"
-                        )
-
-                    # If not, insert "_rec-" + 'mag_or_phase' into the prefix_basename
-                    #   **before** "_run", "_echo" or "_sbref", whichever appears first:
-                    for label in ['_run', '_echo', '_sbref']:
-                        if (label in this_prefix_basename):
-                            this_prefix_basename = this_prefix_basename.replace(
-                                label, "_rec-%s%s" % (mag_or_phase, label)
-                            )
-                            break
-
-            # Now check if this run is multi-echo
+            # Update name if multi-echo
             # (Note: it can be _sbref and multiecho, so don't use "elif"):
             # For multi-echo sequences, we have to specify the echo number in
             # the file name:
-            if bids_meta and is_multiecho:
-                # Get the EchoNumber from json file info.  If not present, use EchoTime
-                if 'EchoNumber' in bids_meta:
-                    echo_number = bids_meta['EchoNumber']
-                else:
-                    echo_number = echo_times.index(bids_meta['EchoTime']) + 1
+            if bids_file and is_multiecho:
+                this_prefix_basename = update_multiecho_name(
+                    bids_meta, this_prefix_basename, echo_times, suffix
+                )
 
-                supported_multiecho = ['_bold', '_phase', '_epi', '_sbref', '_T1w', '_PDT2']
-                # Now, decide where to insert it.
-                # Insert it **before** the following string(s), whichever appears first.
-                for imgtype in supported_multiecho:
-                    if (imgtype in this_prefix_basename):
-                        this_prefix_basename = this_prefix_basename.replace(
-                            imgtype, "_echo-%d%s" % (echo_number, imgtype)
-                        )
-                        break
+            # Update name if uncombined (channel-level) data
+            if bids_file and is_uncombined:
+                this_prefix_basename = update_uncombined_name(
+                    bids_meta, this_prefix_basename, channel_names
+                )
 
             # Fallback option:
             # If we have failed to modify this_prefix_basename, because it didn't fall

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -251,6 +251,9 @@ def update_complex_name(fileinfo, this_prefix_basename, suffix):
     else:
         mag_or_phase = suffix
 
+    # Determine scan suffix
+    filetype = '_' + this_prefix_basename.split('_')[-1]
+
     # Insert reconstruction label
     if not ('_rec-%s' % mag_or_phase) in this_prefix_basename:
         # If "_rec-" is specified, prepend the 'mag_or_phase' value.
@@ -262,12 +265,18 @@ def update_complex_name(fileinfo, this_prefix_basename, suffix):
 
         # If not, insert "_rec-" + 'mag_or_phase' into the prefix_basename
         # **before** "_run", "_echo" or "_sbref", whichever appears first:
-        for label in ['_run', '_echo', '_sbref']:
-            if (label in this_prefix_basename):
+        for label in ['_dir', '_run', '_mod', '_echo', '_recording', '_proc', '_space', filetype]:
+            if label == filetype:
+                this_prefix_basename = this_prefix_basename.replace(
+                    filetype, "_rec-%s%s" % (mag_or_phase, filetype)
+                )
+                break
+            elif (label in this_prefix_basename):
                 this_prefix_basename = this_prefix_basename.replace(
                     label, "_rec-%s%s" % (mag_or_phase, label)
                 )
                 break
+
     return this_prefix_basename
 
 
@@ -289,10 +298,12 @@ def update_multiecho_name(fileinfo, this_prefix_basename, echo_times):
         echo_number = fileinfo['EchoNumber']
     else:
         echo_number = echo_times.index(fileinfo['EchoTime']) + 1
+
+    # Determine scan suffix
     filetype = '_' + this_prefix_basename.split('_')[-1]
 
     # Insert it **before** the following string(s), whichever appears first.
-    for label in ['_run', filetype]:
+    for label in ['_recording', '_proc', '_space', filetype]:
         if label == filetype:
             this_prefix_basename = this_prefix_basename.replace(
                 filetype, "_echo-%s%s" % (echo_number, filetype)
@@ -321,10 +332,13 @@ def update_uncombined_name(fileinfo, this_prefix_basename, channel_names):
     channel_number = ''.join([c for c in fileinfo['CoilString'] if c.isdigit()])
     if not channel_number:
         channel_number = channel_names.index(fileinfo['CoilString']) + 1
+
+    # Determine scan suffix
     filetype = '_' + this_prefix_basename.split('_')[-1]
 
     # Insert it **before** the following string(s), whichever appears first.
-    for label in ['_run', '_echo', filetype]:
+    # Choosing to put channel near the end since it's not in the specification yet.
+    for label in ['_recording', '_proc', '_space', filetype]:
         if label == filetype:
             this_prefix_basename = this_prefix_basename.replace(
                 filetype, "_channel-%s%s" % (channel_number, filetype)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -235,47 +235,52 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
 
 def update_complex_name(fileinfo, this_prefix_basename, suffix):
     """
-    Insert `_part-<mag|phase>` entity into filename if data are from a sequence
+    Insert `_rec-<magnitude|phase>` entity into filename if data are from a sequence
     with magnitude/phase reconstruction.
     """
+    # Functional scans separate magnitude/phase differently
     unsupported_types = ['_bold', '_phase']
     if any(ut in this_prefix_basename for ut in unsupported_types):
         return this_prefix_basename
 
     # Check to see if it is magnitude or phase reconstruction:
     if 'M' in fileinfo.get('ImageType'):
-        mag_or_phase = 'mag'
+        mag_or_phase = 'magnitude'
     elif 'P' in fileinfo.get('ImageType'):
         mag_or_phase = 'phase'
     else:
         mag_or_phase = suffix
 
     # Insert reconstruction label
-    if not ('_part-%s' % mag_or_phase) in this_prefix_basename:
-        # If "_part-" is specified, prepend the 'mag_or_phase' value.
-        if '_part-' in this_prefix_basename:
+    if not ('_rec-%s' % mag_or_phase) in this_prefix_basename:
+        # If "_rec-" is specified, prepend the 'mag_or_phase' value.
+        if '_rec-' in this_prefix_basename:
             raise BIDSError(
-                "Part label for images will be automatically set, remove "
+                "Rec label for images will be automatically set, remove "
                 "from heuristic"
             )
 
-        # If not, insert "_part-" + 'mag_or_phase' into the prefix_basename
+        # If not, insert "_rec-" + 'mag_or_phase' into the prefix_basename
         # **before** "_run", "_echo" or "_sbref", whichever appears first:
         for label in ['_run', '_echo', '_sbref']:
             if (label in this_prefix_basename):
                 this_prefix_basename = this_prefix_basename.replace(
-                    label, "_part-%s%s" % (mag_or_phase, label)
+                    label, "_rec-%s%s" % (mag_or_phase, label)
                 )
                 break
     return this_prefix_basename
 
 
-def update_multiecho_name(fileinfo, this_prefix_basename, echo_times, suffix):
+def update_multiecho_name(fileinfo, this_prefix_basename, echo_times):
     """
     Insert `_echo-<num>` entity into filename if data are from a multi-echo
     sequence.
     """
-    unsupported_types = ['_magnitude1', '_magnitude2', '_phasediff', '_phase1', '_phase2']
+    # Field maps separate echoes differently
+    unsupported_types = [
+        '_magnitude', '_magnitude1', '_magnitude2',
+        '_phasediff', '_phase1', '_phase2', '_fieldmap'
+    ]
     if any(ut in this_prefix_basename for ut in unsupported_types):
         return this_prefix_basename
 
@@ -302,11 +307,16 @@ def update_multiecho_name(fileinfo, this_prefix_basename, echo_times, suffix):
     return this_prefix_basename
 
 
-def update_uncombined_name(fileinfo, this_prefix_basename, channel_names, suffix):
+def update_uncombined_name(fileinfo, this_prefix_basename, channel_names):
     """
     Insert `_channel-<num>` entity into filename if data are from a sequence
     with "save uncombined".
     """
+    # In case any scan types separate channels differently
+    unsupported_types = []
+    if any(ut in this_prefix_basename for ut in unsupported_types):
+        return this_prefix_basename
+
     # Determine the channel number
     channel_number = ''.join([c for c in fileinfo['CoilString'] if c.isdigit()])
     if not channel_number:
@@ -661,12 +671,9 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
             this_prefix_basename = prefix_basename
 
             # Update name if multi-echo
-            # (Note: it can be _sbref and multiecho, so don't use "elif"):
-            # For multi-echo sequences, we have to specify the echo number in
-            # the file name:
             if bids_file and is_multiecho:
                 this_prefix_basename = update_multiecho_name(
-                    bids_meta, this_prefix_basename, echo_times, suffix
+                    bids_meta, this_prefix_basename, echo_times
                 )
 
             # Update name if complex data
@@ -678,7 +685,7 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
             # Update name if uncombined (channel-level) data
             if bids_file and is_uncombined:
                 this_prefix_basename = update_uncombined_name(
-                    bids_meta, this_prefix_basename, channel_names, suffix
+                    bids_meta, this_prefix_basename, channel_names
                 )
 
             # Fallback option:

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -6,7 +6,13 @@ from collections import OrderedDict
 import tarfile
 
 from .external.pydicom import dcm
-from .utils import load_json, get_typed_attr, set_readonly, SeqInfo
+from .utils import (
+    get_typed_attr,
+    load_json,
+    save_json,
+    SeqInfo,
+    set_readonly,
+)
 
 import warnings
 with warnings.catch_warnings():
@@ -410,6 +416,7 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
     import os.path as op
     import json
     import re
+    from heudiconv.utils import save_json
 
     from heudiconv.external.dcmstack import ds
     stack = ds.parse_and_stack(dcmfiles, force=True).values()
@@ -440,8 +447,7 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
         meta_info.update(bids_info)
 
     # write to outfile
-    with open(infofile, 'wt') as fp:
-        json.dump(meta_info, fp, indent=3, sort_keys=True)
+    save_json(infofile, meta_info)
 
 
 def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -5,7 +5,8 @@ import pytest
 
 from heudiconv.external.pydicom import dcm
 from heudiconv.cli.run import main as runner
-from heudiconv.dicoms import parse_private_csa_header, embed_nifti
+from heudiconv.convert import nipype_convert
+from heudiconv.dicoms import parse_private_csa_header, embed_dicom_and_nifti_metadata
 from .utils import TESTS_DATA_PATH
 
 # Public: Private DICOM tags
@@ -26,35 +27,33 @@ def test_private_csa_header(tmpdir):
         runner(['--files', dcm_file, '-c' 'none', '-f', 'reproin'])
 
 
-def test_nifti_embed(tmpdir):
+def test_embed_dicom_and_nifti_metadata(tmpdir):
     """Test dcmstack's additional fields"""
     tmpdir.chdir()
     # set up testing files
     dcmfiles = [op.join(TESTS_DATA_PATH, 'axasc35.dcm')]
     infofile = 'infofile.json'
 
-    # 1) nifti does not exist
-    out = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', None, False)
-    # string -> json
-    out = json.loads(out)
-    # should have created nifti file
-    assert op.exists('nifti.nii')
+    # 1) nifti does not exist -- no longer supported
+    # we should produce nifti using our "standard" ways
+    out_prefix = str(tmpdir / "nifti")
+    nipype_out, prov_file = nipype_convert(
+        dcmfiles, prefix=out_prefix, with_prov=False,
+        bids_options=None, tmpdir=str(tmpdir))
+    niftifile = nipype_out.outputs.converted_files
 
+    assert op.exists(niftifile)
     # 2) nifti exists
-    nifti, info = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', None, False)
-    assert op.exists(nifti)
-    assert op.exists(info)
-    with open(info) as fp:
+    embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, None)
+    assert op.exists(infofile)
+    with open(infofile) as fp:
         out2 = json.load(fp)
-
-    assert out == out2
 
     # 3) with existing metadata
     bids = {"existing": "data"}
-    nifti, info = embed_nifti(dcmfiles, 'nifti.nii', 'infofile.json', bids, False)
-    with open(info) as fp:
+    embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids)
+    with open(infofile) as fp:
         out3 = json.load(fp)
 
-    assert out3["existing"]
-    del out3["existing"]
-    assert out3 == out2 == out
+    assert out3.pop("existing") == "data"
+    assert out3 == out2

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -7,7 +7,10 @@ from heudiconv.external.pydicom import dcm
 from heudiconv.cli.run import main as runner
 from heudiconv.convert import nipype_convert
 from heudiconv.dicoms import parse_private_csa_header, embed_dicom_and_nifti_metadata
-from .utils import TESTS_DATA_PATH
+from .utils import (
+    assert_cwd_unchanged,
+    TESTS_DATA_PATH,
+)
 
 # Public: Private DICOM tags
 DICOM_FIELDS_TO_TEST = {
@@ -27,6 +30,7 @@ def test_private_csa_header(tmpdir):
         runner(['--files', dcm_file, '-c' 'none', '-f', 'reproin'])
 
 
+@assert_cwd_unchanged(ok_to_chdir=True)  # so we cd back after tmpdir.chdir
 def test_embed_dicom_and_nifti_metadata(tmpdir):
     """Test dcmstack's additional fields"""
     tmpdir.chdir()

--- a/heudiconv/tests/utils.py
+++ b/heudiconv/tests/utils.py
@@ -1,8 +1,16 @@
+from functools import wraps
+import os
 import os.path as op
+import sys
+
 import heudiconv.heuristics
+
 
 HEURISTICS_PATH = op.join(heudiconv.heuristics.__path__[0])
 TESTS_DATA_PATH = op.join(op.dirname(__file__), 'data')
+
+import logging
+lgr = logging.getLogger(__name__)
 
 
 def gen_heudiconv_args(datadir, outdir, subject, heuristic_file,
@@ -58,3 +66,51 @@ def fetch_data(tmpdir, dataset, getpath=None):
     getdir = targetdir + (op.sep + getpath if getpath is not None else '')
     ds.get(getdir)
     return targetdir
+
+
+def assert_cwd_unchanged(ok_to_chdir=False):
+    """Decorator to test whether the current working directory remains unchanged
+
+    Provenance: based on the one in datalad, but simplified.
+
+    Parameters
+    ----------
+    ok_to_chdir: bool, optional
+      If True, allow to chdir, so this decorator would not then raise exception
+      if chdir'ed but only return to original directory
+    """
+
+    def decorator(func=None):  # =None to avoid pytest treating it as a fixture
+        @wraps(func)
+        def newfunc(*args, **kwargs):
+            cwd_before = os.getcwd()
+            exc = None
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc_:
+                exc = exc_
+            finally:
+                try:
+                    cwd_after = os.getcwd()
+                except OSError as e:
+                    lgr.warning("Failed to getcwd: %s" % e)
+                    cwd_after = None
+
+                if cwd_after != cwd_before:
+                    os.chdir(cwd_before)
+                    if not ok_to_chdir:
+                        lgr.warning(
+                            "%s changed cwd to %s. Mitigating and changing back to %s"
+                            % (func, cwd_after, cwd_before))
+                        # If there was already exception raised, we better reraise
+                        # that one since it must be more important, so not masking it
+                        # here with our assertion
+                        if exc is None:
+                            assert cwd_before == cwd_after, \
+                                     "CWD changed from %s to %s" % (cwd_before, cwd_after)
+
+                if exc is not None:
+                    raise exc
+        return newfunc
+
+    return decorator


### PR DESCRIPTION
This is #424 (please see it for details) but rebased on top of current ~~master~~ #432 (apparently I was trying to account for that change to avoid possible other conflicts)  

The purpose of the PR just to verify that the tests are ok and seek review from @tsalo before force pushing #424 to this rebased state.

<details>
<summary>Here is the interdiff for the 4 commits from original and this version</summary> 

```shell
$> git range-diff gh-tsalo/ref/modularize-multifile-renamers^^^^..gh-tsalo/ref/modularize-multifile-renamers HEAD^^^^..HEAD
1:  e21a9ba ! 1:  814e2a5 Add functions for renaming complex, multi-echo, and uncombined files.
    @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, o
      
     -        # Check for varying echo times
     -        echo_times = sorted(list(set(
    --            load_json(b).get('EchoTime', None)
    --            for b in bids_files
    +-            b.get('EchoTime', nan)
    +-            for b in bids_metas
     -            if b
     -        )))
     -
     -        is_multiecho = len(echo_times) > 1
     +        # Collect some metadata across all images
     +        echo_times, channel_names, image_types = [], [], []
    -+        for b in bids_files:
    -+            if not b:
    ++        for metadata in bids_metas:
    ++            if not metadata:
     +                continue
    -+            metadata = load_json(b)
     +            echo_times.append(metadata.get('EchoTime', None))
     +            channel_names.append(metadata.get('CoilString', None))
     +            image_types.append(metadata.get('ImageType', None))
    @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, o
     +        is_complex = magnitude_found and phase_found
      
              ### Loop through the bids_files, set the output name and save files
    -         for fl, suffix, bids_file in zip(res_files, suffixes, bids_files):
    +         for fl, suffix, bids_file, bids_meta in zip(res_files, suffixes, bids_files, bids_metas):
     @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
    -             # TODO: monitor conversion duration
    -             if bids_file:
    -                 fileinfo = load_json(bids_file)
    -+                print(suffix)
    - 
    -             # set the prefix basename for this specific file (we'll modify it,
                  # and we don't want to modify it for all the bids_files):
                  this_prefix_basename = prefix_basename
      
     -            # _sbref sequences reconstructing magnitude and phase generate
     -            # two NIfTI files IN THE SAME SERIES, so we cannot just add
     -            # the suffix, if we want to be bids compliant:
    --            if bids_file and this_prefix_basename.endswith('_sbref'):
    +-            if bids_meta and this_prefix_basename.endswith('_sbref') \
    +-                    and len(suffixes) > len(echo_times):
    +-                if len(suffixes) != len(echo_times)*2:
    +-                    lgr.warning(
    +-                        "Got %d suffixes for %d echo times, which isn't "
    +-                        "multiple of two as if it was magnitude + phase pairs",
    +-                        len(suffixes), len(echo_times)
    +-                    )
     -                # Check to see if it is magnitude or phase reconstruction:
    --                if 'M' in fileinfo.get('ImageType'):
    +-                if 'M' in bids_meta.get('ImageType'):
     -                    mag_or_phase = 'magnitude'
    --                elif 'P' in fileinfo.get('ImageType'):
    +-                elif 'P' in bids_meta.get('ImageType'):
     -                    mag_or_phase = 'phase'
     -                else:
     -                    mag_or_phase = suffix
    @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, o
     +            # Update name if complex data
     +            if bids_file and is_complex:
     +                this_prefix_basename = update_complex_name(
    -+                    fileinfo, this_prefix_basename, suffix
    ++                    bids_meta, this_prefix_basename, suffix
     +                )
     +
     +            # Update name if multi-echo
                  # (Note: it can be _sbref and multiecho, so don't use "elif"):
                  # For multi-echo sequences, we have to specify the echo number in
                  # the file name:
    -             if bids_file and is_multiecho:
    +-            if bids_meta and is_multiecho:
     -                # Get the EchoNumber from json file info.  If not present, use EchoTime
    --                if 'EchoNumber' in fileinfo.keys():
    --                    echo_number = fileinfo['EchoNumber']
    +-                if 'EchoNumber' in bids_meta:
    +-                    echo_number = bids_meta['EchoNumber']
     -                else:
    --                    echo_number = echo_times.index(fileinfo['EchoTime']) + 1
    +-                    echo_number = echo_times.index(bids_meta['EchoTime']) + 1
     -
     -                supported_multiecho = ['_bold', '_phase', '_epi', '_sbref', '_T1w', '_PDT2']
     -                # Now, decide where to insert it.
    @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, o
     -                            imgtype, "_echo-%d%s" % (echo_number, imgtype)
     -                        )
     -                        break
    ++            if bids_file and is_multiecho:
     +                this_prefix_basename = update_multiecho_name(
    -+                    fileinfo, this_prefix_basename, echo_times, suffix
    ++                    bids_meta, this_prefix_basename, echo_times, suffix
     +                )
     +
     +            # Update name if uncombined (channel-level) data
     +            if bids_file and is_uncombined:
     +                this_prefix_basename = update_uncombined_name(
    -+                    fileinfo, this_prefix_basename, channel_names
    ++                    bids_meta, this_prefix_basename, channel_names
     +                )
      
                  # Fallback option:
2:  95e574b ! 2:  7bb99ae Fix bugs.
    @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, o
      
              ### Loop through the bids_files, set the output name and save files
     @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
    -             # TODO: monitor conversion duration
    -             if bids_file:
    -                 fileinfo = load_json(bids_file)
    --                print(suffix)
    - 
    -             # set the prefix basename for this specific file (we'll modify it,
                  # and we don't want to modify it for all the bids_files):
                  this_prefix_basename = prefix_basename
      
     -            # Update name if complex data
     -            if bids_file and is_complex:
     -                this_prefix_basename = update_complex_name(
    --                    fileinfo, this_prefix_basename, suffix
    +-                    bids_meta, this_prefix_basename, suffix
     -                )
     -
                  # Update name if multi-echo
                  # (Note: it can be _sbref and multiecho, so don't use "elif"):
                  # For multi-echo sequences, we have to specify the echo number in
     @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
    -                     fileinfo, this_prefix_basename, echo_times, suffix
    +                     bids_meta, this_prefix_basename, echo_times, suffix
                      )
      
     +            # Update name if complex data
     +            if bids_file and is_complex:
     +                this_prefix_basename = update_complex_name(
    -+                    fileinfo, this_prefix_basename, suffix
    ++                    bids_meta, this_prefix_basename, suffix
     +                )
     +
                  # Update name if uncombined (channel-level) data
                  if bids_file and is_uncombined:
                      this_prefix_basename = update_uncombined_name(
    --                    fileinfo, this_prefix_basename, channel_names
    -+                    fileinfo, this_prefix_basename, channel_names, suffix
    +-                    bids_meta, this_prefix_basename, channel_names
    ++                    bids_meta, this_prefix_basename, channel_names, suffix
                      )
      
                  # Fallback option:
3:  7858bbc ! 3:  31b2c90 Change part back to rec.
    @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, o
     -            # the file name:
                  if bids_file and is_multiecho:
                      this_prefix_basename = update_multiecho_name(
    --                    fileinfo, this_prefix_basename, echo_times, suffix
    -+                    fileinfo, this_prefix_basename, echo_times
    +-                    bids_meta, this_prefix_basename, echo_times, suffix
    ++                    bids_meta, this_prefix_basename, echo_times
                      )
      
                  # Update name if complex data
    @@ heudiconv/convert.py: def save_converted_files(res, item_dicoms, bids_options, o
                  # Update name if uncombined (channel-level) data
                  if bids_file and is_uncombined:
                      this_prefix_basename = update_uncombined_name(
    --                    fileinfo, this_prefix_basename, channel_names, suffix
    -+                    fileinfo, this_prefix_basename, channel_names
    +-                    bids_meta, this_prefix_basename, channel_names, suffix
    ++                    bids_meta, this_prefix_basename, channel_names
                      )
      
                  # Fallback option:
4:  788bd96 = 4:  15abe59 Update entity orders based on entity table.

```
</details>