### PR TITLE
ENH+BF: find_files to take list of topdirs, look for _bold only under  sub-* directories

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -114,7 +114,8 @@ def populate_aggregated_jsons(path):
     # way too many -- let's just collect all which are the same!
     # FIELDS_TO_TRACK = {'RepetitionTime', 'FlipAngle', 'EchoTime',
     #                    'Manufacturer', 'SliceTiming', ''}
-    for fpath in find_files('.*_task-.*\_bold\.json', topdir=path,
+    for fpath in find_files('.*_task-.*\_bold\.json',
+                            topdir=glob(op.join(path, 'sub-*')),
                             exclude_vcs=True,
                             exclude="/\.(datalad|heudiconv)/"):
         #

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -24,6 +24,7 @@ atexit.register(tempdirs.cleanup)
 
 _VCS_REGEX = '%s\.(?:git|gitattributes|svn|bzr|hg)(?:%s|$)' % (op.sep, op.sep)
 
+
 @docstring_parameter(_VCS_REGEX)
 def find_files(regex, topdir=op.curdir, exclude=None,
                exclude_vcs=True, dirs=False):
@@ -36,12 +37,16 @@ def find_files(regex, topdir=op.curdir, exclude=None,
     exclude_vcs:
       If True, excludes commonly known VCS subdirectories.  If string, used
       as regex to exclude those files (regex: `{}`)
-    topdir: basestring, optional
+    topdir: basestring or list, optional
       Directory where to search
     dirs: bool, optional
       Either to match directories as well as files
     """
-
+    if isinstance(topdir, (list, tuple)):
+        for topdir_ in topdir:
+            yield from find_files(
+                regex, topdir=topdir_, exclude=exclude, exclude_vcs=exclude_vcs, dirs=dirs)
+        return
     for dirpath, dirnames, filenames in os.walk(topdir):
         names = (dirnames + filenames) if dirs else filenames
         paths = (op.join(dirpath, name) for name in names)


### PR DESCRIPTION
Originally issue reported on
https://neurostars.org/t/heudicov-permission-denied-bids-derivatives-mriqc/16543
where heudiconv would crash while trying to create an _events.tsv file under derivatives/mriqc.

heudiconv should not care to look anywhere besides immediate subject directories, even if people
place derivatives direcly in the dataset into which they are also converting their data into
(making YODA unhappy).

TODOs
- [ ] verify on a sample case that there is no side effect (not sure if I would be up for composing a test)