### PR TITLE
Add support for a  custom seqinfo to extract from DICOMs any additional metadata desired for a heuristic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ You can run your conversion automatically (which will produce a ``.heudiconv`` d
 .. image:: figs/workflow.png
 
 
-``heudiconv`` comes with `existing heuristics <https://github.com/nipy/heudiconv/tree/master/heudiconv/heuristics>`_ which can be used as is, or as examples. 
+``heudiconv`` comes with `existing heuristics <https://github.com/nipy/heudiconv/tree/master/heudiconv/heuristics>`_ which can be used as is, or as examples.
 For instance, the Heuristic `convertall <https://github.com/nipy/heudiconv/blob/master/heudiconv/heuristics/convertall.py>`_ extracts standard metadata from all matching DICOMs.
 ``heudiconv`` creates mapping files, ``<something>.edit.text`` which lets researchers simply establish their own conversion mapping.
 

--- a/docs/heuristics.rst
+++ b/docs/heuristics.rst
@@ -120,7 +120,7 @@ or::
         return seqinfos  # ordered dict containing seqinfo objects: list of DICOMs
 
 ---------------------------------------------------------------
-``custom_seqinfo(series_files, wrapper)``
+``custom_seqinfo(wrapper, series_files)``
 ---------------------------------------------------------------
 If present this function will be called on each group of dicoms with
 a sample nibabel dicom wrapper to extract additional information

--- a/docs/heuristics.rst
+++ b/docs/heuristics.rst
@@ -122,7 +122,7 @@ or::
 ---------------------------------------------------------------
 ``custom_seqinfo(series_files, wrapper)``
 ---------------------------------------------------------------
-If present this function will be called on eacg group of dicoms with
+If present this function will be called on each group of dicoms with
 a sample nibabel dicom wrapper to extract additional information
 to be used in ``infotodict``.
 

--- a/docs/heuristics.rst
+++ b/docs/heuristics.rst
@@ -119,6 +119,19 @@ or::
         ...
         return seqinfos  # ordered dict containing seqinfo objects: list of DICOMs
 
+---------------------------------------------------------------
+``custom_seqinfo(series_files, wrapper)``
+---------------------------------------------------------------
+If present this function will be called on eacg group of dicoms with
+a sample nibabel dicom wrapper to extract additional information
+to be used in ``infotodict``.
+
+Importantly the return value of that function needs to be hashable.
+For instance the following non-hashable types can be converted to an alternative
+hashable type:
+- list > tuple
+- dict > frozendict
+- arrays > bytes (tobytes(), or pickle.dumps), str or tuple of tuples.
 
 -------------------------------
 ``POPULATE_INTENDED_FOR_OPTS``

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -223,7 +223,7 @@ def prep_conversion(
                 custom_grouping=getattr(heuristic, "grouping", None),
                 # callable which will be provided dcminfo and returned
                 # structure extend seqinfo
-                custom_seqinfo = getattr(heuristic, 'custom_seqinfo', None),
+                custom_seqinfo=getattr(heuristic, 'custom_seqinfo', None),
             )
         elif seqinfo is None:
             raise ValueError("Neither 'dicoms' nor 'seqinfo' is given")

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -221,6 +221,9 @@ def prep_conversion(
                 dcmfilter=getattr(heuristic, "filter_dicom", None),
                 flatten=True,
                 custom_grouping=getattr(heuristic, "grouping", None),
+                # callable which will be provided dcminfo and returned
+                # structure extend seqinfo
+                custom_seqinfo = getattr(heuristic, 'custom_seqinfo', None),
             )
         elif seqinfo is None:
             raise ValueError("Neither 'dicoms' nor 'seqinfo' is given")

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -223,7 +223,7 @@ def prep_conversion(
                 custom_grouping=getattr(heuristic, "grouping", None),
                 # callable which will be provided dcminfo and returned
                 # structure extend seqinfo
-                custom_seqinfo=getattr(heuristic, 'custom_seqinfo', None),
+                custom_seqinfo=getattr(heuristic, "custom_seqinfo", None),
             )
         elif seqinfo is None:
             raise ValueError("Neither 'dicoms' nor 'seqinfo' is given")

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -9,7 +9,18 @@ import os.path as op
 from pathlib import Path
 import sys
 import tarfile
-from typing import TYPE_CHECKING, Any, Dict, Hashable, List, NamedTuple, Optional, Union, Protocol, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Hashable,
+    List,
+    NamedTuple,
+    Optional,
+    Protocol,
+    Union,
+    overload,
+)
 from unittest.mock import patch
 import warnings
 
