### PR TITLE
BF: split prefix into path (if any) and provide only basename as prefix for dcm2niix invocation

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -614,7 +614,11 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids_options, tmpdir, dcmconf
     convertnode = Node(Dcm2niix(from_file=fromfile), name='convert')
     convertnode.base_dir = tmpdir
     convertnode.inputs.source_names = item_dicoms
-    convertnode.inputs.out_filename = prefix
+    convertnode.inputs.out_filename = op.basename(prefix)
+    prefix_dir = op.dirname(prefix)
+    # if provided prefix had a path in it -- pass is as output_dir instead of default curdir
+    if prefix_dir:
+        convertnode.inputs.output_dir = prefix_dir
 
     if nipype.__version__.split('.')[0] == '0':
         # deprecated since 1.0, might be needed(?) before

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -5,6 +5,7 @@ import logging
 from math import nan
 import shutil
 import sys
+import random
 import re
 
 from .due import due, Doi
@@ -16,6 +17,7 @@ from .utils import (
     write_config,
     TempDirs,
     safe_copyfile,
+    safe_movefile,
     treat_infofile,
     set_readonly,
     clear_temp_dicoms,
@@ -614,7 +616,7 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids_options, tmpdir, dcmconf
     convertnode = Node(Dcm2niix(from_file=fromfile), name='convert')
     convertnode.base_dir = tmpdir
     convertnode.inputs.source_names = item_dicoms
-    convertnode.inputs.out_filename = op.basename(prefix)
+    convertnode.inputs.out_filename = op.basename(prefix) + "_heudiconv%03d" % random.randint(0, 999)
     prefix_dir = op.dirname(prefix)
     # if provided prefix had a path in it -- pass is as output_dir instead of default curdir
     if prefix_dir:
@@ -631,7 +633,7 @@ def nipype_convert(item_dicoms, prefix, with_prov, bids_options, tmpdir, dcmconf
     # prov information
     prov_file = prefix + '_prov.ttl' if with_prov else None
     if prov_file:
-        safe_copyfile(op.join(convertnode.base_dir,
+        safe_movefile(op.join(convertnode.base_dir,
                               convertnode.name,
                               'provenance.ttl'),
                       prov_file)
@@ -673,8 +675,8 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
 
     if isdefined(res.outputs.bvecs) and isdefined(res.outputs.bvals):
         outname_bvecs, outname_bvals = prefix + '.bvec', prefix + '.bval'
-        safe_copyfile(res.outputs.bvecs, outname_bvecs, overwrite)
-        safe_copyfile(res.outputs.bvals, outname_bvals, overwrite)
+        safe_movefile(res.outputs.bvecs, outname_bvecs, overwrite)
+        safe_movefile(res.outputs.bvals, outname_bvals, overwrite)
 
     if isinstance(res_files, list):
         res_files = sorted(res_files)
@@ -758,19 +760,19 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
             outfile = outname + '.' + outtype
 
             # Write the files needed:
-            safe_copyfile(fl, outfile, overwrite)
+            safe_movefile(fl, outfile, overwrite)
             if bids_file:
                 outname_bids_file = "%s.json" % (outname)
-                safe_copyfile(bids_file, outname_bids_file, overwrite)
+                safe_movefile(bids_file, outname_bids_file, overwrite)
                 bids_outfiles.append(outname_bids_file)
 
     # res_files is not a list
     else:
         outname = "{}.{}".format(prefix, outtype)
-        safe_copyfile(res_files, outname, overwrite)
+        safe_movefile(res_files, outname, overwrite)
         if isdefined(res.outputs.bids):
             try:
-                safe_copyfile(res.outputs.bids, outname_bids, overwrite)
+                safe_movefile(res.outputs.bids, outname_bids, overwrite)
                 bids_outfiles.append(outname_bids)
             except TypeError as exc:  ##catch lists
                 raise TypeError("Multiple BIDS sidecars detected.")

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 import os
 import os.path as op
@@ -13,9 +14,13 @@ from .dicoms import group_dicoms_into_seqinfos
 from .utils import (
     docstring_parameter,
     StudySessionInfo,
+    TempDirs,
 )
 
 lgr = logging.getLogger(__name__)
+tempdirs = TempDirs()
+# Ensure they are cleaned up upon exit
+atexit.register(tempdirs.cleanup)
 
 _VCS_REGEX = '%s\.(?:git|gitattributes|svn|bzr|hg)(?:%s|$)' % (op.sep, op.sep)
 
@@ -66,7 +71,7 @@ def get_extracted_dicoms(fl):
     # of all files in all tarballs
 
     # cannot use TempDirs since will trigger cleanup with __del__
-    tmpdir = mkdtemp(prefix='heudiconvDCM')
+    tmpdir = tempdirs('heudiconvDCM')
 
     sessions = defaultdict(list)
     session = 0

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -358,6 +358,9 @@ def safe_copyfile(src, dest, overwrite=False):
     """
     if op.isdir(dest):
         dest = op.join(dest, op.basename(src))
+    if op.realpath(src) == op.realpath(dest):
+        lgr.debug("Source %s = destination %s", src, dest)
+        return
     if op.lexists(dest):
         if not overwrite:
             raise RuntimeError(

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -379,7 +379,7 @@ def _safe_op_file(src, dest, operation, overwrite=False):
         if not overwrite:
             raise RuntimeError(
                 "was asked to %s %s but destination already exists: %s"
-                % (src, operation, dest)
+                % (operation, src, dest)
             )
         os.unlink(dest)
     getattr(shutil, operation)(src, dest)

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -354,7 +354,21 @@ def get_known_heuristics_with_descriptions():
 
 
 def safe_copyfile(src, dest, overwrite=False):
-    """Copy file but blow if destination name already exists
+    """Copy file but blow if destination name already exists"""
+    return _safe_op_file(src, dest, "copyfile", overwrite=overwrite)
+
+
+def safe_movefile(src, dest, overwrite=False):
+    """Move file but blow if destination name already exists"""
+    return _safe_op_file(src, dest, "move", overwrite=overwrite)
+
+
+def _safe_op_file(src, dest, operation, overwrite=False):
+    """Copy or move file but blow if destination name already exists
+
+    Parameters
+    ----------
+    operation: str, {copyfile, move}
     """
     if op.isdir(dest):
         dest = op.join(dest, op.basename(src))
@@ -364,11 +378,11 @@ def safe_copyfile(src, dest, overwrite=False):
     if op.lexists(dest):
         if not overwrite:
             raise RuntimeError(
-                "was asked to copy %s but destination already exists: %s"
-                % (src, dest)
+                "was asked to %s %s but destination already exists: %s"
+                % (src, operation, dest)
             )
         os.unlink(dest)
-    shutil.copyfile(src, dest)
+    getattr(shutil, operation)(src, dest)
 
 
 # Globals to check filewriting permissions


### PR DESCRIPTION
dcm2niix started to segfault whenever -f is too long https://github.com/rordenlab/dcm2niix/issues/465 .
And it feels that we abused -f wherever -o should have been used.
I have not looked though through history of changes if such use of -f
was warranted, but as I see that output_dir is not explicitly defined,
decided to just use that one instead.

Initial commit  resolved the dcm2niix segfault during heudiconv/tests/test_heuristics.py::test_scans_keys_reproin
when testing on my laptop, BUT resulted in test failures since now placing the files in the output directory copying to destination was not working since it was destination.  I added conditional in `safe_copyfile` (0f6abbf) but that was not sufficient and also made me wonder -- if placing already at the destination (or near) why don't we move instead of copying?  That would also resolve #481 and make heudiconv more robust IMHO in cases where `/tmp` has smaller capacity than the destination.  

The only negative side-effect might be that the target directory, in case of abnormal heudiconv operation, would have those `_heudiXXX` files.  I could present it as a feature which would ease troubleshooting etc ;)

So I followed up with 8b4b7a0 where I have also added a random suffix to the target suffix given to nipype's dcm2niix call.  **This is the most radical change** in this PR which might introduce some bugs if we are not moving/renaming files properly.  But looking at the code we seems to be doing all needed, and then

```shell
$> find pytest-of-yoh -iname *_heudi*
pytest-of-yoh/pytest-0/test_embed_dicom_and_nifti_met0/nifti_heudiconv222.nii.gz
```
as in that explicit test we do not bother renaming etc, whenever all the other files in there seems to look good.  So I have good confindence that we should be ok.

then while at it I followed up with 7ad241c17967f18f33edb4c9109e25be3b87238e which should address #462 .

TODO
- [x] ensure passes existing tests
- [x] add to description since it grew bigger/more radical
- [x] seek feedback (due to dcm2niix change in behavior/limits for `-f` we need it fast though https://github.com/rordenlab/dcm2niix/issues/465 so I will be merging/releasing as soon as I am satisfied)

edit: additional benefit
- by placing into target directory right away we would not loose some files nipype or us forgot to move (like we had with DWI .bvec) -- they just will have an odd suffix.  I like it