### PR TITLE
ENH: Adds "AcquisitionTime" to the `seqinfo`

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -89,8 +89,8 @@ def create_seqinfo(mw, series_files, series_id):
         patient_age=dcminfo.get('PatientAge'),
         patient_sex=dcminfo.get('PatientSex'),
         date=dcminfo.get('AcquisitionDate'),
+        series_uid=dcminfo.get('SeriesInstanceUID'),
         time=dcminfo.get('AcquisitionTime'),
-        series_uid=dcminfo.get('SeriesInstanceUID')
     )
     return seqinfo
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -89,6 +89,7 @@ def create_seqinfo(mw, series_files, series_id):
         patient_age=dcminfo.get('PatientAge'),
         patient_sex=dcminfo.get('PatientSex'),
         date=dcminfo.get('AcquisitionDate'),
+        time=dcminfo.get('AcquisitionTime'),
         series_uid=dcminfo.get('SeriesInstanceUID')
     )
     return seqinfo

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -283,6 +283,11 @@ def test_cache(tmpdir):
     assert (cachedir / 'S01.auto.txt').exists()
     assert (cachedir / 'S01.edit.txt').exists()
 
+    # check dicominfo has "time" as last column:
+    with open(cachedir / 'dicominfo.tsv', 'r') as f:
+        cols = f.readline().split()
+    assert cols[26] == "time"
+
 
 def test_no_etelemetry():
     # smoke test at large - just verifying that no crash if no etelemetry

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -284,7 +284,7 @@ def test_cache(tmpdir):
     assert (cachedir / 'S01.edit.txt').exists()
 
     # check dicominfo has "time" as last column:
-    with open(cachedir / 'dicominfo.tsv', 'r') as f:
+    with open(str(cachedir / 'dicominfo.tsv'), 'r') as f:
         cols = f.readline().split()
     assert cols[26] == "time"
 

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -45,9 +45,9 @@ seqinfo_fields = [
     'patient_age',           # 22
     'patient_sex',           # 23
     'date',                  # 24
-    'time',                  # 25
-    'series_uid',            # 26
- ]
+    'series_uid',            # 25
+    'time',                  # 26
+]
 
 SeqInfo = namedtuple('SeqInfo', seqinfo_fields)
 

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -45,7 +45,8 @@ seqinfo_fields = [
     'patient_age',           # 22
     'patient_sex',           # 23
     'date',                  # 24
-    'series_uid',            # 25
+    'time',                  # 25
+    'series_uid',            # 26
  ]
 
 SeqInfo = namedtuple('SeqInfo', seqinfo_fields)


### PR DESCRIPTION
This commit adds the `"AcquisitionTime"` to the `seqinfo`, so that it is available for the heuristic classification.

**Use case:**
At least for Siemens scanners, for anatomical images (MPRAGE, TSE), when you select the images to be normalized (i.e., corrected for coil sensitivity bias), it allows the user to also save the original images, as a separated series. 

If that is selected, we will have two series of DICOM files corresponding to the same run, with the only difference being the intensity normalization. If we were to extract both series in a BIDS compliant way, we should probably use the label `rec-` to distinguish between them (e.g., `rec-normalized` vs. `rec-original`).

However, it seems like most BIDS Apps (e.g., [MRIQC](mriqc.readthedocs.io) and [fMRIPrep](fmriprep.org)) process all `T1w` and `T2w` images in the `anat` folder as if they were different images to be processed. For example, fMRIPrep averages all T1w/T2w images and then does the cortical segmentation. If we were to have normalized/original pairs of images as two different BIDS files, this will be a problem.

To avoid this situation, our heuristic file could save only one of the image types (say, the normalized). However, if the user chose not to normalize the images, no BIDS files would be extracted.

By adding the `"AcquisitionTime"` to the `seqinfo`, one can write a heuristic file that checks if two series have the same acquisition time and, if one has `NORM` in the `image_type` but the other doesn't, conclude that they come from the same run and decide accordingly. (In [my case](https://github.com/cbinyu/heudiconv/blob/6230f1419b251ec42bcc2e16c2b61dfe05afb257/heudiconv/heuristics/cbi_heuristic_simple.py#L331), I only save the normalized image in the subject's BIDS folder, while keeping both images in the `sourcedata`, for backup.)  If only one type of images is present for a given run, it is saved. So, no matter what the normalization of the images is, we would have only one NIfTI file per run in the BIDS output (well, unless there are more than one `part-` or `echo-`).