@@ -90,14 +101,19 @@ def create_seqinfo(
     global total_files
     total_files += len(series_files)
 
-    custom_seqinfo_data = custom_seqinfo(wrapper=mw, series_files=series_files) \
-        if custom_seqinfo else None
+    custom_seqinfo_data = (
+        custom_seqinfo(wrapper=mw, series_files=series_files)
+        if custom_seqinfo
+        else None
+    )
     try:
         hash(custom_seqinfo_data)
     except TypeError:
-        raise RuntimeError("Data returned by the heuristics custom_seqinfo is not hashable. "
-                           "See https://heudiconv.readthedocs.io/en/latest/heuristics.html#custom_seqinfo for more "
-                           "details.")
+        raise RuntimeError(
+            "Data returned by the heuristics custom_seqinfo is not hashable. "
+            "See https://heudiconv.readthedocs.io/en/latest/heuristics.html#custom_seqinfo for more "
+            "details."
+        )
 
     return SeqInfo(
         total_files_till_now=total_files,

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -90,6 +90,15 @@ def create_seqinfo(
     global total_files
     total_files += len(series_files)
 
+    custom_seqinfo_data = custom_seqinfo(wrapper=mw, series_files=series_files) \
+        if custom_seqinfo else None
+    try:
+        hash(custom_seqinfo_data)
+    except TypeError:
+        raise RuntimeError("Data returned by the heuristics custom_seqinfo is not hashable. "
+                           "See https://heudiconv.readthedocs.io/en/latest/heuristics.html#custom_seqinfo for more "
+                           "details.")
+
     return SeqInfo(
         total_files_till_now=total_files,
         example_dcm_file=op.basename(series_files[0]),
@@ -119,9 +128,7 @@ def create_seqinfo(
         date=dcminfo.get("AcquisitionDate"),
         series_uid=dcminfo.get("SeriesInstanceUID"),
         time=dcminfo.get("AcquisitionTime"),
-        custom =
-            custom_seqinfo(wrapper=mw, series_files=series_files)
-            if custom_seqinfo else None,
+        custom=custom_seqinfo_data,
     )
 
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -194,6 +194,7 @@ def group_dicoms_into_seqinfos(
         dict[SeqInfo, list[str]],
     ]
     | None = None,
+    custom_seqinfo: CustomSeqinfoT | None = None,
 ) -> dict[Optional[str], dict[SeqInfo, list[str]]]:
     ...
 
@@ -212,7 +213,7 @@ def group_dicoms_into_seqinfos(
         dict[SeqInfo, list[str]],
     ]
     | None = None,
-     custom_seqinfo: CustomSeqinfoT | None = None,
+    custom_seqinfo: CustomSeqinfoT | None = None,
 ) -> dict[SeqInfo, list[str]]:
     ...
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -9,8 +9,7 @@ import os.path as op
 from pathlib import Path
 import sys
 import tarfile
-from typing import TYPE_CHECKING, Any, Dict, Hashable, List, NamedTuple, Optional, Union, overload
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union, Protocol, cast, overload
 from unittest.mock import patch
 import warnings
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -43,7 +43,8 @@ compresslevel = 9
 
 
 class CustomSeqinfoT(Protocol):
-    def __call__(self, wrapper: dw.Wrapper, series_files: list[str]) -> Hashable: ...
+    def __call__(self, wrapper: dw.Wrapper, series_files: list[str]) -> Hashable:
+        ...
 
 
 def create_seqinfo(

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -9,7 +9,7 @@ import os.path as op
 from pathlib import Path
 import sys
 import tarfile
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union, Protocol, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, Hashable, List, NamedTuple, Optional, Union, Protocol, overload
 from unittest.mock import patch
 import warnings
 

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 from heudiconv.dicoms import dw
 from heudiconv.utils import SeqInfo
+
+lgr = logging.getLogger('heudiconv')
 
 
 def create_key(
@@ -25,6 +28,7 @@ def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str], **kw: Any) -> t
     try:
         affine = wrapper.affine.tostring()
     except WrapperError:
+        lgr.exception("Errored out while obtaining/converting affine")
         affine = None
     return affine, series_files[0]
 

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 from heudiconv.dicoms import dw
 from heudiconv.utils import SeqInfo
@@ -19,7 +19,7 @@ def create_key(
     return (template, outtype, annotation_classes)
 
 
-def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str], **kw: Any) -> tuple[str, str]:
+def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str]) -> tuple[str, str]:
     # Just a dummy demo for what custom_seqinfo could get/do
     # for already loaded DICOM data, and including storing/returning
     # the sample series file as was requested

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -21,7 +21,12 @@ def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str], **kw: Any) -> t
     # for already loaded DICOM data, and including storing/returning
     # the sample series file as was requested
     # in https://github.com/nipy/heudiconv/pull/333
