### PR TITLE
ENH: zenodo referencing in README.rst + support for ducredit for heudiconv and reproin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,10 @@ into structured directory layouts.
 - it can track the provenance of the conversion from DICOM to NIfTI in W3C PROV format
 - it provides assistance in converting to `BIDS <http://bids.neuroimaging.io/>`_.
 - it integrates with `DataLad <https://www.datalad.org/>`_ to place converted and original data under git/git-annex version control, while automatically annotating files with sensitive information (e.g., non-defaced anatomicals, etc)
+
+How to cite
+-----------
+
+Please use `Zenodo record <https://doi.org/10.5281/zenodo.1012598>`_ for
+your specific version of HeuDiConv.  We also support gathering
+all relevant citations via `DueCredit <http://duecredit.org>`_.

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@
   :target: http://heudiconv.readthedocs.io/en/latest/?badge=latest
   :alt: Readthedocs
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1012598.svg
+  :target: https://doi.org/10.5281/zenodo.1012598
+  :alt: Zenodo (latest)
+
 About
 -----
 

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -44,6 +44,9 @@ class BIDSError(Exception):
     pass
 
 
+BIDS_VERSION = "1.4.1"
+
+
 def populate_bids_templates(path, defaults={}):
     """Premake BIDS text files with templates"""
 
