### PR TITLE
strip non-alphanumeric from session ids too

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -472,9 +472,8 @@ def get_formatted_scans_key_row(dcm_fn):
     row = ['n/a' if not str(e) else e for e in row]
     return row
 
-
 def convert_sid_bids(subject_id):
-    """Strips any non-BIDS compliant characters within subject_id
+    """Shim for stripping any non-BIDS compliant characters within subject_id
 
     Parameters
     ----------
@@ -487,12 +486,34 @@ def convert_sid_bids(subject_id):
     subject_id : string
         Original subject ID
     """
-    cleaner = lambda y: ''.join([x for x in y if x.isalnum()])
-    sid = cleaner(subject_id)
-    if not sid:
-        raise ValueError(
-            "Subject ID became empty after cleanup.  Please provide manually "
-            "a suitable alphanumeric subject ID")
-    lgr.warning('{0} contained nonalphanumeric character(s), subject '
-                'ID was cleaned to be {1}'.format(subject_id, sid))
+    sid, subject_id = sanitize_label(subject_id)
+    lgr.warning('Deprecation warning: convert_sid_bids() is deprecated, '
+                'please use sanitize_label() instead.')
+    
     return sid, subject_id
+
+
+def sanitize_label(label):
+    """Strips any non-BIDS compliant characters within label
+
+    Parameters
+    ----------
+    label : string
+
+    Returns
+    -------
+    clean_label : string
+        New, sanitized label
+    label : string
+        Original label
+    """
+    cleaner = lambda y: ''.join([x for x in y if x.isalnum()])
+    clean_label = cleaner(label)
+    if not clean_label:
+        raise ValueError(
+            "Label became empty after cleanup.  Please provide manually "
+            "a suitable alphanumeric label.")
+    if clean_label != label:
+        lgr.warning('{0} contained nonalphanumeric character(s), label '
+                    'was cleaned to be {1}'.format(label, clean_label))
+    return clean_label, label

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -26,7 +26,7 @@ from .utils import (
     file_md5sum
 )
 from .bids import (
-    convert_sid_bids,
+    sanitize_label,
     populate_bids_templates,
     save_scans_key,
     tuneup_bids_json_files,
@@ -102,10 +102,10 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
             raise ValueError(
                 "BIDS requires alphanumeric subject ID. Got an empty value")
         if not sid.isalnum():  # alphanumeric only
-            sid, old_sid = convert_sid_bids(sid)
+            sid, old_sid = sanitize_label(sid)
             
         if ses and not ses.isalnum():  # alphanumeric only
-            ses, old_ses = convert_sid_bids(ses)
+            ses, old_ses = sanitize_label(ses)
 
     if not anon_sid:
         anon_sid = sid

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -103,6 +103,9 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
                 "BIDS requires alphanumeric subject ID. Got an empty value")
         if not sid.isalnum():  # alphanumeric only
             sid, old_sid = convert_sid_bids(sid)
+            
+        if ses and not ses.isalnum():  # alphanumeric only
+            ses, old_ses = convert_sid_bids(ses)
 
     if not anon_sid:
         anon_sid = sid


### PR DESCRIPTION
Similar to our subject IDs, many of our session IDs have underscores as well. This causes BIDS validation to fail:

> [ERR] Ses label contain an Illegal Character hyphen or underscore. Please edit the filename as per BIDS spec. (code: 63 - SESSION_VALUE_CONTAINS_ILLEGAL_CHARACTER)

The same function in heudiconv that strips non-alphanumeric characters for subject IDs (`convert_sid_bids`) can be used for session IDs here too.