### PR TITLE
ENH: Replace rec entity with part entity for complex-valued data

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -235,7 +235,7 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
 
 def update_complex_name(metadata, filename, suffix):
     """
-    Insert `_rec-<magnitude|phase>` entity into filename if data are from a
+    Insert `_part-<mag|phase>` entity into filename if data are from a
     sequence with magnitude/phase part.
 
     Parameters
@@ -254,7 +254,10 @@ def update_complex_name(metadata, filename, suffix):
         Updated filename with rec entity added in appropriate position.
     """
     # Some scans separate magnitude/phase differently
-    unsupported_types = ['_bold', '_phase',
+    # A small note: _phase is deprecated, but this may add part-mag to
+    # magnitude data while leaving phase data with a separate suffix,
+    # depending on how one sets up their heuristic.
+    unsupported_types = ['_phase',
                          '_magnitude', '_magnitude1', '_magnitude2',
                          '_phasediff', '_phase1', '_phase2']
     if any(ut in filename for ut in unsupported_types):
@@ -262,7 +265,7 @@ def update_complex_name(metadata, filename, suffix):
 
     # Check to see if it is magnitude or phase part:
     if 'M' in metadata.get('ImageType'):
-        mag_or_phase = 'magnitude'
+        mag_or_phase = 'mag'
     elif 'P' in metadata.get('ImageType'):
         mag_or_phase = 'phase'
     else:
@@ -272,19 +275,19 @@ def update_complex_name(metadata, filename, suffix):
     filetype = '_' + filename.split('_')[-1]
 
     # Insert rec label
-    if not ('_rec-%s' % mag_or_phase) in filename:
-        # If "_rec-" is specified, prepend the 'mag_or_phase' value.
-        if '_rec-' in filename:
+    if not ('_part-%s' % mag_or_phase) in filename:
+        # If "_part-" is specified, prepend the 'mag_or_phase' value.
+        if '_part-' in filename:
             raise BIDSError(
-                "Reconstruction label for images will be automatically set, "
+                "Part label for images will be automatically set, "
                 "remove from heuristic"
             )
 
         # Insert it **before** the following string(s), whichever appears first.
-        for label in ['_dir', '_run', '_mod', '_echo', '_recording', '_proc', '_space', filetype]:
+        for label in ['_recording', '_proc', '_space', filetype]:
             if (label == filetype) or (label in filename):
                 filename = filename.replace(
-                    label, "_rec-%s%s" % (mag_or_phase, label)
+                    label, "_part-%s%s" % (mag_or_phase, label)
                 )
                 break
 

--- a/heudiconv/tests/test_convert.py
+++ b/heudiconv/tests/test_convert.py
@@ -16,7 +16,7 @@ def test_update_complex_name():
     fn = 'sub-X_ses-Y_task-Z_run-01_sbref'
     metadata = {'ImageType': ['ORIGINAL', 'PRIMARY', 'P', 'MB', 'TE3', 'ND', 'MOSAIC']}
     suffix = 3
-    out_fn_true = 'sub-X_ses-Y_task-Z_rec-phase_run-01_sbref'
+    out_fn_true = 'sub-X_ses-Y_task-Z_run-01_part-phase_sbref'
     out_fn_test = update_complex_name(metadata, fn, suffix)
     assert out_fn_test == out_fn_true
     # Catch an unsupported type and *do not* update
@@ -26,12 +26,12 @@ def test_update_complex_name():
     # Data type is missing from metadata so use suffix
     fn = 'sub-X_ses-Y_task-Z_run-01_sbref'
     metadata = {'ImageType': ['ORIGINAL', 'PRIMARY', 'MB', 'TE3', 'ND', 'MOSAIC']}
-    out_fn_true = 'sub-X_ses-Y_task-Z_rec-3_run-01_sbref'
+    out_fn_true = 'sub-X_ses-Y_task-Z_run-01_rec-3_sbref'
     out_fn_test = update_complex_name(metadata, fn, suffix)
     assert out_fn_test == out_fn_true
     # Catch existing field with value that *does not match* metadata
     # and raise Exception
-    fn = 'sub-X_ses-Y_task-Z_rec-magnitude_run-01_sbref'
+    fn = 'sub-X_ses-Y_task-Z_run-01_rec-mag_sbref'
     metadata = {'ImageType': ['ORIGINAL', 'PRIMARY', 'P', 'MB', 'TE3', 'ND', 'MOSAIC']}
     suffix = 3
     with pytest.raises(BIDSError):

--- a/heudiconv/tests/test_convert.py
+++ b/heudiconv/tests/test_convert.py
@@ -10,7 +10,7 @@ from heudiconv.bids import BIDSError
 
 def test_update_complex_name():
     """Unit testing for heudiconv.convert.update_complex_name(), which updates
-    filenames with the rec field if appropriate.
+    filenames with the part field if appropriate.
     """
     # Standard name update
     fn = 'sub-X_ses-Y_task-Z_run-01_sbref'
@@ -26,12 +26,12 @@ def test_update_complex_name():
     # Data type is missing from metadata so use suffix
     fn = 'sub-X_ses-Y_task-Z_run-01_sbref'
     metadata = {'ImageType': ['ORIGINAL', 'PRIMARY', 'MB', 'TE3', 'ND', 'MOSAIC']}
-    out_fn_true = 'sub-X_ses-Y_task-Z_run-01_rec-3_sbref'
+    out_fn_true = 'sub-X_ses-Y_task-Z_run-01_part-3_sbref'
     out_fn_test = update_complex_name(metadata, fn, suffix)
     assert out_fn_test == out_fn_true
     # Catch existing field with value that *does not match* metadata
     # and raise Exception
-    fn = 'sub-X_ses-Y_task-Z_run-01_rec-mag_sbref'
+    fn = 'sub-X_ses-Y_task-Z_run-01_part-mag_sbref'
     metadata = {'ImageType': ['ORIGINAL', 'PRIMARY', 'P', 'MB', 'TE3', 'ND', 'MOSAIC']}
     suffix = 3
     with pytest.raises(BIDSError):


### PR DESCRIPTION
Closes #476.

Changes proposed:

- Replace `rec-<magnitude|phase>` with `part-<mag|phase>` now that BIDS supports the `part` entity.
- Update associated test.