### PR TITLE
RF/ENH: populate a singular scans.json at the top level of the bids dataset

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -18,7 +18,7 @@ from .utils import (
     load_json,
     save_json,
     create_file_if_missing,
-    json_dumps_pretty,
+    json_dumps,
     set_readonly,
     is_readonly,
     get_datetime,
@@ -120,6 +120,9 @@ def populate_bids_templates(path, defaults={}):
     create_file_if_missing(op.join(path, 'README'),
         "TODO: Provide description for the dataset -- basic details about the "
         "study, possibly pointing to pre-registration (if public or embargoed)")
+    create_file_if_missing(op.join(path, 'scans.json'),
+        json_dumps(SCANS_FILE_FIELDS, sort_keys=False)
+    )
 
     populate_aggregated_jsons(path)
 
@@ -404,11 +407,6 @@ def add_rows_to_scans_keys_file(fn, newrows):
         os.unlink(fn)
     else:
         fnames2info = newrows
-        # Populate _scans.json (an optional file to describe column names in
-        # _scans.tsv). This auto generation will make BIDS-validator happy.
-        scans_json = '.'.join(fn.split('.')[:-1] + ['json'])
-        if not op.lexists(scans_json):
-            save_json(scans_json, SCANS_FILE_FIELDS, sort_keys=False)
 
     header = SCANS_FILE_FIELDS
     # prepare all the data rows

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -4,13 +4,16 @@ from heudiconv.cli.run import main as runner
 from heudiconv.main import workflow
 from heudiconv import __version__
 from heudiconv.utils import (create_file_if_missing,
+                             load_json,
                              set_readonly,
                              is_readonly)
 from heudiconv.bids import (populate_bids_templates,
                             add_participant_record,
                             get_formatted_scans_key_row,
                             add_rows_to_scans_keys_file,
-                            find_subj_ses)
+                            find_subj_ses,
+                            SCANS_FILE_FIELDS,
+                            )
 from heudiconv.external.dlad import MIN_VERSION, add_to_datalad
 
 from .utils import TESTS_DATA_PATH
@@ -81,6 +84,8 @@ def test_populate_bids_templates(tmpdir):
     assert "something" not in description_file.read()
     assert "TODO" in description_file.read()
 
+    assert load_json(tmpdir / "scans.json") == SCANS_FILE_FIELDS
+
 
 def test_add_participant_record(tmpdir):
     tf = tmpdir.join('participants.tsv')
@@ -127,6 +132,7 @@ def test_prepare_for_datalad(tmpdir):
         '.gitattributes',
         '.datalad/config', '.datalad/.gitattributes',
         'dataset_description.json',
+        'scans.json',
         'CHANGES', 'README'}
     assert set(ds.repo.get_indexed_files()) == target_files
     # and all are under git
@@ -217,7 +223,9 @@ def test_add_rows_to_scans_keys_file(tmpdir):
         assert dates == sorted(dates)
 
     _check_rows(fn, rows)
-    assert op.exists(opj(tmpdir.strpath, 'file.json'))
+    # we no longer produce a sidecar .json file there and only generate
+    # it while populating templates for BIDS
+    assert not op.exists(opj(tmpdir.strpath, 'file.json'))
     # add a new one
     extra_rows = {
         'a_new_file.nii.gz': ['2016adsfasd23', '', 'fasadfasdf'],

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -84,7 +84,8 @@ def test_populate_bids_templates(tmpdir):
     assert "something" not in description_file.read()
     assert "TODO" in description_file.read()
 
-    assert load_json(tmpdir / "scans.json") == SCANS_FILE_FIELDS
+    # Explicit str() is needed for py 3.5. TODO: remove when dropping 3.5
+    assert load_json(str(tmpdir / "scans.json")) == SCANS_FILE_FIELDS
 
 
 def test_add_participant_record(tmpdir):


### PR DESCRIPTION
instead of exactly the same .json alongside every `_scans.tsv`.  See the 2nd commit (https://github.com/nipy/heudiconv/commit/864da69a3b1acc875da2429290984126dad34b18) for more motivation etc.

While at it also RF'ed `_canonical_dump` into a tiny `json_dumps`

causes only minor merge conflict for #482 