### PR TITLE
Delete .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-Dockerfile


### PR DESCRIPTION
Closes #606.

Excluding version-controlled files from the Docker image causes the resulting copy of the repository inside the image to be dirty, which in turn results in "+dDATE" added to the version number.