### PR TITLE
BF: boost minimal require nipype to 1.2.3 to address missing bval/bvec values issue

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -23,7 +23,7 @@ PYTHON_REQUIRES = ">=3.5"
 REQUIRES = [
     'nibabel',
     'pydicom',
-    'nipype >=1.0.0',
+    'nipype >=1.2.3',
     'dcmstack>=0.8',
     'etelemetry',
     'filelock>=3.0.12',


### PR DESCRIPTION
Closes #38