### PR TITLE
FIX/ENH/RF: Introduce configuration module and catch lingering tmpdirs

### DIFF
--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 from argparse import ArgumentParser
+from importlib import reload
 
 from .. import __version__, config
 from ..main import workflow
@@ -12,7 +13,6 @@ lgr = logging.getLogger(__name__)
 
 def main(argv=None):
     # ensure config is reset before starting anew
-    from importlib import reload
     reload(config)
 
     parser = get_parser()

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import logging
 import os
 import sys
@@ -13,15 +12,14 @@ lgr = logging.getLogger(__name__)
 
 def main(argv=None):
     parser = get_parser()
-    args = parser.parse_args(argv)
+    opts = parser.parse_args(argv)
     # exit if nothing to be done
-    if not args.files and not args.dicom_dir_template and not args.command:
+    if not any((opts.files, opts.dicom_dir_template, opts.command)):
         lgr.warning("Nothing to be done - displaying usage help")
         parser.print_help()
         sys.exit(1)
 
-    kwargs = vars(args)
-    workflow(**kwargs)
+    return workflow(**vars(opts))
 
 
 def get_parser():
@@ -44,6 +42,7 @@ def get_parser():
     group.add_argument(
         '--files',
         nargs='*',
+        type=os.path.abspath,
         help='Files (tarballs, dicoms) or directories containing files to '
              'process. Cannot be provided if using --dicom_dir_template.')
     parser.add_argument(

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -4,13 +4,17 @@ import os
 import sys
 from argparse import ArgumentParser
 
-from .. import __version__
+from .. import __version__, config
 from ..main import workflow
 
 lgr = logging.getLogger(__name__)
 
 
 def main(argv=None):
+    # ensure config is reset before starting anew
+    from importlib import reload
+    reload(config)
+
     parser = get_parser()
     opts = parser.parse_args(argv)
     # exit if nothing to be done

--- a/heudiconv/config.py
+++ b/heudiconv/config.py
@@ -1,0 +1,185 @@
+"""
+A Python module for managing configurations across a heudiconv run.
+"""
+
+import atexit
+import os
+from pathlib import Path
+
+
+_initialized = False
+# avoid telemetry check if user desires
+_disable_et = bool(
+    os.getenv("NO_ET") is not None
+    or os.getenv("NIPYPE_NO_ET") is not None
+)
+os.environ["NIPYPE_NO_ET"] = "1"
+os.environ["NO_ET"] = "1"
+_latest_version = "Unknown"
+
+if not _disable_et:
+    # Ensure analytics hit only once
+    from contextlib import suppress
+    from requests import get, ConnectionError, ReadTimeout
+    with suppress((ConnectionError, ReadTimeout)):
+        res = get("https://rig.mit.edu/et/projects/nipy/heudiconv", timeout=0.1)
+    try:
+        _latest_version = res.json()['version']
+    except Exception:
+        pass
+
+
+class _Config:
+    """An abstract class forbidding instantiation."""
+
+    _paths = tuple()
+
+    def __init__(self):
+        """Avert instantiation."""
+        raise RuntimeError('Configuration type is not instantiable.')
+
+    @classmethod
+    def load(cls, settings, init=True):
+        """Store settings from a dictionary."""
+        for k, v in settings.items():
+            if v is None:
+                continue
+            if k in cls._paths:
+                setattr(cls, k, Path(v).absolute())
+                continue
+            if k in cls._multipaths:
+                setattr(cls, k, tuple(Path(i).absolute() for i in v))
+            if hasattr(cls, k):
+                setattr(cls, k, v)
+
+        if init:
+            try:
+                cls.init()
+            except AttributeError:
+                pass
+
+    @classmethod
+    def get(cls):
+        """Return defined settings."""
+        out = {}
+        for k, v in cls.__dict__.items():
+            if k.startswith('_') or v is None:
+                continue
+            if callable(getattr(cls, k)):
+                continue
+            if k in cls._paths:
+                v = str(v)
+            if k in cls._multipaths:
+                v = tuple(str(i) for i in v)
+            out[k] = v
+        return out
+
+
+class workflow(_Config):
+    """Configure run-level settings."""
+
+    _paths = (
+        'dcmconfig',
+        'outdir',
+        'conv_outdir',
+    )
+    _multipaths = (
+        'files',
+    )
+
+    dicom_dir_template = None
+    "Template to search one or more directories for DICOMs and tarballs."
+    files = None
+    "Files (tarballs, DICOMs) or directories containing files to process."
+    subjs = None
+    "List of target subject IDs."
+    converter = None
+    "Tool to use for DICOM conversion."
+    outdir = Path('.').absolute()
+    "Output directory for conversion."
+    locator = None
+    "Study path under ``outdir``."
+    conv_outdir = None
+    "Anonymization output directory for converted files."
+    anon_cmd = None
+    "Command to run to anonymize subject IDs."
+    heuristic = None
+    "Path to custom file or name of built-in heuristic."
+    with_prov = False
+    "Store additional provenance information."
+    session = None
+    "Session for longitudinal studies."
+    bids = None
+    "Generate relevant BIDS files."
+    overwrite = False
+    "Overwrite existing converted files."
+    datalad = False
+    "Store the entire collection as DataLad datasets."
+    debug = False
+    "Do not catch exceptions and show traceback."
+    grouping = None
+    "DICOM grouping method."
+    minmeta = None
+    "Minimize BIDS sidecar metadata."
+    random_seed = None
+    "Random seed to initialize PRNG."
+    dcmconfig = None
+    "JSON file for additional dcm2niix configuration."
+    queue = None
+    "Batch system to submit jobs in parallel."
+    queue_args = None
+    "Additional queue arguments."
+
+    @classmethod
+    def init(cls):
+        """Initialize heudiconv execution"""
+        from .utils import load_heuristic
+
+        if cls.heuristic is not None:
+            cls.heuristic = load_heuristic(cls.heuristic)
+        if cls.random_seed is not None:
+            _init_seed(cls.random_seed)
+
+
+def from_dict(settings):
+    """Read and load settings from a flat dictionary."""
+    workflow.load(settings)
+    # mark as initialized
+    global _initialized
+    _initialized = True
+
+
+def get(flat=False):
+    """Get config as a dict."""
+    settings = {
+        'workflow': workflow.get(),
+    }
+    if not flat:
+        return settings
+
+    return {'.'.join((section, k)): v
+            for section, configs in settings.items()
+            for k, v in configs.items()}
+
+
+def _init_seed(seed):
+    import random
+    import numpy as np
+    random.seed(seed)
+    np.random.seed(seed)
+
+
+def add_tmpdir(tmpdir):
+    """Track temporary directories"""
+    _tmpdirs.add(tmpdir)
+
+
+def _cleanup():
+    """Cleanup tracked temporary directories"""
+    for tmpdir in _tmpdirs:
+        tmpdir.cleanup()
+
+
+_tmpdirs = set()
+# ensure cleanup of temporary directories occurs at exit
+atexit.register(_cleanup)

--- a/heudiconv/config.py
+++ b/heudiconv/config.py
@@ -21,7 +21,7 @@ if not _disable_et:
     from contextlib import suppress
     from requests import get, ConnectionError, ReadTimeout
     with suppress((ConnectionError, ReadTimeout)):
-        res = get("https://rig.mit.edu/et/projects/nipy/heudiconv", timeout=0.1)
+        res = get("https://rig.mit.edu/et/projects/nipy/heudiconv", timeout=0.5)
     try:
         _latest_version = res.json()['version']
     except Exception:

--- a/heudiconv/config.py
+++ b/heudiconv/config.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 
 
-_initialized = False
 # avoid telemetry check if user desires
 _disable_et = bool(
     os.getenv("NO_ET") is not None
@@ -144,9 +143,6 @@ class workflow(_Config):
 def from_dict(settings):
     """Read and load settings from a flat dictionary."""
     workflow.load(settings)
-    # mark as initialized
-    global _initialized
-    _initialized = True
 
 
 def get(flat=False):

--- a/heudiconv/config.py
+++ b/heudiconv/config.py
@@ -92,7 +92,7 @@ class workflow(_Config):
     "Files (tarballs, DICOMs) or directories containing files to process."
     subjs = None
     "List of target subject IDs."
-    converter = None
+    converter = 'dcm2niix'
     "Tool to use for DICOM conversion."
     outdir = Path('.').absolute()
     "Output directory for conversion."
@@ -108,13 +108,13 @@ class workflow(_Config):
     "Store additional provenance information."
     session = None
     "Session for longitudinal studies."
-    bids = None
+    bids_options = None
     "Generate relevant BIDS files."
     overwrite = False
     "Overwrite existing converted files."
-    datalad = False
+    datalad = None
     "Store the entire collection as DataLad datasets."
-    debug = False
+    debug = None
     "Do not catch exceptions and show traceback."
     grouping = None
     "DICOM grouping method."
@@ -128,13 +128,15 @@ class workflow(_Config):
     "Batch system to submit jobs in parallel."
     queue_args = None
     "Additional queue arguments."
+    command = None
+    "Custom action to be performed on provided files"
 
     @classmethod
     def init(cls):
         """Initialize heudiconv execution"""
         from .utils import load_heuristic
 
-        if cls.heuristic is not None:
+        if cls.heuristic:
             cls.heuristic = load_heuristic(cls.heuristic)
         if cls.random_seed is not None:
             _init_seed(cls.random_seed)
@@ -172,8 +174,13 @@ def add_tmpdir(tmpdir):
 
 def _cleanup():
     """Cleanup tracked temporary directories"""
+    import shutil
+
     for tmpdir in _tmpdirs:
-        tmpdir.cleanup()
+        try:
+            shutil.rmtree(tmpdir)
+        except FileNotFoundError:
+            pass
 
 
 _tmpdirs = set()

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -469,11 +469,11 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                         tuneup_bids_json_files(bids_outfiles)
                         if prov_file:
                             prov_files.append(prov_file)
-                        else:
-                            raise RuntimeError(
-                                "was asked to convert into %s but destination already exists"
-                                % (outname)
-                            )
+                else:
+                    raise RuntimeError(
+                        "was asked to convert into %s but destination already exists"
+                        % (outname)
+                    )
 
         # add the taskname field to the json file(s):
         add_taskname_to_infofile(bids_outfiles)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -441,7 +441,7 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                                      prefix + scaninfo_suffix)
 
                 if not op.exists(outname) or overwrite:
-                    with tempfile.TemporayDirectory(prefix='dcm2niix') as tmpdir:
+                    with tempfile.TemporaryDirectory(prefix='dcm2niix') as tmpdir:
                         # run conversion through nipype
                         res, prov_file = nipype_convert(
                             item_dicoms,

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -4,12 +4,12 @@ import os.path as op
 import logging
 from collections import OrderedDict
 import tarfile
+import tempfile
 
 from .external.pydicom import dcm
 from .utils import (
     get_typed_attr,
     load_json,
-    save_json,
     SeqInfo,
     set_readonly,
 )
@@ -323,7 +323,7 @@ def get_dicom_series_time(dicom_list):
     return calendar.timegm(time.strptime(dicom_time_str, '%Y%m%d%H%M%S'))
 
 
-def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
+def compress_dicoms(dicom_list, out_prefix, overwrite):
     """Archives DICOMs into a tarball
 
     Also tries to do it reproducibly, so takes the date for files
@@ -336,8 +336,6 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
     out_prefix : str
       output path prefix, including the portion of the output file name
       before .dicom.tgz suffix
-    tempdirs : object
-      TempDirs object to handle multiple tmpdirs
     overwrite : bool
       Overwrite existing tarfiles
 
@@ -347,7 +345,6 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
       Result tarball
     """
 
-    tmpdir = tempdirs(prefix='dicomtar')
     outtar = out_prefix + '.dicom.tgz'
 
     if op.exists(outtar) and not overwrite:
@@ -366,28 +363,28 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
         ti.mtime = dcm_time
         return ti
 
-    # poor man mocking since can't rely on having mock
-    try:
-        import time
-        _old_time = time.time
-        time.time = lambda: dcm_time
-        if op.lexists(outtar):
-            os.unlink(outtar)
-        with tarfile.open(outtar, 'w:gz', dereference=True) as tar:
-            for filename in dicom_list:
-                outfile = op.join(tmpdir, op.basename(filename))
-                if not op.islink(outfile):
-                    os.symlink(op.realpath(filename), outfile)
-                # place into archive stripping any lead directories and
-                # adding the one corresponding to prefix
-                tar.add(outfile,
-                        arcname=op.join(op.basename(out_prefix),
-                                        op.basename(outfile)),
-                        recursive=False,
-                        filter=_assign_dicom_time)
-    finally:
-        time.time = _old_time
-        tempdirs.rmtree(tmpdir)
+    with tempfile.TemporaryDirectory(prefix='DICOMtar') as tmpdir:
+        # poor man mocking since can't rely on having mock
+        try:
+            import time
+            _old_time = time.time
+            time.time = lambda: dcm_time
+            if op.lexists(outtar):
+                os.unlink(outtar)
+            with tarfile.open(outtar, 'w:gz', dereference=True) as tar:
+                for filename in dicom_list:
+                    outfile = op.join(tmpdir, op.basename(filename))
+                    if not op.islink(outfile):
+                        os.symlink(op.realpath(filename), outfile)
+                    # place into archive stripping any lead directories and
+                    # adding the one corresponding to prefix
+                    tar.add(outfile,
+                            arcname=op.join(op.basename(out_prefix),
+                                            op.basename(outfile)),
+                            recursive=False,
+                            filter=_assign_dicom_time)
+        finally:
+            time.time = _old_time
 
     return outtar
 
@@ -449,7 +446,7 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
 
 
 def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
-                               prov_file, scaninfo, tempdirs, with_prov):
+                               prov_file, scaninfo, with_prov):
     """
     Enhance sidecar information file with more information from DICOMs
 
@@ -461,7 +458,6 @@ def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
     outname_bids
     prov_file
     scaninfo
-    tempdirs
     with_prov
 
     Returns
@@ -469,40 +465,41 @@ def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
 
     """
     from nipype import Node, Function
