### PR TITLE
BF: Don't fail if etelemetry.get_project returns None

### DIFF
--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -252,16 +252,16 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
 
     outdir = op.abspath(outdir)
 
+    latest = None
     try:
         import etelemetry
         latest = etelemetry.get_project("nipy/heudiconv")
     except Exception as e:
         lgr.warning("Could not check for version updates: %s", str(e))
-        latest = {"version": 'Unknown'}
 
     lgr.info(INIT_MSG(packname=__packagename__,
                       version=__version__,
-                      latest=latest["version"]))
+                      latest=(latest or {}).get("version", "Unknown")))
 
     if command:
         process_extra_commands(outdir, command, files, dicom_dir_template,


### PR DESCRIPTION
main.workflow() crashes with a TypeError when logging the latest
version if "NO_ET" is in os.environ because etelemetry.get_project()
returns None.  Guard against this failure as well the KeyError that
would be triggered if get_project(), for whatever reason, returns a
dictionary without a "version" key.