### PR TITLE
DOC: do provide short version for sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ copyright = '2014-2022, Heudiconv team'
 author = 'Heudiconv team'
 
 # The short X.Y version
-version = ''
+version = '.'.join(__version__.split('.')[:2])
 # The full version, including alpha/beta/rc tags
 release = __version__
 


### PR DESCRIPTION
Otherwise we get

WARNING: conf value "version" should not be empty for EPUB3

which I believe is what errors out our build on RTD.