### PR TITLE
Docker images: tag also as "unstable", strip "v" prefix, and avoid building in non-release workflow for releases.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,11 @@ jobs:
         working-directory: utils
 
       - name: Build Docker image
-        run: docker build -t nipy/heudiconv:master .
+        run: |
+          docker build \
+            -t nipy/heudiconv:master \
+            -t nipy/heudiconv:unstable \
+            .
 
       - name: Push Docker image
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,15 +21,20 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build \
-            -t nipy/heudiconv:master \
-            -t nipy/heudiconv:unstable \
-            .
+          # build only if not release tag, i.e. has some "-" in describe
+          # so we do not duplicate work with release workflow.
+          git describe --match 'v[0-9]*' | grep -q -e - && \
+              docker build \
+                -t nipy/heudiconv:master \
+                -t nipy/heudiconv:unstable \
+                .
 
       - name: Push Docker image
         run: |
-          docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
-          docker push nipy/heudiconv:master
+          git describe --match 'v[0-9]*' | grep -q -e - && (
+              docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
+              docker push nipy/heudiconv:master
+          )
         env:
           DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
           git describe --match 'v[0-9]*' | grep -q -e - && (
               docker login -u "$DOCKER_LOGIN" --password-stdin <<<"$DOCKER_TOKEN"
               docker push nipy/heudiconv:master
+              docker push nipy/heudiconv:unstable
           )
         env:
           DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,9 @@ jobs:
         run: |
           docker build \
             -t nipy/heudiconv:master \
+            -t nipy/heudiconv:unstable \
             -t nipy/heudiconv:latest \
-            -t nipy/heudiconv:"$(git describe)" \
+            -t nipy/heudiconv:"$(git describe | sed -e 's,^v,,g')" \
             .
 
       - name: Push Docker images


### PR DESCRIPTION
We had on docker hub

![image](https://user-images.githubusercontent.com/39889/219118022-9a5c0213-44ce-4cf2-8ec5-0e99342d4243.png)

so we were building also there. In consultation with @asmacdo we decided to just build on github actions since we have more control/logging (yet to establish con/tinuous I guess for the archive).  So I have disabled building on docker hub, and tuned the workflow so we provide continuity here.