### PR TITLE
[ENH] Retain sub-second resolution in scans files

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -26,6 +26,19 @@ from .utils import (
 
 lgr = logging.getLogger(__name__)
 
+# Fields to be populated in _scans files. Order matters
+SCANS_FILE_FIELDS = OrderedDict([
+    ("filename", OrderedDict([
+        ("Description", "Name of the nifti file")])),
+    ("acq_time", OrderedDict([
+        ("LongName", "Acquisition time"),
+        ("Description", "Acquisition time of the particular scan")])),
+    ("operator", OrderedDict([
+        ("Description", "Name of the operator")])),
+    ("randstr", OrderedDict([
+        ("LongName", "Random string"),
+        ("Description", "md5 hash of UIDs")])),
+])
 
 class BIDSError(Exception):
     pass
@@ -360,22 +373,9 @@ def add_rows_to_scans_keys_file(fn, newrows):
         # _scans.tsv). This auto generation will make BIDS-validator happy.
         scans_json = '.'.join(fn.split('.')[:-1] + ['json'])
         if not op.lexists(scans_json):
-            save_json(scans_json,
-                OrderedDict([
-                    ("filename", OrderedDict([
-                        ("Description", "Name of the nifti file")])),
-                    ("acq_time", OrderedDict([
-                        ("LongName", "Acquisition time"),
-                        ("Description", "Acquisition time of the particular scan")])),
-                    ("operator", OrderedDict([
-                        ("Description", "Name of the operator")])),
-                    ("randstr", OrderedDict([
-                        ("LongName", "Random string"),
-                        ("Description", "md5 hash of UIDs")])),
-                ]),
-                sort_keys=False)
+            save_json(scans_json, SCANS_FILE_FIELDS, sort_keys=False)
 
-    header = ['filename', 'acq_time', 'operator', 'randstr']
+    header = SCANS_FILE_FIELDS
     # prepare all the data rows
     data_rows = [[k] + v for k, v in fnames2info.items()]
     # sort by the date/filename

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -406,9 +406,9 @@ def get_formatted_scans_key_row(dcm_fn):
     # parse date and time and get it into isoformat
     try:
         date = dcm_data.ContentDate
-        time = dcm_data.ContentTime.split('.')[0]
-        td = time + date
-        acq_time = datetime.strptime(td, '%H%M%S%Y%m%d').isoformat()
+        time = dcm_data.ContentTime
+        td = time + ':' + date
+        acq_time = datetime.strptime(td, '%H%M%S.%f:%Y%m%d').isoformat()
     except (AttributeError, ValueError) as exc:
         lgr.warning("Failed to get date/time for the content: %s", str(exc))
         acq_time = ''

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -21,6 +21,7 @@ from .utils import (
     json_dumps_pretty,
     set_readonly,
     is_readonly,
+    get_datetime,
 )
 
 lgr = logging.getLogger(__name__)
@@ -407,8 +408,7 @@ def get_formatted_scans_key_row(dcm_fn):
     try:
         date = dcm_data.ContentDate
         time = dcm_data.ContentTime
-        td = time + ':' + date
-        acq_time = datetime.strptime(td, '%H%M%S.%f:%Y%m%d').isoformat()
+        acq_time = get_datetime(date, time)
     except (AttributeError, ValueError) as exc:
         lgr.warning("Failed to get date/time for the content: %s", str(exc))
         acq_time = ''

--- a/heudiconv/tests/test_heuristics.py
+++ b/heudiconv/tests/test_heuristics.py
@@ -116,7 +116,7 @@ def test_scans_keys_reproin(tmpdir, invocation):
             if i != 0:
                 assert(os.path.exists(pjoin(dirname(scans_keys[0]), row[0])))
                 assert(re.match(
-                    '^[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}$',
+                    '^[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}.\d]{6}$',
                     row[1]))
 
 

--- a/heudiconv/tests/test_heuristics.py
+++ b/heudiconv/tests/test_heuristics.py
@@ -116,7 +116,7 @@ def test_scans_keys_reproin(tmpdir, invocation):
             if i != 0:
                 assert(os.path.exists(pjoin(dirname(scans_keys[0]), row[0])))
                 assert(re.match(
-                    '^[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}.\d]{6}$',
+                    '^[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}.[\d]{6}$',
                     row[1]))
 
 

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -173,7 +173,7 @@ def test_get_formatted_scans_key_row():
 
     row1 = get_formatted_scans_key_row(dcm_fn)
     assert len(row1) == 3
-    assert row1[0] == '2016-10-14T09:26:36'
+    assert row1[0] == '2016-10-14T09:26:36.693000'
     assert row1[1] == 'n/a'
     prandstr1 = row1[2]
 

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -94,3 +94,4 @@ def test_get_datetime():
     """
     assert get_datetime('20200512', '162130') == '2020-05-12T16:21:30'
     assert get_datetime('20200512', '162130.5') == '2020-05-12T16:21:30.500000'
+    assert get_datetime('20200512', '162130.5', microseconds=False) == '2020-05-12T16:21:30'

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -92,11 +92,5 @@ def test_get_datetime():
     """
     Test utils.get_datetime()
     """
-    date = '20200512'
-    time = '162130'
-    datetime_str = get_datetime(date, time)
-    assert datetime_str == '2020-05-12T16:21:30'
-    date = '20200512'
-    time = '162130.5'
-    datetime_str = get_datetime(date, time)
-    assert datetime_str == '2020-05-12T16:21:30.500000'
+    assert get_datetime('20200512', '162130') == '2020-05-12T16:21:30'
+    assert get_datetime('20200512', '162130.5') == '2020-05-12T16:21:30.500000'

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -10,6 +10,7 @@ from heudiconv.utils import (
     load_json,
     create_tree,
     save_json,
+    get_datetime,
     JSONDecodeError)
 
 import pytest
@@ -85,3 +86,17 @@ def test_load_json(tmpdir, caplog):
     save_json(valid_json_file, vcontent)
     
     assert load_json(valid_json_file) == vcontent
+
+
+def test_get_datetime():
+    """
+    Test utils.get_datetime()
+    """
+    date = '20200512'
+    time = '162130'
+    datetime_str = get_datetime(date, time)
+    assert datetime_str == '2020-05-12T16:21:30.000000'
+    date = '20200512'
+    time = '162130.5'
+    datetime_str = get_datetime(date, time)
+    assert datetime_str == '2020-05-12T16:21:30.500000'

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -95,7 +95,7 @@ def test_get_datetime():
     date = '20200512'
     time = '162130'
     datetime_str = get_datetime(date, time)
-    assert datetime_str == '2020-05-12T16:21:30.000000'
+    assert datetime_str == '2020-05-12T16:21:30'
     date = '20200512'
     time = '162130.5'
     datetime_str = get_datetime(date, time)

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from collections import namedtuple
 from glob import glob
 from subprocess import check_output
+from datetime import datetime
 
 from nipype.utils.filemanip import which
 
@@ -505,3 +506,27 @@ def get_typed_attr(obj, attr, _type, default=None):
     except (TypeError, ValueError):
         return default
     return val
+
+
+def get_datetime(date, time):
+    """
+    Convert date and time from dicom to isoformat.
+
+    Parameters
+    ----------
+    date : str
+        Date in YYYYMMDD format.
+    time : str
+        Time in either HHMMSS.ffffff format or HHMMSS format.
+
+    Returns
+    -------
+    datetime_str : str
+        Combined date and time in ISO format, with milliseconds.
+    """
+    if '.' not in time:
+        # add milliseconds if not available
+        time += '.000'
+    td = time + ':' + date
+    datetime_str = datetime.strptime(td, '%H%M%S.%f:%Y%m%d').isoformat()
+    return datetime_str

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -508,7 +508,7 @@ def get_typed_attr(obj, attr, _type, default=None):
     return val
 
 
-def get_datetime(date, time):
+def get_datetime(date, time, *, microseconds=True):
     """
     Combine date and time from dicom to isoformat.
 
@@ -518,16 +518,21 @@ def get_datetime(date, time):
         Date in YYYYMMDD format.
     time : str
         Time in either HHMMSS.ffffff format or HHMMSS format.
+    microseconds: bool, optional
+        Either to include microseconds in the output
 
     Returns
     -------
     datetime_str : str
-        Combined date and time in ISO format (with microseconds if
-        they were available in provided time).
+        Combined date and time in ISO format, with microseconds as
+        if fraction was provided in 'time', and 'microseconds' was
+        True.
     """
     if '.' not in time:
         # add dummy microseconds if not available for strptime to parse
         time += '.000000'
     td = time + ':' + date
     datetime_str = datetime.strptime(td, '%H%M%S.%f:%Y%m%d').isoformat()
+    if not microseconds:
+        datetime_str = datetime_str.split('.', 1)[0]
     return datetime_str

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -510,7 +510,7 @@ def get_typed_attr(obj, attr, _type, default=None):
 
 def get_datetime(date, time):
     """
-    Convert date and time from dicom to isoformat.
+    Combine date and time from dicom to isoformat.
 
     Parameters
     ----------
@@ -522,11 +522,12 @@ def get_datetime(date, time):
     Returns
     -------
     datetime_str : str
-        Combined date and time in ISO format, with milliseconds.
+        Combined date and time in ISO format (with microseconds if
+        they were available in provided time).
     """
     if '.' not in time:
-        # add milliseconds if not available
-        time += '.000'
+        # add dummy microseconds if not available for strptime to parse
+        time += '.000000'
     td = time + ':' + date
     datetime_str = datetime.strptime(td, '%H%M%S.%f:%Y%m%d').isoformat()
     return datetime_str


### PR DESCRIPTION
Closes #447.

Changes proposed:
- Keep sub-second timing information in ContentTime when compiling `acq_time` for scans.tsv files.