### PR TITLE
ENH: Use AcquisitionTime for acq_time scans file field

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -406,7 +406,7 @@ def get_formatted_scans_key_row(dcm_fn):
     # parse date and time and get it into isoformat
     try:
         date = dcm_data.ContentDate
-        time = dcm_data.ContentTime.split('.')[0]
+        time = dcm_data.AcquisitionTime.split('.')[0]
         td = time + date
         acq_time = datetime.strptime(td, '%H%M%S%Y%m%d').isoformat()
     except (AttributeError, ValueError) as exc:

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -404,7 +404,7 @@ def get_formatted_scans_key_row(dcm_fn):
     """
     dcm_data = dcm.read_file(dcm_fn, stop_before_pixels=True, force=True)
     # we need to store filenames and acquisition times
-    # parse date and time and get it into isoformat
+    # parse date and time of start of run acquisition and get it into isoformat
     try:
         date = dcm_data.ContentDate
         time = dcm_data.AcquisitionTime

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -406,7 +406,7 @@ def get_formatted_scans_key_row(dcm_fn):
     # we need to store filenames and acquisition times
     # parse date and time of start of run acquisition and get it into isoformat
     try:
-        date = dcm_data.ContentDate
+        date = dcm_data.AcquisitionDate
         time = dcm_data.AcquisitionTime
         acq_time = get_datetime(date, time)
     except (AttributeError, ValueError) as exc:

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -171,7 +171,7 @@ def test_get_formatted_scans_key_row():
 
     row1 = get_formatted_scans_key_row(dcm_fn)
     assert len(row1) == 3
-    assert row1[0] == '2016-10-14T09:26:36.693000'
+    assert row1[0] == '2016-10-14T09:26:34.692500'
     assert row1[1] == 'n/a'
     prandstr1 = row1[2]
 


### PR DESCRIPTION
Closes #450. 

Changes proposed:
- Change ContentTime to AcquisitionTime for acq_time field in scans file.
- Change ContentDate to AcquisitionDate for acq_time field in scans file.