### PR TITLE
FIX: Lingering temporary directories

### DIFF
--- a/heudiconv/__init__.py
+++ b/heudiconv/__init__.py
@@ -10,3 +10,20 @@ logging.basicConfig(
     level=getattr(logging, os.environ.get('HEUDICONV_LOG_LEVEL', 'INFO'))
 )
 lgr.debug("Starting the abomination")  # just to "run-test" logging
+
+try:
+    tmpdirs
+except NameError:
+    import atexit
+    tmpdirs = set()
+
+    def _clean_tmpdirs():
+        """Cleanup tracked temporary directories"""
+    import shutil
+
+    for tmpdir in tmpdirs:
+        try:
+            shutil.rmtree(tmpdir)
+        except FileNotFoundError:
+            pass
+    atexit.register(_clean_tmpdirs)

--- a/heudiconv/__init__.py
+++ b/heudiconv/__init__.py
@@ -10,20 +10,3 @@ logging.basicConfig(
     level=getattr(logging, os.environ.get('HEUDICONV_LOG_LEVEL', 'INFO'))
 )
 lgr.debug("Starting the abomination")  # just to "run-test" logging
-
-try:
-    tmpdirs
-except NameError:
-    import atexit
-    tmpdirs = set()
-
-    def _clean_tmpdirs():
-        """Cleanup tracked temporary directories"""
-    import shutil
-
-    for tmpdir in tmpdirs:
-        try:
-            shutil.rmtree(tmpdir)
-        except FileNotFoundError:
-            pass
-    atexit.register(_clean_tmpdirs)

--- a/heudiconv/_tmpdirs.py
+++ b/heudiconv/_tmpdirs.py
@@ -1,0 +1,30 @@
+import logging
+import tempfile
+
+
+class TempDirs:
+    """A helper to centralize handling and cleanup of dirs"""
+
+    dirs = set()
+    lgr = logging.getLogger('heudiconv.tempdirs')
+
+    def __init__(self):
+        import atexit
+        atexit.register(self.cleanup)
+
+    def add_tmpdir(self, prefix=None):
+        tmpdir = tempfile.mkdtemp(prefix=prefix)
+        self.dirs.add(tmpdir)
+        return tmpdir
+
+    def cleanup(self):
+        """Cleanup tracked temporary directories"""
+        import shutil
+
+        for tmpdir in self.dirs:
+            try:
+                shutil.rmtree(tmpdir)
+            except FileNotFoundError:
+                pass
+
+tmpdirs = TempDirs()

--- a/heudiconv/_tmpdirs.py
+++ b/heudiconv/_tmpdirs.py
@@ -21,10 +21,13 @@ class TempDirs:
         """Cleanup tracked temporary directories"""
         import shutil
 
+        self.lgr.debug("Removing %d temporary directories", len(self.dirs))
         for tmpdir in self.dirs:
             try:
+                self.lgr.debug("Removing %s", tmpdir)
                 shutil.rmtree(tmpdir)
             except FileNotFoundError:
                 pass
+
 
 tmpdirs = TempDirs()

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -464,7 +464,7 @@ def convert(items, converter, scaninfo_suffix, custom_callable, with_prov,
                                      prefix + scaninfo_suffix)
 
                 if not op.exists(outname) or overwrite:
