### PR TITLE
Remove .git/ from .dockerignore so that versioning works while building docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 Dockerfile
-.git/


### PR DESCRIPTION
Note: that implies that local .git/ better does not contain any sensitive data.  We should be building off github action fresh clone, should be safe AFAIK

Closes #516 
Marking for release so we get 0.11.1 with a docker image on the hub (hopefully)