-    return wrapper.affine.tostring(), series_files[0]
+    from nibabel.nicom.dicomwrappers import WrapperError
+    try:
+        affine = wrapper.affine.tostring()
+    except WrapperError:
+        affine = None
+    return affine, series_files[0]
 
 
 def infotodict(

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -6,7 +6,7 @@ from typing import Optional
 from heudiconv.dicoms import dw
 from heudiconv.utils import SeqInfo
 
-lgr = logging.getLogger('heudiconv')
+lgr = logging.getLogger("heudiconv")
 
 
 def create_key(
@@ -25,6 +25,7 @@ def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str]) -> tuple[str, s
     # the sample series file as was requested
     # in https://github.com/nipy/heudiconv/pull/333
     from nibabel.nicom.dicomwrappers import WrapperError
+
     try:
         affine = wrapper.affine.tobytes()
     except WrapperError:

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -26,7 +26,7 @@ def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str], **kw: Any) -> t
     # in https://github.com/nipy/heudiconv/pull/333
     from nibabel.nicom.dicomwrappers import WrapperError
     try:
-        affine = wrapper.affine.tostring()
+        affine = wrapper.affine.tobytes()
     except WrapperError:
         lgr.exception("Errored out while obtaining/converting affine")
         affine = None

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
+from heudiconv.dicoms import dw
 from heudiconv.utils import SeqInfo
 
 
@@ -13,6 +14,14 @@ def create_key(
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
     return (template, outtype, annotation_classes)
+
+
+def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str], **kw: Any) -> tuple[str, str]:
+    # Just a dummy demo for what custom_seqinfo could get/do
+    # for already loaded DICOM data, and including storing/returning
+    # the sample series file as was requested
+    # in https://github.com/nipy/heudiconv/pull/333
+    return wrapper.affine, series_files[0]
 
 
 def infotodict(

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -21,7 +21,7 @@ def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str], **kw: Any) -> t
     # for already loaded DICOM data, and including storing/returning
     # the sample series file as was requested
     # in https://github.com/nipy/heudiconv/pull/333