-                    with tempfile.TemporaryDirectory(prefix='dcm2niix') as tmpdir:
+                    with tempfile.TemporaryDirectory(prefix='heudiconv-dcm2niix') as tmpdir:
 
                         # run conversion through nipype
                         res, prov_file = nipype_convert(

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -371,7 +371,7 @@ def compress_dicoms(dicom_list, out_prefix, overwrite):
         return ti
 
     # poor man mocking since can't rely on having mock
-    with tempfile.TemporaryDirectory(prefix='dicomtar') as tmpdir:
+    with tempfile.TemporaryDirectory(prefix='heudiconv-dicomtar') as tmpdir:
         try:
             import time
             _old_time = time.time
@@ -476,7 +476,7 @@ def embed_metadata_from_dicoms(bids_options, item_dicoms, outname, outname_bids,
     # We need to assure that paths are absolute if they are relative
     item_dicoms = list(map(op.abspath, item_dicoms))
 
-    with tempfile.TemporaryDirectory(prefix='embedmeta') as tmpdir:
+    with tempfile.TemporaryDirectory(prefix='heudiconv-embedmeta') as tmpdir:
         embedfunc = Node(Function(input_names=['dcmfiles', 'niftifile', 'infofile',
                                             'bids_info',],
                                 function=embed_dicom_and_nifti_metadata),

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -370,5 +370,6 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
     #
     # TODO: record_collection of the sid/session although that information
     # is pretty much present in .heudiconv/SUBJECT/info so we could just poke there
-    from ._tmpdirs import tmpdirs
-    tmpdirs.cleanup()
+    if not debug:
+        from ._tmpdirs import tmpdirs
+        tmpdirs.cleanup()

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -370,3 +370,5 @@ def workflow(*, dicom_dir_template=None, files=None, subjs=None,
     #
     # TODO: record_collection of the sid/session although that information
     # is pretty much present in .heudiconv/SUBJECT/info so we could just poke there
+    from ._tmpdirs import tmpdirs
+    tmpdirs.cleanup()

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -72,7 +72,7 @@ def get_extracted_dicoms(fl):
     # of all files in all tarballs
 
     from ._tmpdirs import tmpdirs
-    tmpdir = tmpdirs.add_tmpdir(prefix="heudiconvDCM")
+    tmpdir = tmpdirs.add_tmpdir(prefix="heudiconv-DCM")
 
     sessions = defaultdict(list)
     session = 0

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -14,13 +14,9 @@ from .dicoms import group_dicoms_into_seqinfos
 from .utils import (
     docstring_parameter,
     StudySessionInfo,
-    TempDirs,
 )
 
 lgr = logging.getLogger(__name__)
-tempdirs = TempDirs()
-# Ensure they are cleaned up upon exit
-atexit.register(tempdirs.cleanup)
 
 _VCS_REGEX = '%s\.(?:git|gitattributes|svn|bzr|hg)(?:%s|$)' % (op.sep, op.sep)
 
@@ -75,8 +71,8 @@ def get_extracted_dicoms(fl):
     # strategy: extract everything in a temp dir and assemble a list
     # of all files in all tarballs
 
-    # cannot use TempDirs since will trigger cleanup with __del__
-    tmpdir = tempdirs('heudiconvDCM')
+    from ._tmpdirs import tmpdirs
+    tmpdir = tmpdirs.add_tmpdir(prefix="heudiconvDCM")
 
     sessions = defaultdict(list)
     session = 0

--- a/heudiconv/tests/test_heuristics.py
+++ b/heudiconv/tests/test_heuristics.py
@@ -3,7 +3,9 @@ from heudiconv.cli.run import main as runner
 import os
 import os.path as op
 from mock import patch
+from pathlib import Path
 from six.moves import StringIO
+import tempfile
 
 from glob import glob
 from os.path import join as pjoin, dirname
@@ -35,6 +37,9 @@ def test_smoke_convertall(tmpdir):
 
     args.extend(['-f', 'convertall'])
     runner(args)
+
+    # ensure we are not leaving lingering temporary directories
+    assert not list(Path(tempfile.gettempdir()).glob('heudiconv*'))
 
 
 @pytest.mark.parametrize('heuristic', ['reproin', 'convertall'])

--- a/heudiconv/tests/test_tarballs.py
+++ b/heudiconv/tests/test_tarballs.py
@@ -10,7 +10,7 @@ from six.moves import StringIO
 from glob import glob
 
 from heudiconv.dicoms import compress_dicoms
-from heudiconv.utils import TempDirs, file_md5sum
+from heudiconv.utils import file_md5sum
 
 tests_datadir = opj(dirname(__file__), 'data')
 
@@ -19,7 +19,6 @@ def test_reproducibility(tmpdir):
     prefix = str(tmpdir.join("precious"))
     args = [glob(opj(tests_datadir, '01-fmap_acq-3mm', '*')),
             prefix,
-            TempDirs(),
             True]
     tarball = compress_dicoms(*args)
     md5 = file_md5sum(tarball)


### PR DESCRIPTION
This is a spin-off of #466 and a continuation of #485

After first confirming the problem with a failing test, this PR:
- Removes custom temporary directory object from various function signatures
- Replaces temporary directory creation with context managers (where possible)
- Simplifies and moves ``TempDirs`` object into a dedicated module