### PR TITLE
Setting git author and email in test environment

### DIFF
--- a/heudiconv/tests/conftest.py
+++ b/heudiconv/tests/conftest.py
@@ -1,3 +1,8 @@
 import os
-os.environ["GIT_AUTHOR_EMAIL"] = "maxm@example.com"
-os.environ["GIT_AUTHOR_NAME"] = "Max Mustermann"
+import pytest
+@pytest.fixture(autouse=True, scope="session")
+def git_env():
+       os.environ["GIT_AUTHOR_EMAIL"] = "maxm@example.com"
+       os.environ["GIT_AUTHOR_NAME"] = "Max Mustermann"
+       os.environ["GIT_COMMITTER_EMAIL"] = "maxm@example.com"
+       os.environ["GIT_COMMITTER_NAME"] = "Max Mustermann"

--- a/heudiconv/tests/conftest.py
+++ b/heudiconv/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+os.environ["GIT_AUTHOR_EMAIL"] = "maxm@example.com"
+os.environ["GIT_AUTHOR_NAME"] = "Max Mustermann"


### PR DESCRIPTION
@yarikoptic as discussed on Tuesday. I tried a few different approaches, I think this is better than via a fixture since it ensures it will always be set throughout the test suite, without having to annotate individual tests.