-    tmpdir = tempdirs(prefix='embedmeta')
 
     # We need to assure that paths are absolute if they are relative
     item_dicoms = list(map(op.abspath, item_dicoms))
 
-    embedfunc = Node(Function(input_names=['dcmfiles', 'niftifile', 'infofile',
-                                           'bids_info',],
-                              function=embed_dicom_and_nifti_metadata),
-                     name='embedder')
-    embedfunc.inputs.dcmfiles = item_dicoms
-    embedfunc.inputs.niftifile = op.abspath(outname)
-    embedfunc.inputs.infofile = op.abspath(scaninfo)
-    embedfunc.inputs.bids_info = load_json(op.abspath(outname_bids)) if (bids_options is not None) else None
-    embedfunc.base_dir = tmpdir
-    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory(prefix='embedmeta') as tmpdir:
+        embedfunc = Node(Function(input_names=['dcmfiles', 'niftifile', 'infofile',
+                                               'bids_info'],
+                                  function=embed_dicom_and_nifti_metadata),
+                         name='embedder')
+        embedfunc.inputs.dcmfiles = item_dicoms
+        embedfunc.inputs.niftifile = op.abspath(outname)
+        embedfunc.inputs.infofile = op.abspath(scaninfo)
+        embedfunc.inputs.bids_info = load_json(op.abspath(outname_bids)) if (bids_options is not None) else None
+        embedfunc.base_dir = tmpdir
+        cwd = os.getcwd()
 
