### PR TITLE
BF(TST): use caplog to control logging level, use python3 in shebang

### DIFF
--- a/heudiconv/tests/anonymize_script.py
+++ b/heudiconv/tests/anonymize_script.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python 
+#! /usr/bin/env python3
 
 import sys
 import re


### PR DESCRIPTION
Tests were failing for me locally since logging by default was above INFO, and
I had no python but python3.  Since we are operating in python3 realm ATM, I have
decided to just change the shebang accordingly.

Since PR is trivial, will merge it as soon as CI is happy