### PR TITLE
Remove use of `six`

### DIFF
--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -33,7 +33,6 @@ REQUIRES = [
 ]
 
 TESTS_REQUIRES = [
-    'six',
     'pytest',
     'mock',
     'tinydb',

--- a/heudiconv/tests/test_heuristics.py
+++ b/heudiconv/tests/test_heuristics.py
@@ -1,9 +1,9 @@
 from heudiconv.cli.run import main as runner
 
+from io import StringIO
 import os
 import os.path as op
 from mock import patch
-from six.moves import StringIO
 
 from glob import glob
 from os.path import join as pjoin, dirname

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -24,9 +24,9 @@ import os
 import pytest
 import sys
 
+from io import StringIO
 from mock import patch
 from os.path import join as opj
-from six.moves import StringIO
 import stat
 import os.path as op
 

--- a/heudiconv/tests/test_tarballs.py
+++ b/heudiconv/tests/test_tarballs.py
@@ -6,7 +6,6 @@ import time
 from mock import patch
 from os.path import join as opj
 from os.path import dirname
-from six.moves import StringIO
 from glob import glob
 
 from heudiconv.dicoms import compress_dicoms


### PR DESCRIPTION
heudiconv requires Python 3.7 or higher, so there is no need to use `six`.