### PR TITLE
ENH: Provide informative exception if command needs a heuristic to be specified

### DIFF
--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -62,6 +62,7 @@ def process_extra_commands(outdir, args):
         for f in args.files:
             treat_infofile(f)
     elif args.command == 'ls':
+        ensure_heuristic_arg(args)
         heuristic = load_heuristic(args.heuristic)
         heuristic_ls = getattr(heuristic, 'ls', None)
         for f in args.files:
@@ -78,6 +79,7 @@ def process_extra_commands(outdir, args):
                     % (str(study_session), len(sequences), suf)
                 )
     elif args.command == 'populate-templates':
+        ensure_heuristic_arg(args)
         heuristic = load_heuristic(args.heuristic)
         for f in args.files:
             populate_bids_templates(f, getattr(heuristic, 'DEFAULT_FIELDS', {}))
@@ -88,14 +90,19 @@ def process_extra_commands(outdir, args):
         for name_desc in get_known_heuristics_with_descriptions().items():
             print("- %s: %s" % name_desc)
     elif args.command == 'heuristic-info':
-        from ..utils import get_heuristic_description, get_known_heuristic_names
-        if not args.heuristic:
-            raise ValueError("Specify heuristic using -f. Known are: %s"
-                             % ', '.join(get_known_heuristic_names()))
+        ensure_heuristic_arg(args)
+        from ..utils import get_heuristic_description
         print(get_heuristic_description(args.heuristic, full=True))
     else:
         raise ValueError("Unknown command %s", args.command)
     return
+
+
+def ensure_heuristic_arg(args):
+    from ..utils import get_known_heuristic_names
+    if not args.heuristic:
+        raise ValueError("Specify heuristic using -f. Known are: %s"
+                         % ', '.join(get_known_heuristic_names()))
 
 
 def main(argv=None):

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -65,6 +65,17 @@ def test_populate_bids_templates(tmpdir):
 
     # it should also be available as a command
     os.unlink(str(description_file))
+
+    # it must fail if no heuristic was provided
+    with pytest.raises(ValueError) as cme:
+        runner([
+            '--command', 'populate-templates',
+            '--files', str(tmpdir)
+        ])
+    assert str(cme.value).startswith("Specify heuristic using -f. Known are:")
+    assert "convertall," in str(cme.value)
+    assert not description_file.exists()
+
     runner([
         '--command', 'populate-templates', '-f', 'convertall',
         '--files', str(tmpdir)


### PR DESCRIPTION
partially addresses last item in #173 - ideally should work without heuristic, but not ATM, so I will keep that issue open, but at least it should crash more informatively