### PR TITLE
DOC: add more tutorials to the overview

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -13,6 +13,14 @@ other users' tutorials covering their experience with ``heudiconv``.
 
 - `Sample Conversion: Coastal Coding 2019 <http://www.repronim.org/coco2019-training/presentations/heudiconv/#1>`_.
 
+- `A joined DataLad and HeuDiConv tutorial for reproducible fMRI studies <http://www.repronim.org/coco2019-training/04-02-reproin/>`_.
+
+- `The ReproIn conversion workflow overview <https://github.com/repronim/reproin#conversion>`_.
+
+- `Slides <https://docs.google.com/presentation/d/14UNWQVY49c9Xc-7sj1FkoILXnt-wYjW404oqT-FtCW8/edit#slide=id.p>`_ and
+  `recording <https://www.youtube.com/watch?v=j2SKX37-w4c&list=PLs3CA4ShM1DUX0nTMKfoB8Z6kdrZpByLa&index=5&t=0s>`_
+  of a ReproNim Webinar on ``heudiconv``.
+
 .. caution::
     Some of these tutorials may not be up to date with 
     the latest releases of ``heudiconv``.


### PR DESCRIPTION
This PR adds four yet unmentioned tutorials to the User tutorial section of the docs:

- DataLad + HeuDiConv tutorial: http://www.repronim.org/coco2019-training/04-02-reproin/ 
- ReproIn conversion workflow: https://github.com/repronim/reproin#conversion
- slides from ReproNim Webinar: https://docs.google.com/presentation/d/14UNWQVY49c9Xc-7sj1FkoILXnt-wYjW404oqT-FtCW8/edit#slide=id.p  
- video from ReproNim Webinar: https://www.youtube.com/watch?v=j2SKX37-w4c&list=PLs3CA4ShM1DUX0nTMKfoB8Z6kdrZpByLa&index=5&t=0s