### PR TITLE
[BF] remove unassigned embedfunc outputs

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -476,7 +476,6 @@ def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
 
     embedfunc = Node(Function(input_names=['dcmfiles', 'niftifile', 'infofile',
                                            'bids_info',],
-                              output_names=['outfile', 'meta'],
                               function=embed_dicom_and_nifti_metadata),
                      name='embedder')
     embedfunc.inputs.dcmfiles = item_dicoms


### PR DESCRIPTION
This fixes an error of `ERROR: Embedding failed: 'NoneType' object is not subscriptable`.

It looks like `embed_dicom_and_nifti_metadata` no longer returns a json and metadata, but the Node wrapping it in `embed_metadata_from_dicoms` still was expecting an output. This was getting caught inside the try/catch block, but caused it to skip the rest of the processing in `embed_metadata_from_dicoms`.

This patch just removes the outputs from the node, since it appears to be unused.