### PR TITLE
Run codespell on some obvious typos

### DIFF
--- a/heudiconv/cli/monitor.py
+++ b/heudiconv/cli/monitor.py
@@ -79,7 +79,7 @@ def process(paths2process, db, wait=WAIT_TIME, logdir='log'):
 
 def monitor(topdir='/tmp/new_dir', check_ptrn='/20../../..',
             db=None, wait=WAIT_TIME, logdir='log'):
-    # make logdir if not existant
+    # make logdir if not existent
     try:
         os.makedirs(logdir)
     except OSError:

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -51,7 +51,7 @@ def conversion_info(subject, outdir, info, filegroup, ses):
             continue
         template, outtype = key[0], key[1]
         # So no annotation_classes of any kind!  so if not used -- what was the
-        # intension???? XXX
+        # intention???? XXX
         outpath = outdir
         for idx, itemgroup in enumerate(items):
             if not isinstance(itemgroup, list):
@@ -131,7 +131,7 @@ def prep_conversion(sid, dicoms, outdir, heuristic, converter, anon_sid,
     # ref: https://github.com/nipy/heudiconv/issues/84#issuecomment-330048609
     # for more automagical wishes
     target_heuristic_filename = op.join(idir, 'heuristic.py')
-    # faciliates change - TODO: remove in 1.0
+    # facilitates change - TODO: remove in 1.0
     old_heuristic_filename = op.join(idir, op.basename(heuristic.filename))
     if op.exists(old_heuristic_filename):
         assure_no_file_exists(target_heuristic_filename)

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -551,7 +551,7 @@ def infotodict(seqinfo):
                                   if isinstance(current_run, int)
                                   else current_run)
         else:
-            # if there is no _run -- no run label addded
+            # if there is no _run -- no run label added
             run_label = None
 
         # yoh: had a wrong assumption

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -71,7 +71,7 @@ def get_extracted_dicoms(fl):
     #     raise ValueError("some but not all input files are tar files")
 
     # tarfiles already know what they contain, and often the filenames
-    # are unique, or at least in a unqiue subdir per session
+    # are unique, or at least in a unique subdir per session
     # strategy: extract everything in a temp dir and assemble a list
     # of all files in all tarballs
 

--- a/heudiconv/queue.py
+++ b/heudiconv/queue.py
@@ -91,7 +91,7 @@ def clean_args(hargs, iterarg, iteridx):
     is_iterarg = False
     itercount = 0
 
-    indicies = []
+    indices = []
     cmdargs = hargs[:]
 
     for i, arg in enumerate(hargs):
@@ -100,13 +100,13 @@ def clean_args(hargs, iterarg, iteridx):
             is_iterarg = False
         if is_iterarg:
             if iteridx != itercount:
-                indicies.append(i)
+                indices.append(i)
             itercount += 1
         if arg in iterarg:
             is_iterarg = True
         if arg in queue_args:
-            indicies.extend([i, i+1])
+            indices.extend([i, i+1])
 
-    for j in sorted(indicies, reverse=True):
+    for j in sorted(indices, reverse=True):
         del cmdargs[j]
     return cmdargs

--- a/heudiconv/tests/test_heuristics.py
+++ b/heudiconv/tests/test_heuristics.py
@@ -69,7 +69,7 @@ def test_reproin_largely_smoke(tmpdir, heuristic, invocation):
             runner(args + ['--subjects', 'sub1', 'sub2'])
 
         if heuristic != 'reproin':
-            # if subject is not overriden, raise error
+            # if subject is not overridden, raise error
             with pytest.raises(NotImplementedError):
                 runner(args)
             return
@@ -158,7 +158,7 @@ def test_scout_conversion(tmpdir):
     # Let's do some basic checks on produced files
     j = load_json(sespath / 'fmap/sub-phantom1sid1_ses-localizer_acq-3mm_phasediff.json')
     # We store HeuDiConv version in each produced .json file
-    # TODO: test that we are not somehow overwritting that version in existing
+    # TODO: test that we are not somehow overwriting that version in existing
     # files which we have not produced in a particular run.
     assert j[HEUDICONV_VERSION_JSON_KEY] == __version__
 


### PR DESCRIPTION
Primarily goal of this PR is to kick out a 0.11.0 release since we are already at v0.10.0-146-g0da0323 with a good number of merged PRs.  I was hoping to finish #544 but haven't yet, so another MINOR major ;) might follow not too far away. Not sure if git foo is correct but at large here are the following pull request merges (kick out low #ed since those are PRs into PRs)

```
(git)lena:~/proj/heudiconv/heudiconv-master[enh-release]git
$> git log --pretty=oneline --merges v0.10.0..origin/master | grep 'pull request' | nl
     1	0da03238898426538b54160a731809f0de6cd04b Merge pull request #558 from nipy/gh-557
     2	a1f63de34f23a3f6a2a750caaeb9631191988978 Merge pull request #547 from cbinyu/fix_echo_order_in_filename
     3	772feeba1fe87d0bc84d85a9a07ce20344ef46c2 Merge pull request #555 from dbic/rf-3.7
     4	80713f8e2a4e0f25e40eaed28cc5a9ed0c3b5ac9 Merge pull request #553 from dbic/bf-misc
     5	cb2fd912b8310d7022e9358a84c3b589fe3c07e8 Merge pull request #546 from dbic/adds_populate_intended_for
     6	e747f0595dd393384d65219f5137d42b2a5c8e73 Merge pull request #482 from cbinyu/adds_populate_intended_for
     7	92eecfe237069b1d8a6e487067c86c0d37bc0664 Merge pull request #461 from tsalo/fix/updater-lists
     8	4b23544c96c33d05f34f3c839ac12fb51974dbdc Merge pull request #13 from neurorepro/adds_populate_intended_for
     9	717f500bf4a2c2a182a9e92d02aec1a57e8dc1c8 Merge pull request #12 from neurorepro/adds_populate_intended_for
    10	3f9a504270f83d00bb483c8f52ae0c228fc7d808 Merge pull request #535 from UNFmontreal/fix/tar_unordered_files
    11	eddb35ca375978479b621d3ad34d15c93b326ef0 Merge pull request #542 from cbinyu/fix_echo_order_in_filename
    12	80a65385ef867124611d037fceac27d27e30f480 Merge pull request #534 from dbic/bf-warning-test
    13	8d85f14261025fcd7ac2382721ab008f276b715c Merge pull request #533 from dbic/rf-newer-travis
    14	2695ecf5a120fe2b84203e7ab66c67829650641f Merge pull request #529 from dbic/enh-version
    15	c4956b35b38d506a181e0f933a22819b8e687991 Merge pull request #511 from dbic/bf-anon-cmd
    16	0ecd867bb07d29a1412c15d027111f377b33bc00 Merge pull request #10 from dbic/adds_populate_intended_for
    17	141f6e9d78fe591eb2c2f74ea7f151f24b43a73d Merge pull request #34 from cbinyu/patch_dbic
    18	d3b82101c9f00ebc55b2cc0c541ced491aaae953 Merge pull request #11 from cbinyu/BIDSFile_helper
    19	7edcf3627502a0fed89bdf892f08a5e435ad63a7 Merge pull request #4 from nipy/master
```
so -- if CI is still happy -- will merge and will see if `auto` and docker building established by @jwodder would work out cleanly.