### PR TITLE
BF(?): make _setter images be taken as scouts - only DICOMs are saved

### DIFF
--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -641,6 +641,8 @@ def infotodict(
             datatype == "anat"
             and datatype_suffix
             and datatype_suffix.startswith("scout")
+        ) or (
+            s.series_description.lower() == s.protocol_name.lower() + "_setter"
         ):
             outtype = ("dicom",)
         else:


### PR DESCRIPTION
Aiming to fix #40

@cookpa @tsalo -- may be such approach would be sufficient (i.e. would not cause some disturbance as e.g. not saving DICOM tarballs correctly for T1w)?  Would you be so kind to try on your data?

edit: an alternative -- completely ignore/skip them