-    return wrapper.affine, series_files[0]
+    return wrapper.affine.tostring(), series_files[0]
 
 
 def infotodict(

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from heudiconv.dicoms import dw
 from heudiconv.utils import SeqInfo
 
 lgr = logging.getLogger("heudiconv")
@@ -17,21 +16,6 @@ def create_key(
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
     return (template, outtype, annotation_classes)
-
-
-def custom_seqinfo(wrapper: dw.Wrapper, series_files: list[str]) -> tuple[str, str]:
-    # Just a dummy demo for what custom_seqinfo could get/do
-    # for already loaded DICOM data, and including storing/returning
-    # the sample series file as was requested
-    # in https://github.com/nipy/heudiconv/pull/333
-    from nibabel.nicom.dicomwrappers import WrapperError
-
-    try:
-        affine = wrapper.affine.tobytes()
-    except WrapperError:
-        lgr.exception("Errored out while obtaining/converting affine")
-        affine = None
-    return affine, series_files[0]
 
 
 def infotodict(

--- a/heudiconv/heuristics/convertall_custom.py
+++ b/heudiconv/heuristics/convertall_custom.py
@@ -4,11 +4,18 @@ This heuristic also demonstrates on how to create a "derived" heuristic which wo
 behavior of an already existing heuristic without complete rewrite.  Such approach could be
 useful for heuristic like  reproin  to overload mapping etc.
 """
+from __future__ import annotations
+
+from typing import Any
+
+import nibabel.nicom.dicomwrappers as dw
 
 from .convertall import *  # noqa: F403
 
 
-def custom_seqinfo(series_files, wrapper, **kw):  # noqa: U100
+def custom_seqinfo(
+    series_files: list[str], wrapper: dw.Wrapper, **kw: Any  # noqa: U100
+) -> tuple[str | None, str]:
     """Demo for extracting custom header fields into custom_seqinfo field
 
     Operates on already loaded DICOM data.

--- a/heudiconv/heuristics/convertall_custom.py
+++ b/heudiconv/heuristics/convertall_custom.py
@@ -1,0 +1,25 @@
+"""A demo convertall heuristic with custom_seqinfo extracting affine and sample DICOM path
+
+This heuristic also demonstrates on how to create a "derived" heuristic which would augment
+behavior of an already existing heuristic without complete rewrite.  Such approach could be
+useful for heuristic like  reproin  to overload mapping etc.
+"""
+
+from .convertall import *  # noqa: F403
+
+
+def custom_seqinfo(series_files, wrapper, **kw):  # noqa: U100
+    """Demo for extracting custom header fields into custom_seqinfo field
+
+    Operates on already loaded DICOM data.
+    Origin: https://github.com/nipy/heudiconv/pull/333
+    """
+
+    from nibabel.nicom.dicomwrappers import WrapperError
+
+    try:
+        affine = wrapper.affine.tostring()
+    except WrapperError:
+        lgr.exception("Errored out while obtaining/converting affine")  # noqa: F405
+        affine = None
+    return affine, series_files[0]

--- a/heudiconv/heuristics/convertall_custom.py
+++ b/heudiconv/heuristics/convertall_custom.py
@@ -18,7 +18,7 @@ def custom_seqinfo(series_files, wrapper, **kw):  # noqa: U100
     from nibabel.nicom.dicomwrappers import WrapperError
 
     try:
-        affine = wrapper.affine.tostring()
+        affine = str(wrapper.affine)
     except WrapperError:
         lgr.exception("Errored out while obtaining/converting affine")  # noqa: F405
         affine = None

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -224,6 +224,7 @@ def get_study_sessions(
             file_filter=getattr(heuristic, "filter_files", None),
             dcmfilter=getattr(heuristic, "filter_dicom", None),
             custom_grouping=getattr(heuristic, "grouping", None),
+            custom_seqinfo=getattr(heuristic, 'custom_seqinfo', None),
         )
 
         if sids:

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -224,7 +224,7 @@ def get_study_sessions(
             file_filter=getattr(heuristic, "filter_files", None),
             dcmfilter=getattr(heuristic, "filter_dicom", None),
             custom_grouping=getattr(heuristic, "grouping", None),
-            custom_seqinfo=getattr(heuristic, 'custom_seqinfo', None),
+            custom_seqinfo=getattr(heuristic, "custom_seqinfo", None),
         )
 
         if sids:

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -119,6 +119,7 @@ def test_custom_seqinfo() -> None:
     assert len(seqinfo.custom) == 2
     assert seqinfo.custom[1] == dcmfiles[0]
 
+
 def test_get_datetime_from_dcm_from_acq_date_time() -> None:
     typical_dcm = dcm.dcmread(
         op.join(TESTS_DATA_PATH, "phantom.dcm"), stop_before_pixels=True

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -107,14 +107,12 @@ def test_custom_seqinfo() -> None:
     dcmfiles = glob(op.join(TESTS_DATA_PATH, "phantom.dcm"))
 
     seqinfos = group_dicoms_into_seqinfos(
-        dcmfiles,
-        "studyUID",
-        flatten=True,
-        custom_seqinfo=custom_seqinfo)
+        dcmfiles, "studyUID", flatten=True, custom_seqinfo=custom_seqinfo
+    )
 
     seqinfo = list(seqinfos.keys())[0]
 
-    assert hasattr(seqinfo, 'custom')
+    assert hasattr(seqinfo, "custom")
     assert isinstance(seqinfo.custom, tuple)
     assert len(seqinfo.custom) == 2
     assert seqinfo.custom[1] == dcmfiles[0]

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -99,6 +99,26 @@ def test_group_dicoms_into_seqinfos() -> None:
     ]
 
 
+def test_custom_seqinfo() -> None:
+    """Tests for custom seqinfo extraction"""
+
+    from heudiconv.heuristics.convertall import custom_seqinfo
+
+    dcmfiles = glob(op.join(TESTS_DATA_PATH, "phantom.dcm"))
+
+    seqinfos = group_dicoms_into_seqinfos(
+        dcmfiles,
+        "studyUID",
+        flatten=True,
+        custom_seqinfo=custom_seqinfo)
+
+    seqinfo = list(seqinfos.keys())[0]
+
+    assert hasattr(seqinfo, 'custom')
+    assert isinstance(seqinfo.custom, tuple)
+    assert len(seqinfo.custom) == 2
+    assert seqinfo.custom[1] == dcmfiles[0]
+
 def test_get_datetime_from_dcm_from_acq_date_time() -> None:
     typical_dcm = dcm.dcmread(
         op.join(TESTS_DATA_PATH, "phantom.dcm"), stop_before_pixels=True

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -102,7 +102,7 @@ def test_group_dicoms_into_seqinfos() -> None:
 def test_custom_seqinfo() -> None:
     """Tests for custom seqinfo extraction"""
 
-    from heudiconv.heuristics.convertall import custom_seqinfo
+    from heudiconv.heuristics.convertall_custom import custom_seqinfo
 
     dcmfiles = glob(op.join(TESTS_DATA_PATH, "phantom.dcm"))
 

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -108,7 +108,7 @@ def test_custom_seqinfo() -> None:
 
     seqinfos = group_dicoms_into_seqinfos(
         dcmfiles, "studyUID", flatten=True, custom_seqinfo=custom_seqinfo
-    )
+    )  # type: ignore
 
     seqinfo = list(seqinfos.keys())[0]
 

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -24,6 +24,7 @@ from types import ModuleType
 from typing import (
     Any,
     AnyStr,
+    Hashable,
     Mapping,
     NamedTuple,
     Optional,
@@ -69,6 +70,7 @@ class SeqInfo(NamedTuple):
     date: Optional[str]  # 24
     series_uid: Optional[str]  # 25
     time: Optional[str]  # 26
+    custom: Optional[Hashable]  # 27
 
 
 class StudySessionInfo(NamedTuple):


### PR DESCRIPTION
Getting back to #333 (attn @bpinsard ) and recent #580 (attn @kcho) decided may be to add to the army of custom ad-hoc callbacks etc heuristics could provide.  So, WDYT if heuristic could provide `custom_seqinfo` callable (crude example is below in PR) where any information could be extracted from already loaded nibabel's dicom wrapper or just a full list of files for that sequence.  I think it would be a slightly better solution to #333 since would not *always* store potentially sensitive path in the extracted metadata record  and potentially could operate on already loaded DICOM metadata thus making it faster to extract extra metadata.

@bpinsard @kcho -- would smth like that work for your cases?

TODOs
- [ ] ~~replace~~compliment hashing check with some more adequate, may be round trip check through json + verification that no `\t` is present. if `\t` -- kaboom. Add to documentation that `\t` must be sanitized, or add such sanitization (and document it)
- [x] add basic test. Since `convertall` already got that custom field filled, test should just check if it is there.