### PR TITLE
0.9 of dcmstack was released, no need for github version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,3 @@
 -r requirements.txt
 tinydb
 inotify
-# we need master version until it gets released
-# see https://github.com/moloney/dcmstack/issues/75
-git+https://github.com/moloney/dcmstack.git


### PR DESCRIPTION
marked for release since why not, there were a few merges etc