-    lgr.debug("Embedding into %s based on dicoms[0]=%s for nifti %s",
-              scaninfo, item_dicoms[0], outname)
-    try:
-        if op.lexists(scaninfo):
-            # TODO: handle annexed file case
-            if not op.islink(scaninfo):
-                set_readonly(scaninfo, False)
-        res = embedfunc.run()
-        set_readonly(scaninfo)
-        if with_prov:
-            g = res.provenance.rdf()
-            g.parse(prov_file,
-                    format='turtle')
-            g.serialize(prov_file, format='turtle')
-            set_readonly(prov_file)
-    except Exception as exc:
-        lgr.error("Embedding failed: %s", str(exc))
-        os.chdir(cwd)
+        lgr.debug("Embedding into %s based on dicoms[0]=%s for nifti %s",
+                scaninfo, item_dicoms[0], outname)
+        try:
+            if op.lexists(scaninfo):
+                # TODO: handle annexed file case
+                if not op.islink(scaninfo):
+                    set_readonly(scaninfo, False)
+            res = embedfunc.run()
+            set_readonly(scaninfo)
+            if with_prov:
+                g = res.provenance.rdf()
+                g.parse(prov_file,
+                        format='turtle')
+                g.serialize(prov_file, format='turtle')
+                set_readonly(prov_file)
+        except Exception as exc:
+            lgr.error("Embedding failed: %s", str(exc))
+            os.chdir(cwd)
+
 
 def parse_private_csa_header(dcm_data, public_attr, private_attr, default=None):
     """

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -7,7 +7,7 @@ from .bids import populate_bids_templates, tuneup_bids_json_files
 from .convert import prep_conversion
 from .parser import get_study_sessions
 from .queue import queue_conversion
-from .utils import anonymize_sid, load_heuristic, treat_infofile, SeqInfo
+from .utils import anonymize_sid, treat_infofile, SeqInfo
 
 lgr = logging.getLogger(__name__)
 
@@ -77,7 +77,6 @@ def process_extra_commands(outdir, command, files, dicom_dir_template,
             treat_infofile(f)
     elif command == 'ls':
         ensure_heuristic_arg(heuristic)
-        heuristic = load_heuristic(heuristic)
         heuristic_ls = getattr(heuristic, 'ls', None)
         for f in files:
             study_sessions = get_study_sessions(
@@ -94,7 +93,6 @@ def process_extra_commands(outdir, command, files, dicom_dir_template,
                 )
     elif command == 'populate-templates':
         ensure_heuristic_arg(heuristic)
-        heuristic = load_heuristic(heuristic)
         for f in files:
             populate_bids_templates(f, getattr(heuristic, 'DEFAULT_FIELDS', {}))
     elif command == 'sanitize-jsons':
@@ -222,8 +220,8 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
     -----
     All parameters in this function must be called as keyword arguments.
     """
