### PR TITLE
RF(+BF somewhat): remove no longer needed dependencies etc

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -23,9 +23,7 @@ PYTHON_REQUIRES = ">=3.5"
 REQUIRES = [
     'nibabel',
     'pydicom',
-    'nipype >=1.0.0; python_version > "3.0"',
-    'nipype >=1.0.0,!=1.2.1,!=1.2.2; python_version == "2.7"',
-    'pathlib',
+    'nipype >=1.0.0',
     'dcmstack>=0.8',
     'etelemetry',
     'filelock>=3.0.12',

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ def main():
     # Get version and release info, which is all stored in heudiconv/info.py
     info_file = op.join(thispath, 'heudiconv', 'info.py')
     with open(info_file) as infofile:
-        # exec(infofile.read(), globals(), ldict)
-        # Workaround for python 2.7 prior 2.7.8
-        eval(compile(infofile.read(), '<string>', 'exec'), globals(), ldict)
+        exec(infofile.read(), globals(), ldict)
 
 
     def findsome(subdir, extensions):


### PR DESCRIPTION
Ran into it while testing neurodebian package for 0.8.0 -- ran into:
```
$> docker run -it --rm reproin-test-0.8.0:latest --help
Traceback (most recent call last):
  File "/usr/bin/heudiconv", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3191, in <module>
    @_call_aside
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3175, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3204, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pathlib' distribution was not found and is required by heudiconv
```
because `info.py` claims it as a dependency, and there were no `pip` install which would have pulled it from pypi (even though it is included in python itself)