@@ -53,7 +56,7 @@ def populate_bids_templates(path, defaults={}):
         save_json(descriptor,
               OrderedDict([
                   ('Name', "TODO: name of the dataset"),
-                  ('BIDSVersion', "1.0.1"),
+                  ('BIDSVersion', BIDS_VERSION),
                   ('License', defaults.get('License',
                         "TODO: choose a license, e.g. PDDL "
                         "(http://opendatacommons.org/licenses/pddl/)")),

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -11,6 +11,7 @@ from ..utils import load_heuristic, anonymize_sid, treat_infofile, SeqInfo
 from ..convert import prep_conversion
 from ..bids import populate_bids_templates, tuneup_bids_json_files
 from ..queue import queue_conversion
+from ..due import due, Doi
 
 import inspect
 import logging
@@ -244,6 +245,12 @@ def get_parser():
     return parser
 
 
+@due.dcite(
+    Doi('10.5281/zenodo.1012598'),
+    path='heudiconv',
+    description='Flexible DICOM converter for organizing brain imaging data',
+    version=__version__,
+    cite_module=True)
 def process_args(args):
     """Given a structure of arguments from the parser perform computation"""
 

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -7,6 +7,8 @@ import shutil
 import sys
 import re
 
+from .due import due, Doi
+
 from .utils import (
     read_config,
     load_json,
@@ -27,7 +29,8 @@ from .bids import (
     save_scans_key,
     tuneup_bids_json_files,
     add_participant_record,
-    BIDSError
+    BIDSError,
+    BIDS_VERSION,
 )
 from .dicoms import (
     group_dicoms_into_seqinfos,
@@ -409,6 +412,20 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
     """
     prov_files = []
     tempdirs = TempDirs()
+
+    if bids_options is not None:
+        due.cite(
+            # doi matches the BIDS_VERSION
+            Doi("10.5281/zenodo.4085321"),
+            description="Brain Imaging Data Structure (BIDS) Specification",
+            path="bids",
+            version=BIDS_VERSION,
+            tags=["implementation"])
+        due.cite(
+            Doi("10.1038/sdata.2016.44"),
+            description="Brain Imaging Data Structure (BIDS), Original paper",
+            path="bids",
+            tags=["documentation"])
 
     for item_idx, item in enumerate(items):
 

--- a/heudiconv/due.py
+++ b/heudiconv/due.py
@@ -1,0 +1,74 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX, Text
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2019  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.8'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    active = False
+    activate = add = cite = dump = load = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url, Text
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if not isinstance(e, ImportError):
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = Text = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -123,6 +123,8 @@ from collections import OrderedDict
 import hashlib
 from glob import glob
 
+from heudiconv.due import due, Doi
+
 import logging
 lgr = logging.getLogger('heudiconv')
 
@@ -467,6 +469,10 @@ def ls(study_session, seqinfo):
 # XXX we killed session indicator!  what should we do now?!!!
 # WE DON:T NEED IT -- it will be provided into conversion_info as `session`
 # So we just need subdir and file_suffix!
+@due.dcite(
+    Doi('10.5281/zenodo.1207117'),
+    path='heudiconv.heuristics.reproin',
+    description='ReproIn heudiconv heuristic for turnkey conversion into BIDS')
 def infotodict(seqinfo):
     """Heuristic evaluator for determining which runs belong where
 

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -39,7 +39,9 @@ TESTS_REQUIRES = [
 
 EXTRA_REQUIRES = {
     'tests': TESTS_REQUIRES,
-    'extras': [],  # Requires patched version ATM ['dcmstack'],
+    'extras': [
+        'duecredit',  # optional dependency
+    ],  # Requires patched version ATM ['dcmstack'],
     'datalad': ['datalad >=0.12.3']
 }
 


### PR DESCRIPTION
Individual commits might provide more info.  Here is a result of a sample run with duecredit enabled:

```
DueCredit Report:
- Flexible DICOM converter for organizing brain imaging data / heudiconv (v 0.8.0) [1]
  - ReproIn heudiconv heuristic for turnkey conversion into BIDS / heudiconv.heuristics.reproin (v 0.8) [2]
- I/O library to access to common neuroimaging file formats / nibabel (v 3.0.1) [3]
- Scientific tools library / numpy (v 1.17.4) [4]

3 packages cited
1 module cited
0 functions cited

References
----------

[1] Halchenko, Y. et al., 2020. nipy/heudiconv v0.8.0.
[2] Visconti di Oleggio Castello, M. et al., 2020. ReproNim/reproin 0.6.0.
[3] Brett, M. et al., 2015. Nibabel 2.0.1.
[4] Van Der Walt, S., Colbert, S.C. & Varoquaux, G., 2011. The NumPy array: a structure for efficient numerical computation. Computing in Science & Engineering, 13(2), pp.22–30.
DUECREDIT_ENABLE=1 heudiconv -o /tmp/out -f reproin --files   5.33s user 0.35s system 98% cpu 5.767 total
```

<details>
<summary>With BibTeX output produced by `duecredit summary --format bibtex`:</summary> 

```bibtex
@misc{https://doi.org/10.5281/zenodo.1012598,
  doi = {10.5281/ZENODO.1012598},
  url = {https://zenodo.org/record/1012598},
  author = {Halchenko, Yaroslav and Goncalves, Mathias and Castello, Matteo Visconti Di Oleggio and {Satrajit Ghosh} and Hanke, Michael and Salo, Taylor and {, Dae} and Kent, James and {Pvelasco} and Amlien, Inge and Brett, Matthew and Tilley, Steven and Markiewicz, Chris and Lukas, Darren Christopher and Gorgolewski, Chris and Kim, Sin and {Joerg Stadler} and Kaczmarzyk, Jakub and Lee, John and Lurie, Daniel and Pellman, John and Braun, Henry and Melo, Bruno and Poldrack, Benjamin and Schiffler, Björn and {Michał Szczepanik} and Samuels, Kalle and Carlin, Johan and Feingold, Franklin and Kahn, Ari},
  title = {nipy/heudiconv v0.8.0},
  publisher = {Zenodo},
  year = {2020}
}
@misc{https://doi.org/10.5281/zenodo.1207117,
  doi = {10.5281/ZENODO.1207117},
  url = {https://zenodo.org/record/1207117},
  author = {Visconti di Oleggio Castello, Matteo and Dobson, James E. and Sackett, Terry and Kodiweera, Chandana and Haxby, James V. and Goncalves, Mathias and Ghosh, Satrajit and Halchenko, Yaroslav O.},
  title = {ReproNim/reproin 0.6.0},
  publisher = {Zenodo},
  year = {2020}
}
@misc{https://doi.org/10.5281/zenodo.60847,
  doi = {10.5281/ZENODO.60847},
  url = {https://zenodo.org/record/60847},
  author = {Brett, Matthew and Hanke, Michael and Cipollini, Ben and {Marc-Alexandre Côté} and Markiewicz, Chris and Gerhard, Stephan and Larson, Eric and Lee, Gregory R. and Halchenko, Yaroslav and Kastman, Erik and {Cindeem} and Morency, Félix C. and {Moloney} and Millman, Jarrod and Rokem, Ariel and {Jaeilepp} and Gramfort, Alexandre and Bosch, Jasper J.F. Van Den and {Krish Subramaniam} and Nichols, Nolan and {Embaker} and {Bpinsard} and {Chaselgrove} and Oosterhof, Nikolaas N. and St-Jean, Samuel and {Bago Amirbekian} and Nimmo-Smith, Ian and {Satrajit Ghosh}},
  title = {Nibabel 2.0.1},
  publisher = {Zenodo},
  year = {2015}
}
@article{van2011numpy,
        title={The NumPy array: a structure for efficient numerical computation},
        author={Van Der Walt, Stefan and Colbert, S Chris and Varoquaux, Gael},
        journal={Computing in Science \& Engineering},
        volume={13},
        number={2},
        pages={22--30},
        year={2011},
        publisher={AIP Publishing},
        doi={10.1109/MCSE.2011.37}
        }

```
</details>