-    # Initialized configuration if we haven't already
 
+    # Ensure configuration is initialized
     if init_config:
         config.from_dict(locals())
         # recurse with updated params

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -127,7 +127,8 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
              anon_cmd=None, heuristic=None, with_prov=False, session=None,
              bids_options=None, overwrite=False, datalad=False, debug=False,
              command=None, grouping='studyUID', minmeta=False,
-             random_seed=None, dcmconfig=None, queue=None, queue_args=None):
+             random_seed=None, dcmconfig=None, queue=None, queue_args=None,
+             init_config=True):
     """Run the HeuDiConv conversion workflow.
 
     Parameters
@@ -214,6 +215,8 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
     queue_args : str or None, optional
         Additional queue arguments passed as single string of space-separated
         Argument=Value pairs. Default is None.
+    init_config : bool, optional
+        Initializes ``heudiconv``'s configuration module based on parameters.
 
     Notes
     -----
@@ -222,11 +225,11 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
     # Initialized configuration if we haven't already
     print(locals())
 
-    if not config._initialized:
+    if init_config:
         config.from_dict(locals())
         # recurse with updated params
         print("Running with updated args")
-        return workflow(**config.get()['workflow'])
+        return workflow(init_config=False, **config.get()['workflow'])
 
     # Should be possible but only with a single subject -- will be used to
     # override subject deduced from the DICOMs
@@ -363,6 +366,3 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
     #
     # TODO: record_collection of the sid/session although that information
     # is pretty much present in .heudiconv/SUBJECT/info so we could just poke there
-
-    # reset config
-    config._initialized = False

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -223,12 +223,10 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
     All parameters in this function must be called as keyword arguments.
     """
     # Initialized configuration if we haven't already
