### PR TITLE
Travis - Use bionic for the base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # vim ft=yaml
 language: python
+dist: bionic
 python:
   - 3.6
   - 3.7


### PR DESCRIPTION
we were still using 16.04.  For that one we do not even have newer dcm2niix
in NeuroDebian: http://neuro.debian.net/pkgs/dcm2niix.html

With older version test_b0dwi_for_fmap passes (on travis) but I see it
failing locally, so want to see what happens on Travis