### PR TITLE
URI formatting of the default "TODO" value for "CogAtlasID"

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -172,7 +172,7 @@ def populate_aggregated_jsons(path):
         placeholders = {
             "TaskName": ("TODO: full task name for %s" %
                          task_acq.split('_')[0].split('-')[1]),
-            "CogAtlasID": "doi:TODO",
+            "CogAtlasID": "http://www.cognitiveatlas.org/task/id/TODO",
         }
         if op.lexists(task_file):
             j = load_json(task_file)

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -172,7 +172,7 @@ def populate_aggregated_jsons(path):
         placeholders = {
             "TaskName": ("TODO: full task name for %s" %
                          task_acq.split('_')[0].split('-')[1]),
-            "CogAtlasID": "TODO",
+            "CogAtlasID": "doi:TODO",
         }
         if op.lexists(task_file):
             j = load_json(task_file)


### PR DESCRIPTION
BIDS [specifies](https://bids-specification.readthedocs.io/en/v1.4.1/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#fmri-task-information) that the `"CogAtlasID"` should be a [URI](https://bids-specification.readthedocs.io/en/v1.4.1/02-common-principles.html#uniform-resource-indicator).

Fixes #472