### PR TITLE
ENH: specify POPULATE_INTENDED_FOR_OPTS within reproin following the doc

### DIFF
--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -199,6 +199,10 @@ DEFAULT_FIELDS = {
         "TODO: adjust to your case.",
 }
 
+POPULATE_INTENDED_FOR_OPTS = {
+    'matching_parameters': ['ImagingVolume', 'Shims'],
+    'criterion': 'Closest'
+}
 
 def _delete_chars(from_str, deletechars):
     """ Delete characters from string allowing for Python 2 / 3 difference

--- a/heudiconv/tests/test_convert.py
+++ b/heudiconv/tests/test_convert.py
@@ -229,13 +229,14 @@ def test_populate_intended_for(tmpdir, monkeypatch, capfd,
     output = capfd.readouterr()
     # if the heuristic module has a 'POPULATE_INTENDED_FOR_OPTS' field, we expect
     # to get the output of the mock_populate_intended_for, otherwise, no output:
-    if getattr(heuristic, 'POPULATE_INTENDED_FOR_OPTS', None):
+    pif_cfg = getattr(heuristic, 'POPULATE_INTENDED_FOR_OPTS', None)
+    if pif_cfg:
         assert all([
             "\n".join([
                 "session: " + outfolder.format(sID=s, ses=sesID),
                 # "ImagingVolume" is defined in heuristic file; "Shims" is the default
-                "matching_parameters: " + "ImagingVolume",
-                "criterion: Closest"
+                f"matching_parameters: {pif_cfg['matching_parameters']}",
+                f"criterion: {pif_cfg['criterion']}"
             ]) in output.out
             for s in subjects
         ])


### PR DESCRIPTION
Just copy pasted from the doc.  I am afraid it might not work out as is for everyone, but ATM I think it is better to have it than not ;-)  I also tested locally on a sample conversion that `heudiconv --dbg -f reproin --command populate-intended-for` worked out nicely (for a single subj/sess conversion).