### PR TITLE
Do not issue warning if cannot parse _task entity

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -860,7 +860,10 @@ def save_converted_files(res, item_dicoms, bids_options, outtype, prefix, outnam
 
 
 def add_taskname_to_infofile(infofiles):
-    """Add the "TaskName" field to json files corresponding to func images.
+    """Add the "TaskName" field to json files with _task- entity in the name.
+
+    Note: _task- entity could be present not only in functional data
+    but in many other modalities now.
 
     Parameters
     ----------
@@ -879,7 +882,8 @@ def add_taskname_to_infofile(infofiles):
                                                op.basename(infofile))
                                      .group(0).split('_')[0])
         except AttributeError:
-            lgr.warning("Failed to find task field in {0}.".format(infofile))
+            # leave it to bids-validator to validate/inform about presence
+            # of required entities/fields.
             continue
 
         # write to outfile


### PR DESCRIPTION
Also adjusted docstring to note that now _task- can be used in many other modalities

    ❯ git grep -l -B4 -E 'task: (r|o)'
    src/schema/README.md
    src/schema/rules/files/raw/anat.yaml
    src/schema/rules/files/raw/beh.yaml
    src/schema/rules/files/raw/channels.yaml
    src/schema/rules/files/raw/eeg.yaml
    src/schema/rules/files/raw/func.yaml
    src/schema/rules/files/raw/ieeg.yaml
    src/schema/rules/files/raw/meg.yaml
    src/schema/rules/files/raw/nirs.yaml
    src/schema/rules/files/raw/pet.yaml
    src/schema/rules/files/raw/task.yaml

and overall -- even if required for some modality (e.g. func) IMHO we should not redo bids-validator functionality here.  It should be validator to report oddities (may be we should bolt on integration with basic validation present in bidsschematools).

Closes #613 