-    print(locals())
 
     if init_config:
         config.from_dict(locals())
         # recurse with updated params
-        print("Running with updated args")
         return workflow(init_config=False, **config.get()['workflow'])
 
     # Should be possible but only with a single subject -- will be used to

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -7,8 +7,9 @@ import re
 from collections import defaultdict
 
 import tarfile
-from tempfile import mkdtemp
+from tempfile import TemporaryDirectory
 
+from . import config
 from .dicoms import group_dicoms_into_seqinfos
 from .utils import (
     docstring_parameter,
@@ -65,8 +66,13 @@ def get_extracted_dicoms(fl):
     # strategy: extract everything in a temp dir and assemble a list
     # of all files in all tarballs
 
-    # cannot use TempDirs since will trigger cleanup with __del__
-    tmpdir = mkdtemp(prefix='heudiconvDCM')
+    # To ensure proper conversion for tarballed files, these
+    # temporary directories must persist until the conversion
+    # step. To address this, the configuration module tracks
+    # temporary directories in memory, and automically cleans
+    # up upon program exit.
+    tmpdir = TemporaryDirectory(prefix='heudiconvDCM')
+    config.add_tmpdir(tmpdir)
 
     sessions = defaultdict(list)
     session = 0

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -7,7 +7,7 @@ import re
 from collections import defaultdict
 
 import tarfile
-from tempfile import TemporaryDirectory
+from tempfile import mkdtemp
 
 from . import config
 from .dicoms import group_dicoms_into_seqinfos
@@ -71,7 +71,7 @@ def get_extracted_dicoms(fl):
     # step. To address this, the configuration module tracks
     # temporary directories in memory, and automically cleans
     # up upon program exit.
-    tmpdir = TemporaryDirectory(prefix='heudiconvDCM')
+    tmpdir = mkdtemp(prefix='heudiconvDCM')
     config.add_tmpdir(tmpdir)
 
     sessions = defaultdict(list)
@@ -96,10 +96,10 @@ def get_extracted_dicoms(fl):
         tf_content = [m.name for m in tmembers if m.isfile()]
         # store full paths to each file, so we don't need to drag along
         # tmpdir as some basedir
-        sessions[session] = [op.join(tmpdir, f) for f in tf_content]
+        sessions[session] = [op.join(str(tmpdir), f) for f in tf_content]
         session += 1
         # extract into tmp dir
-        tf.extractall(path=tmpdir, members=tmembers)
+        tf.extractall(path=str(tmpdir), members=tmembers)
 
     if session == 1:
         # we had only 1 session, so no really multiple sessions according

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -17,6 +17,7 @@ DICOM_FIELDS_TO_TEST = {
     'ProtocolName': 'tProtocolName'
 }
 
+
 def test_private_csa_header(tmpdir):
     dcm_file = op.join(TESTS_DATA_PATH, 'axasc35.dcm')
     dcm_data = dcm.read_file(dcm_file, stop_before_pixels=True)

--- a/heudiconv/tests/test_tarballs.py
+++ b/heudiconv/tests/test_tarballs.py
@@ -1,16 +1,12 @@
 import os
-import pytest
-import sys
 import time
 
-from mock import patch
 from os.path import join as opj
 from os.path import dirname
-from six.moves import StringIO
 from glob import glob
 
 from heudiconv.dicoms import compress_dicoms
-from heudiconv.utils import TempDirs, file_md5sum
+from heudiconv.utils import file_md5sum
 
 tests_datadir = opj(dirname(__file__), 'data')
 
@@ -19,7 +15,6 @@ def test_reproducibility(tmpdir):
     prefix = str(tmpdir.join("precious"))
     args = [glob(opj(tests_datadir, '01-fmap_acq-3mm', '*')),
             prefix,
-            TempDirs(),
             True]
     tarball = compress_dicoms(*args)
     md5 = file_md5sum(tarball)

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -84,7 +84,7 @@ def test_load_json(tmpdir, caplog):
     vfname = "valid.json"
     valid_json_file = str(tmpdir / vfname)
     save_json(valid_json_file, vcontent)
-    
+
     assert load_json(valid_json_file) == vcontent
 
 

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -489,5 +489,3 @@ def get_datetime(date, time, *, microseconds=True):
     if not microseconds:
         datetime_str = datetime_str.split('.', 1)[0]
     return datetime_str
-
-

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -66,40 +66,6 @@ StudySessionInfo = namedtuple(
 )
 
 
-class TempDirs(object):
-    """A helper to centralize handling and cleanup of dirs"""
-
-    def __init__(self):
-        self.dirs = []
-        self.exists = op.exists
-        self.lgr = logging.getLogger('tempdirs')
-
-    def __call__(self, prefix=None):
-        tmpdir = tempfile.mkdtemp(prefix=prefix)
-        self.dirs.append(tmpdir)
-        return tmpdir
-
-    def __del__(self):
-        try:
-            self.cleanup()
-        except AttributeError:
-            pass
-
-    def cleanup(self):
-        self.lgr.debug("Removing %d temporary directories", len(self.dirs))
-        for t in self.dirs[:]:
-            self.lgr.debug("Removing %s", t)
-            if self:
-                self.rmtree(t)
-        self.dirs = []
-
-    def rmtree(self, tmpdir):
-        if self.exists(tmpdir):
-            shutil.rmtree(tmpdir)
-        if tmpdir in self.dirs:
-            self.dirs.remove(tmpdir)
-
-
 def docstring_parameter(*sub):
     """ Borrowed from https://stackoverflow.com/a/10308363/6145776 """
     def dec(obj):
@@ -181,7 +147,7 @@ def load_json(filename):
         raise
 
     return data
-    
+
 
 def assure_no_file_exists(path):
     """Check if file or symlink (git-annex?) exists, and if so -- remove"""
@@ -413,19 +379,6 @@ def is_readonly(path):
     return not bool(perms & ALL_CAN_WRITE)
 
 
-def clear_temp_dicoms(item_dicoms):
-    """Ensures DICOM temporary directories are safely cleared"""
-    try:
-        tmp = Path(op.commonprefix(item_dicoms)).parents[1]
-    except IndexError:
-        return
-    if (str(tmp.parent) == tempfile.gettempdir()
-        and str(tmp.stem).startswith('heudiconvDCM')
-        and op.exists(str(tmp))):
-        # clean up directory holding dicoms
-        shutil.rmtree(str(tmp))
-
-
 def file_md5sum(filename):
     with open(filename, 'rb') as f:
         return hashlib.md5(f.read()).hexdigest()
@@ -536,3 +489,5 @@ def get_datetime(date, time, *, microseconds=True):
     if not microseconds:
         datetime_str = datetime_str.split('.', 1)[0]
     return datetime_str
+
+


### PR DESCRIPTION
Spawned while fiddling with #462.

This config module improves accessibility of arguments across the various modules of the heudiconv workflow. Since `heudiconv` started as a single, massive script, the implementation favored run-level access to all / most variables.

During this "enh-factor", the legacy ``TempDirs`` class was removed, and most temporary directories were changed into
``tempfile.TemporaryDirectory`` instances, with the exception being the tmpdir housing the extracted tarball files. This is tracked directly by the config class, and should catch any leaked directories from lingering past heudiconv's execution.

P.S. - We are in desperate need of standardizing the coding style here - if/when this is and any other almost-ready PRs are merged, I'm inclined to run an autolinter (preferably `black`) and give the codebase some needed love.