### PR TITLE
Add type annotations

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -1,0 +1,27 @@
+name: Type-check
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  typing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Run type checker
+        run: tox -e typing

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.7'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -103,7 +103,7 @@ def maybe_na(val: Any) -> str:
         return "n/a"
 
 
-def treat_age(age: Any) -> str:
+def treat_age(age: str|float) -> str:
     """Age might encounter 'Y' suffix or be a float"""
     agestr = str(age)
     if agestr.endswith("M"):

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -718,11 +718,13 @@ def get_key_info_for_fmap_assignment(
         key_info = [get_shim_setting(json_file)]
     elif matching_parameter == "ImagingVolume":
         from nibabel import load as nb_load
+        from nibabel.nifti1 import Nifti1Header
 
         nifti_files = glob(remove_suffix(json_file, ".json") + ".nii*")
         assert len(nifti_files) == 1
         nifti_file = nifti_files[0]
         nifti_header = nb_load(nifti_file).header
+        assert isinstance(nifti_header, Nifti1Header)
         key_info = [nifti_header.get_best_affine(), nifti_header.get_data_shape()[:3]]
     elif matching_parameter == "ModalityAcquisitionLabel":
         # Check the acq label for the fmap and the modality for others:

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -103,8 +103,10 @@ def maybe_na(val: Any) -> str:
         return "n/a"
 
 
-def treat_age(age: str|float) -> str:
+def treat_age(age: str | float | None) -> str | None:
     """Age might encounter 'Y' suffix or be a float"""
+    if age is None:
+        return None  # might be converted to N/A by maybe_na
     agestr = str(age)
     if agestr.endswith("M"):
         agestr = agestr.rstrip("M")
@@ -367,7 +369,7 @@ def tuneup_bids_json_files(json_files: list[str]) -> None:
                 set_readonly(json_phasediffname)
 
 
-def add_participant_record(studydir: str, subject: str, age: str, sex: str) -> None:
+def add_participant_record(studydir: str, subject: str, age: str | None, sex: str | None) -> None:
     participants_tsv = op.join(studydir, "participants.tsv")
     participant_id = "sub-%s" % subject
 

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -96,27 +96,28 @@ def maybe_na(val: Any) -> str:
     are also treated as 'n/a'
     """
     if val is not None:
-        val = str(val)
-        val = val.strip()
-    return "n/a" if (not val or val in ("N/A", "NA")) else val
+        valstr = str(val).strip()
+        return "n/a" if (not valstr or valstr in ("N/A", "NA")) else valstr
+    else:
+        return "n/a"
 
 
 def treat_age(age: Any) -> str:
     """Age might encounter 'Y' suffix or be a float"""
-    age = str(age)
-    if age.endswith("M"):
-        age = age.rstrip("M")
-        age = float(age) / 12
-        age = ("%.2f" if age != int(age) else "%d") % age
+    agestr = str(age)
+    if agestr.endswith("M"):
+        agestr = agestr.rstrip("M")
+        ageflt = float(agestr) / 12
+        agestr = ("%.2f" if ageflt != int(ageflt) else "%d") % ageflt
     else:
-        age = age.rstrip("Y")
-    if age:
+        agestr = agestr.rstrip("Y")
+    if agestr:
         # strip all leading 0s but allow to scan a newborn (age 0Y)
-        age = "0" if not age.lstrip("0") else age.lstrip("0")
-        if age.startswith("."):
+        agestr = "0" if not agestr.lstrip("0") else agestr.lstrip("0")
+        if agestr.startswith("."):
             # we had float point value, let's prepend 0
-            age = "0" + age
-    return age
+            agestr = "0" + agestr
+    return agestr
 
 
 def populate_bids_templates(
@@ -477,7 +478,8 @@ def save_scans_key(item, bids_files: list[str]) -> None:
     # and if there is a conflict, we would just blow since this function
     # should be invoked only on a result of a single item conversion as far
     # as I see it, so should have the same subject/session
-    subj, ses = None, None
+    subj: Optional[str] = None
+    ses: Optional[str] = None
     for bids_file in bids_files:
         # get filenames
         f_name = "/".join(bids_file.split("/")[-2:])

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -1083,7 +1083,7 @@ class BIDSFile:
         self._suffix = suffix
         self._extension = extension
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, self.__class__):
             return False
         if (

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -1,5 +1,7 @@
 """Handle BIDS specific operations"""
 
+from __future__ import annotations
+
 __docformat__ = "numpy"
 
 from collections import OrderedDict
@@ -12,7 +14,7 @@ import logging
 import os
 import os.path as op
 import re
-import typing
+from typing import Any, Optional
 import warnings
 
 import numpy as np
@@ -87,7 +89,7 @@ AllowedCriteriaForFmapAssignment = [
 ]
 
 
-def maybe_na(val):
+def maybe_na(val: Any) -> str:
     """Return 'n/a' if non-None value represented as str is not empty
 
     Primarily for the consistent use of lower case 'n/a' so 'N/A' and 'NA'
@@ -99,7 +101,7 @@ def maybe_na(val):
     return "n/a" if (not val or val in ("N/A", "NA")) else val
 
 
-def treat_age(age):
+def treat_age(age: Any) -> str:
     """Age might encounter 'Y' suffix or be a float"""
     age = str(age)
     if age.endswith("M"):
@@ -117,7 +119,9 @@ def treat_age(age):
     return age
 
 
-def populate_bids_templates(path, defaults=None):
+def populate_bids_templates(
+    path: str, defaults: Optional[dict[str, Any]] = None
+) -> None:
     """Premake BIDS text files with templates"""
 
     lgr.info("Populating template files under %s", path)
@@ -198,7 +202,7 @@ def populate_bids_templates(path, defaults=None):
     populate_aggregated_jsons(path)
 
 
-def populate_aggregated_jsons(path):
+def populate_aggregated_jsons(path: str) -> None:
     """Aggregate across the entire BIDS dataset ``.json``\\s into top level ``.json``\\s
 
     Top level .json files would contain only the fields which are
@@ -267,8 +271,8 @@ def populate_aggregated_jsons(path):
         # do not touch any existing thing, it may be precious
         if not op.lexists(events_file):
             lgr.debug("Generating %s", events_file)
-            with open(events_file, "w") as f:
-                f.write(
+            with open(events_file, "w") as fp:
+                fp.write(
                     "onset\tduration\ttrial_type\tresponse_time\tstim_file"
                     "\tTODO -- fill in rows and add more tab-separated "
                     "columns if desired"
@@ -302,7 +306,7 @@ def populate_aggregated_jsons(path):
         save_json(task_file, fields, sort_keys=True, pretty=True)
 
 
-def tuneup_bids_json_files(json_files):
+def tuneup_bids_json_files(json_files: list[str]) -> None:
     """Given a list of BIDS .json files, e.g."""
     if not json_files:
         return
@@ -361,7 +365,7 @@ def tuneup_bids_json_files(json_files):
                 set_readonly(json_phasediffname)
 
 
-def add_participant_record(studydir, subject, age, sex):
+def add_participant_record(studydir: str, subject: str, age: str, sex: str) -> None:
     participants_tsv = op.join(studydir, "participants.tsv")
     participant_id = "sub-%s" % subject
 
@@ -446,7 +450,7 @@ def add_participant_record(studydir, subject, age, sex):
         )
 
 
-def find_subj_ses(f_name):
+def find_subj_ses(f_name: str) -> tuple[Optional[str], Optional[str]]:
     """Given a path to the bids formatted filename parse out subject/session"""
     # we will allow the match at either directories or within filename
     # assuming that bids layout is "correct"
@@ -456,12 +460,12 @@ def find_subj_ses(f_name):
     return res.get("subj", None), res.get("ses", None)
 
 
-def save_scans_key(item, bids_files):
+def save_scans_key(item, bids_files: list[str]) -> None:
     """
     Parameters
     ----------
     item:
-    bids_files: str or list
+    bids_files: list of str
 
     Returns
     -------
@@ -508,7 +512,7 @@ def save_scans_key(item, bids_files):
     )
 
 
-def add_rows_to_scans_keys_file(fn, newrows):
+def add_rows_to_scans_keys_file(fn: str, newrows: dict[str, list[str]]) -> None:
     """Add new rows to the _scans file.
 
     Parameters
@@ -534,7 +538,7 @@ def add_rows_to_scans_keys_file(fn, newrows):
     else:
         fnames2info = newrows
 
-    header = SCANS_FILE_FIELDS
+    header = list(SCANS_FILE_FIELDS.keys())
     # prepare all the data rows
     data_rows = [[k] + v for k, v in fnames2info.items()]
     # sort by the date/filename
@@ -549,7 +553,7 @@ def add_rows_to_scans_keys_file(fn, newrows):
         writer.writerows([header] + data_rows_sorted)
 
 
-def get_formatted_scans_key_row(dcm_fn) -> typing.List[str]:
+def get_formatted_scans_key_row(dcm_fn) -> list[str]:
     """
     Parameters
     ----------
@@ -582,7 +586,7 @@ def get_formatted_scans_key_row(dcm_fn) -> typing.List[str]:
     return row
 
 
-def convert_sid_bids(subject_id):
+def convert_sid_bids(subject_id: str) -> str:
     """Shim for stripping any non-BIDS compliant characters within subject_id
 
     Parameters
@@ -593,8 +597,6 @@ def convert_sid_bids(subject_id):
     -------
     sid : string
         New subject ID
-    subject_id : string
-        Original subject ID
     """
     warnings.warn(
         "convert_sid_bids() is deprecated, please use sanitize_label() instead.",
@@ -604,7 +606,7 @@ def convert_sid_bids(subject_id):
     return sanitize_label(subject_id)
 
 
-def get_shim_setting(json_file):
+def get_shim_setting(json_file: str) -> Any:
     """
     Gets the "ShimSetting" field from a json_file.
     If no "ShimSetting" present, return error
@@ -627,11 +629,11 @@ def get_shim_setting(json_file):
             json_file,
             SHIM_KEY,
         )
-        raise KeyError
+        raise
     return shims
 
 
-def find_fmap_groups(fmap_dir):
+def find_fmap_groups(fmap_dir: str) -> dict[str, list[str]]:
     """
     Finds the different fmap groups in a fmap directory.
     By groups here we mean fmaps that are intended to go together
@@ -639,7 +641,7 @@ def find_fmap_groups(fmap_dir):
 
     Parameters
     ----------
-    fmap_dir : str or os.path
+    fmap_dir : str
         path to the session folder (or to the subject folder, if there are no
         sessions).
 
@@ -672,17 +674,19 @@ def find_fmap_groups(fmap_dir):
             for fm in fmap_jsons
         )
     )
-    fmap_groups = OrderedDict()
-    for k in prefixes:
-        fmap_groups[k] = [
+    return {
+        k: [
             fm
             for fm in fmap_jsons
             if fmap_regex.sub("", remove_suffix(op.basename(fm), ".json")) == k
         ]
-    return fmap_groups
+        for k in prefixes
+    }
 
 
-def get_key_info_for_fmap_assignment(json_file, matching_parameter):
+def get_key_info_for_fmap_assignment(
+    json_file: str, matching_parameter: str
+) -> list[Any]:
     """
     Gets key information needed to assign fmaps to other modalities.
     (Note: It is the responsibility of the calling function to make sure
@@ -690,14 +694,14 @@ def get_key_info_for_fmap_assignment(json_file, matching_parameter):
 
     Parameters
     ----------
-    json_file : str or os.path
+    json_file : str
         path to the json file
     matching_parameter : str in AllowedFmapParameterMatching
         matching_parameter that will be used to match runs
 
     Returns
     -------
-    key_info : dict
+    key_info : list
         part of the json file that will need to match between the fmap and
         the other image
     """
@@ -710,9 +714,9 @@ def get_key_info_for_fmap_assignment(json_file, matching_parameter):
     elif matching_parameter == "ImagingVolume":
         from nibabel import load as nb_load
 
-        nifti_file = glob(remove_suffix(json_file, ".json") + ".nii*")
-        assert len(nifti_file) == 1
-        nifti_file = nifti_file[0]
+        nifti_files = glob(remove_suffix(json_file, ".json") + ".nii*")
+        assert len(nifti_files) == 1
+        nifti_file = nifti_files[0]
         nifti_header = nb_load(nifti_file).header
         key_info = [nifti_header.get_best_affine(), nifti_header.get_data_shape()[:3]]
     elif matching_parameter == "ModalityAcquisitionLabel":
@@ -721,6 +725,7 @@ def get_key_info_for_fmap_assignment(json_file, matching_parameter):
         if modality == "fmap":
             # extract the <acq> entity:
             acq_label = BIDSFile.parse(op.basename(json_file))["acq"]
+            assert acq_label is not None
             if any(s in acq_label.lower() for s in ["fmri", "bold", "func"]):
                 key_info = ["func"]
             elif any(s in acq_label.lower() for s in ["diff", "dwi"]):
@@ -750,7 +755,9 @@ def get_key_info_for_fmap_assignment(json_file, matching_parameter):
     return key_info
 
 
-def find_compatible_fmaps_for_run(json_file, fmap_groups, matching_parameters):
+def find_compatible_fmaps_for_run(
+    json_file: str, fmap_groups: dict[str, list[str]], matching_parameters: list[str]
+) -> dict[str, list[str]]:
     """
     Finds compatible fmaps for a given run, for populate_intended_for.
     (Note: It is the responsibility of the calling function to make sure
@@ -758,7 +765,7 @@ def find_compatible_fmaps_for_run(json_file, fmap_groups, matching_parameters):
 
     Parameters
     ----------
-    json_file : str or os.path
+    json_file : str
         path to the json file
     fmap_groups : dict
         key: prefix common to the group
@@ -806,7 +813,9 @@ def find_compatible_fmaps_for_run(json_file, fmap_groups, matching_parameters):
     return compatible_fmap_groups
 
 
-def find_compatible_fmaps_for_session(path_to_bids_session, matching_parameters):
+def find_compatible_fmaps_for_session(
+    path_to_bids_session: str, matching_parameters: list[str]
+) -> Optional[dict[str, dict[str, list[str]]]]:
     """
     Finds compatible fmaps for all non-fmap runs in a session.
     (Note: It is the responsibility of the calling function to make sure
@@ -814,7 +823,7 @@ def find_compatible_fmaps_for_session(path_to_bids_session, matching_parameters)
 
     Parameters
     ----------
-    path_to_bids_session : str or os.path
+    path_to_bids_session : str
         path to the session folder (or to the subject folder, if there are no
         sessions).
     matching_parameters : list of str from AllowedFmapParameterMatching
@@ -836,7 +845,7 @@ def find_compatible_fmaps_for_session(path_to_bids_session, matching_parameters)
         lgr.warning(
             "We cannot add the IntendedFor field: no fmap/ in %s", path_to_bids_session
         )
-        return
+        return None
     fmap_groups = find_fmap_groups(fmap_dir)
 
     # Get a set with all non-fmap json files in the session (exclude SBRef files).
@@ -857,7 +866,9 @@ def find_compatible_fmaps_for_session(path_to_bids_session, matching_parameters)
     return compatible_fmaps
 
 
-def select_fmap_from_compatible_groups(json_file, compatible_fmap_groups, criterion):
+def select_fmap_from_compatible_groups(
+    json_file: str, compatible_fmap_groups: dict[str, list[str]], criterion: str
+) -> Optional[str]:
     """
     Selects the fmap that will be used to correct for distortions in json_file
     from the compatible fmap_groups list, based on the given criterion
@@ -866,7 +877,7 @@ def select_fmap_from_compatible_groups(json_file, compatible_fmap_groups, criter
 
     Parameters
     ----------
-    json_file : str or os.path
+    json_file : str
         path to the json file
     compatible_fmap_groups : dict
         fmap_groups that are compatible with the specific json_file
@@ -875,7 +886,7 @@ def select_fmap_from_compatible_groups(json_file, compatible_fmap_groups, criter
 
     Returns
     -------
-    selected_fmap_key : str or os.path
+    selected_fmap_key : str
         key from the compatible_fmap_groups for the selected fmap group
     """
     if len(compatible_fmap_groups) == 0:
@@ -888,12 +899,12 @@ def select_fmap_from_compatible_groups(json_file, compatible_fmap_groups, criter
     modality_folders = set(
         op.dirname(fmap) for v in compatible_fmap_groups.values() for fmap in v
     )  # there should be only one value, ending in 'fmap'
-    sess_folder = set(op.dirname(k) for k in modality_folders)
-    if len(sess_folder) > 1:
+    sess_folders = set(op.dirname(k) for k in modality_folders)
+    if len(sess_folders) > 1:
         # for now, we only deal with single sessions:
         raise RuntimeError
     # if we made it here, we have only one session:
-    sess_folder = list(sess_folder)[0]
+    sess_folder = list(sess_folders)[0]
 
     # get acquisition times from '_scans.tsv':
     try:
@@ -942,11 +953,15 @@ def select_fmap_from_compatible_groups(json_file, compatible_fmap_groups, criter
         selected_fmap_key = [
             k for k, v in diff_fmaps_acq_times.items() if v == min_diff_acq_times
         ][0]
+    else:
+        raise ValueError(f"Invalid 'criterion' value: {criterion!r}")
 
     return selected_fmap_key
 
 
-def populate_intended_for(path_to_bids_session, matching_parameters, criterion):
+def populate_intended_for(
+    path_to_bids_session: str, matching_parameters: str | list[str], criterion: str
+) -> None:
     """
     Adds the 'IntendedFor' field to the fmap .json files in a session folder.
     It goes through the session folders and for every json file, it finds
@@ -961,7 +976,7 @@ def populate_intended_for(path_to_bids_session, matching_parameters, criterion):
 
     Parameters
     ----------
-    path_to_bids_session : str or os.path
+    path_to_bids_session : str
         path to the session folder (or to the subject folder, if there are no
         sessions).
     matching_parameters : list of str from AllowedFmapParameterMatching
@@ -1004,6 +1019,7 @@ def populate_intended_for(path_to_bids_session, matching_parameters, criterion):
     compatible_fmaps = find_compatible_fmaps_for_session(
         path_to_bids_session, matching_parameters=matching_parameters
     )
+    assert compatible_fmaps is not None
     selected_fmaps = {}
     for json_file, fmap_groups in compatible_fmaps.items():
         if not op.dirname(json_file).endswith("fmap"):
@@ -1034,7 +1050,7 @@ def populate_intended_for(path_to_bids_session, matching_parameters, criterion):
                 update_json(fm_json, {"IntendedFor": intended_for}, pretty=True)
 
 
-class BIDSFile(object):
+class BIDSFile:
     """as defined in https://bids-specification.readthedocs.io/en/stable/99-appendices/04-entity-table.html
     which might soon become machine readable
     order matters
@@ -1058,7 +1074,9 @@ class BIDSFile(object):
         "recording",
     ]
 
-    def __init__(self, entities, suffix, extension):
+    def __init__(
+        self, entities: dict[str, str], suffix: str, extension: Optional[str]
+    ) -> None:
         self._entities = entities
         self._suffix = suffix
         self._extension = extension
@@ -1076,7 +1094,7 @@ class BIDSFile(object):
             return False
 
     @classmethod
-    def parse(cls, filename):
+    def parse(cls, filename: str) -> BIDSFile:
         """Parse the filename for BIDS entities, suffix and extension"""
         # use re.findall to find all lower-case-letters + '-' + alphanumeric + '_' pairs:
         entities_list = re.findall("([a-z]+)-([a-zA-Z0-9]+)[_]*", filename)
@@ -1093,7 +1111,7 @@ class BIDSFile(object):
             suffix, extension = ending, None
         return BIDSFile(entities, suffix, extension)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """reconstitute in a legit BIDS filename using the order from entity table"""
         if "sub" not in self._entities:
             raise ValueError("The 'sub-' entity is mandatory")
@@ -1112,15 +1130,15 @@ class BIDSFile(object):
             + extension
         )
 
-    def __getitem__(self, entity):
+    def __getitem__(self, entity: str) -> Optional[str]:
         return self._entities[entity] if entity in self._entities else None
 
     def __setitem__(
-        self, entity, value
-    ):  # would puke with some exception if already known
+        self, entity: str, value: str
+    ) -> None:  # would puke with some exception if already known
         return self.set(entity, value, overwrite=False)
 
-    def set(self, entity, value, overwrite=True):
+    def set(self, entity: str, value: str, overwrite: bool = True) -> None:
         if entity not in self._entities:
             # just set it; no complains here
             self._entities[entity] = value
@@ -1143,15 +1161,15 @@ class BIDSFile(object):
             )
 
     @property  # as needed make them RW
-    def suffix(self):
+    def suffix(self) -> str:
         return self._suffix
 
     @property
-    def extension(self):
+    def extension(self) -> Optional[str]:
         return self._extension
 
 
-def sanitize_label(label):
+def sanitize_label(label: str) -> str:
     """Strips any non-BIDS compliant characters within label
 
     Parameters

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -13,6 +13,7 @@ import hashlib
 import logging
 import os
 import os.path as op
+from pathlib import Path
 import re
 from typing import Any, Optional
 import warnings
@@ -461,7 +462,9 @@ def find_subj_ses(f_name: str) -> tuple[Optional[str], Optional[str]]:
     return res.get("subj", None), res.get("ses", None)
 
 
-def save_scans_key(item, bids_files: list[str]) -> None:
+def save_scans_key(
+    item: tuple[str, tuple[str, ...], list[str]], bids_files: list[str]
+) -> None:
     """
     Parameters
     ----------
@@ -555,11 +558,11 @@ def add_rows_to_scans_keys_file(fn: str, newrows: dict[str, list[str]]) -> None:
         writer.writerows([header] + data_rows_sorted)
 
 
-def get_formatted_scans_key_row(dcm_fn) -> list[str]:
+def get_formatted_scans_key_row(dcm_fn: str | Path) -> list[str]:
     """
     Parameters
     ----------
-    item
+    dcm_fn: str
 
     Returns
     -------
@@ -1186,7 +1189,7 @@ def sanitize_label(label: str) -> str:
     clean_label = "".join(x for x in label if x.isalnum())
     if not clean_label:
         raise ValueError(
-            "Label became empty after cleanup.  Please provide manually "
+            "Label became empty after cleanup.  Please manually provide "
             "a suitable alphanumeric label."
         )
     if clean_label != label:

--- a/heudiconv/cli/monitor.py
+++ b/heudiconv/cli/monitor.py
@@ -164,7 +164,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main():
+def main() -> None:
     parsed = parse_args()
     print("Got {0}".format(parsed))
     # open database

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
 
 from argparse import ArgumentParser
 import logging
 import os
 import sys
+from typing import Optional
 
 from .. import __version__
 from ..main import workflow
@@ -11,7 +13,7 @@ from ..main import workflow
 lgr = logging.getLogger(__name__)
 
 
-def main(argv=None):
+def main(argv: Optional[list[str]] = None) -> None:
     logging.basicConfig(
         format="%(levelname)s: %(message)s",
         level=getattr(logging, os.environ.get("HEUDICONV_LOG_LEVEL", "INFO")),
@@ -28,7 +30,7 @@ def main(argv=None):
     workflow(**kwargs)
 
 
-def get_parser():
+def get_parser() -> ArgumentParser:
     docstr = """Example:
              heudiconv -d 'rawdata/{subject}' -o . -f heuristic.py -s s1 s2 s3"""
     parser = ArgumentParser(description=docstr)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -124,7 +124,7 @@ def prep_conversion(
     anon_sid: Optional[str],
     anon_outdir: Optional[str],
     with_prov: bool,
-    ses: str | int | None,
+    ses: Optional[str],
     bids_options: Optional[str],
     seqinfo: Optional[dict[SeqInfo, list[str]]],
     min_meta: bool,

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     if sys.version_info >= (3, 8):
         from typing import TypedDict
     else:
-        from type_extensions import TypedDict
+        from typing_extensions import TypedDict
 
     class PopulateIntendedForOpts(TypedDict, total=False):
         matching_parameters: str | list[str]

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -26,6 +26,7 @@ from .dicoms import (
 )
 from .due import Doi, due
 from .utils import (
+    SeqInfo,
     TempDirs,
     assure_no_file_exists,
     clear_temp_dicoms,
@@ -35,7 +36,6 @@ from .utils import (
     safe_copyfile,
     safe_movefile,
     save_json,
-    seqinfo_fields,
     set_readonly,
     treat_infofile,
     write_config,
@@ -201,7 +201,7 @@ def prep_conversion(
         # allow to overwrite even if was present under git-annex already
         assure_no_file_exists(dicominfo_file)
         with open(dicominfo_file, "wt") as fp:
-            fp.write("\t".join([val for val in seqinfo_fields]) + "\n")
+            fp.write("\t".join(SeqInfo._fields) + "\n")
             for seq in seqinfo_list:
                 fp.write("\t".join([str(val) for val in seq]) + "\n")
         lgr.debug("Calling out to %s.infodict", heuristic)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __docformat__ = "numpy"
 
 import logging

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -32,14 +32,12 @@ lgr = logging.getLogger(__name__)
 total_files = 0
 
 
-def create_seqinfo(
-    mw: dw.MosaicWrapper, series_files: list[str], series_id: str
-) -> SeqInfo:
+def create_seqinfo(mw: dw.Wrapper, series_files: list[str], series_id: str) -> SeqInfo:
     """Generate sequence info
 
     Parameters
     ----------
-    mw: MosaicWrapper
+    mw: Wrapper
     series_files: list
     series_id: str
     """

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -105,7 +105,7 @@ def create_seqinfo(
 
 
 def validate_dicom(
-    fl: str, dcmfilter: Optional[Callable[[Any], Any]]
+    fl: str, dcmfilter: Optional[Callable[[dcm.dataset.Dataset], Any]]
 ) -> Optional[tuple[dw.Wrapper, tuple[int, str], Optional[str]]]:
     """
     Parse DICOM attributes. Returns None if not valid.
@@ -165,10 +165,12 @@ def group_dicoms_into_seqinfos(
     files: list[str],
     grouping: str,
     file_filter: Optional[Callable[[str], Any]] = None,
-    dcmfilter: Optional[Callable[[Any], Any]] = None,
+    dcmfilter: Optional[Callable[[dcm.dataset.Dataset], Any]] = None,
     flatten: Literal[False] = False,
     custom_grouping: str
-    | Callable[[list[str], Optional[Callable[[Any], Any]], type[SeqInfo]], Any]
+    | Callable[
+        [list[str], Optional[Callable[[dcm.dataset.Dataset], Any]], type[SeqInfo]], Any
+    ]
     | None = None,
 ) -> dict[Optional[str], dict[SeqInfo, list[str]]]:
     ...
@@ -179,11 +181,13 @@ def group_dicoms_into_seqinfos(
     files: list[str],
     grouping: str,
     file_filter: Optional[Callable[[str], Any]] = None,
-    dcmfilter: Optional[Callable[[Any], Any]] = None,
+    dcmfilter: Optional[Callable[[dcm.dataset.Dataset], Any]] = None,
     *,
     flatten: Literal[True],
     custom_grouping: str
-    | Callable[[list[str], Optional[Callable[[Any], Any]], type[SeqInfo]], Any]
+    | Callable[
+        [list[str], Optional[Callable[[dcm.dataset.Dataset], Any]], type[SeqInfo]], Any
+    ]
     | None = None,
 ) -> dict[SeqInfo, list[str]]:
     ...
@@ -193,10 +197,12 @@ def group_dicoms_into_seqinfos(
     files: list[str],
     grouping: str,
     file_filter: Optional[Callable[[str], Any]] = None,
-    dcmfilter: Optional[Callable[[Any], Any]] = None,
+    dcmfilter: Optional[Callable[[dcm.dataset.Dataset], Any]] = None,
     flatten: Literal[False, True] = False,
     custom_grouping: str
-    | Callable[[list[str], Optional[Callable[[Any], Any]], type[SeqInfo]], Any]
+    | Callable[
+        [list[str], Optional[Callable[[dcm.dataset.Dataset], Any]], type[SeqInfo]], Any
+    ]
     | None = None,
 ) -> dict[Optional[str], dict[SeqInfo, list[str]]] | dict[SeqInfo, list[str]]:
     """Process list of dicoms and return seqinfo and file group

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -9,7 +9,7 @@ import os.path as op
 from pathlib import Path
 import sys
 import tarfile
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, overload
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, cast, overload
 from unittest.mock import patch
 import warnings
 
@@ -261,7 +261,8 @@ def group_dicoms_into_seqinfos(
         if custom_grouping is None:
             raise RuntimeError("Custom grouping is not defined in heuristic")
         if callable(custom_grouping):
-            return custom_grouping(files, dcmfilter, SeqInfo)
+            return cast(Dict[SeqInfo, List[str]],
+                        custom_grouping(files, dcmfilter, SeqInfo))
         grouping = custom_grouping
         study_customgroup = None
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -628,7 +628,7 @@ def embed_dicom_and_nifti_metadata(
 
 
 def embed_metadata_from_dicoms(
-    bids_options: Optional[Any],
+    bids_options: Optional[str],
     item_dicoms: list[str],
     outname: str,
     outname_bids: str,

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -1,17 +1,27 @@
 # dicom operations
-from collections import OrderedDict
+from __future__ import annotations
+
+from collections.abc import Callable
 import datetime
 import logging
 import os
 import os.path as op
+from pathlib import Path
+import sys
 import tarfile
-from typing import List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, overload
 from unittest.mock import patch
 import warnings
 
 import pydicom as dcm
 
-from .utils import SeqInfo, get_typed_attr, load_json, set_readonly
+from .utils import SeqInfo, TempDirs, get_typed_attr, load_json, set_readonly
+
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -22,7 +32,9 @@ lgr = logging.getLogger(__name__)
 total_files = 0
 
 
-def create_seqinfo(mw, series_files, series_id):
+def create_seqinfo(
+    mw: dw.MosaicWrapper, series_files: list[str], series_id: str
+) -> SeqInfo:
     """Generate sequence info
 
     Parameters
@@ -35,7 +47,7 @@ def create_seqinfo(mw, series_files, series_id):
     accession_number = dcminfo.get("AccessionNumber")
 
     # TODO: do not group echoes by default
-    size = list(mw.image_shape) + [len(series_files)]
+    size: list[int] = list(mw.image_shape) + [len(series_files)]
     if len(size) < 4:
         size.append(1)
 
@@ -60,7 +72,7 @@ def create_seqinfo(mw, series_files, series_id):
     global total_files
     total_files += len(series_files)
 
-    seqinfo = SeqInfo(
+    return SeqInfo(
         total_files_till_now=total_files,
         example_dcm_file=op.basename(series_files[0]),
         series_id=series_id,
@@ -90,10 +102,11 @@ def create_seqinfo(mw, series_files, series_id):
         series_uid=dcminfo.get("SeriesInstanceUID"),
         time=dcminfo.get("AcquisitionTime"),
     )
-    return seqinfo
 
 
-def validate_dicom(fl, dcmfilter):
+def validate_dicom(
+    fl: str, dcmfilter: Optional[Callable[[Any], Any]]
+) -> Optional[tuple[dw.Wrapper, tuple[int, str], Optional[str]]]:
     """
     Parse DICOM attributes. Returns None if not valid.
     """
@@ -112,34 +125,80 @@ def validate_dicom(fl, dcmfilter):
             else ""
         )
     try:
-        series_id = (int(mw.dcm_data.SeriesNumber), mw.dcm_data.ProtocolName)
+        protocol_name = mw.dcm_data.ProtocolName
+        assert isinstance(protocol_name, str)
+        series_id = (int(mw.dcm_data.SeriesNumber), protocol_name)
     except AttributeError as e:
         lgr.warning('Ignoring %s since not quite a "normal" DICOM: %s', fl, e)
-        return
+        return None
     if dcmfilter is not None and dcmfilter(mw.dcm_data):
         lgr.warning("Ignoring %s because of DICOM filter", fl)
-        return
+        return None
     if mw.dcm_data[0x0008, 0x0016].repval in (
         "Raw Data Storage",
         "GrayscaleSoftcopyPresentationStateStorage",
     ):
-        return
+        return None
     try:
         file_studyUID = mw.dcm_data.StudyInstanceUID
+        assert isinstance(file_studyUID, str)
     except AttributeError:
         lgr.info("File {} is missing any StudyInstanceUID".format(fl))
         file_studyUID = None
     return mw, series_id, file_studyUID
 
 
+class SeriesID(NamedTuple):
+    series_number: int
+    protocol_name: str
+    file_studyUID: Optional[str] = None
+
+    def __str__(self) -> str:
+        s = f"{self.series_number}-{self.protocol_name}"
+        if self.file_studyUID is not None:
+            s += f"-{self.file_studyUID}"
+        return s
+
+
+@overload
 def group_dicoms_into_seqinfos(
-    files,
-    grouping,
-    file_filter=None,
-    dcmfilter=None,
-    flatten=False,
-    custom_grouping=None,
-):
+    files: list[str],
+    grouping: str,
+    file_filter: Optional[Callable[[str], Any]] = None,
+    dcmfilter: Optional[Callable[[Any], Any]] = None,
+    flatten: Literal[False] = False,
+    custom_grouping: str
+    | Callable[[list[str], Optional[Callable[[Any], Any]], type[SeqInfo]], Any]
+    | None = None,
+) -> dict[Optional[str], dict[SeqInfo, list[str]]]:
+    ...
+
+
+@overload
+def group_dicoms_into_seqinfos(
+    files: list[str],
+    grouping: str,
+    file_filter: Optional[Callable[[str], Any]] = None,
+    dcmfilter: Optional[Callable[[Any], Any]] = None,
+    *,
+    flatten: Literal[True],
+    custom_grouping: str
+    | Callable[[list[str], Optional[Callable[[Any], Any]], type[SeqInfo]], Any]
+    | None = None,
+) -> dict[SeqInfo, list[str]]:
+    ...
+
+
+def group_dicoms_into_seqinfos(
+    files: list[str],
+    grouping: str,
+    file_filter: Optional[Callable[[str], Any]] = None,
+    dcmfilter: Optional[Callable[[Any], Any]] = None,
+    flatten: Literal[False, True] = False,
+    custom_grouping: str
+    | Callable[[list[str], Optional[Callable[[Any], Any]], type[SeqInfo]], Any]
+    | None = None,
+) -> dict[Optional[str], dict[SeqInfo, list[str]]] | dict[SeqInfo, list[str]]:
     """Process list of dicoms and return seqinfo and file group
     `seqinfo` contains per-sequence extract of fields from DICOMs which
     will be later provided into heuristics to decide on filenames
@@ -179,9 +238,10 @@ def group_dicoms_into_seqinfos(
     # per_accession_number = grouping == 'accession_number'
     lgr.info("Analyzing %d dicoms", len(files))
 
-    groups = [[], []]
-    mwgroup = []
-    studyUID = None
+    group_keys: list[SeriesID] = []
+    group_values: list[int] = []
+    mwgroup: list[dw.Wrapper] = []
+    studyUID: Optional[str] = None
 
     if file_filter:
         nfl_before = len(files)
@@ -207,9 +267,10 @@ def group_dicoms_into_seqinfos(
         if mwinfo is None:
             removeidx.append(idx)
             continue
-        mw, series_id, file_studyUID = mwinfo
+        mw, series_id_, file_studyUID = mwinfo
+        series_id = SeriesID(series_id_[0], series_id_[1])
         if per_studyUID:
-            series_id = series_id + (file_studyUID,)
+            series_id = series_id._replace(file_studyUID=file_studyUID)
 
         if flatten:
             if per_studyUID:
@@ -239,37 +300,38 @@ def group_dicoms_into_seqinfos(
                         mwgroup[idx].dcm_data.get("StudyInstanceUID") == file_studyUID
                     ), "Same series found for multiple different studies"
                 ingrp = True
-                series_id = (
+                series_id = SeriesID(
                     mwgroup[idx].dcm_data.SeriesNumber,
                     mwgroup[idx].dcm_data.ProtocolName,
                 )
                 if per_studyUID:
-                    series_id = series_id + (file_studyUID,)
-                groups[0].append(series_id)
-                groups[1].append(idx)
+                    series_id = series_id._replace(file_studyUID=file_studyUID)
+                group_keys.append(series_id)
+                group_values.append(idx)
 
         if not ingrp:
             mwgroup.append(mw)
-            groups[0].append(series_id)
-            groups[1].append(len(mwgroup) - 1)
+            group_keys.append(series_id)
+            group_values.append(len(mwgroup) - 1)
 
-    group_map = dict(zip(groups[0], groups[1]))
+    group_map = dict(zip(group_keys, group_values))
 
     if removeidx:
         # remove non DICOMS from files
         for idx in sorted(removeidx, reverse=True):
             del files[idx]
 
-    seqinfos = OrderedDict()
+    seqinfos: dict[Optional[str], dict[SeqInfo, list[str]]] = {}
+    flat_seqinfos: dict[SeqInfo, list[str]] = {}
     # for the next line to make any sense the series_id needs to
     # be sortable in a way that preserves the series order
     for series_id, mwidx in sorted(group_map.items()):
         mw = mwgroup[mwidx]
-        series_files = [files[i] for i, s in enumerate(groups[0]) if s == series_id]
+        series_files = [files[i] for i, s in enumerate(group_keys) if s == series_id]
         if per_studyUID:
-            studyUID = series_id[2]
-            series_id = series_id[:2]
-        series_id = "-".join(map(str, series_id))
+            studyUID = series_id.file_studyUID
+            series_id = series_id._replace(file_studyUID=None)
+        series_id_str = str(series_id)
         if mw.image_shape is None:
             # this whole thing has no image data (maybe just PSg DICOMs)
             # If this is a Siemens PhoenixZipReport or PhysioLog, keep it:
@@ -279,8 +341,9 @@ def group_dicoms_into_seqinfos(
             else:
                 # nothing to see here, just move on
                 continue
-        seqinfo = create_seqinfo(mw, series_files, series_id)
+        seqinfo = create_seqinfo(mw, series_files, series_id_str)
 
+        key: Optional[str]
         if per_studyUID:
             key = studyUID
         elif grouping == "accession_number":
@@ -306,35 +369,43 @@ def group_dicoms_into_seqinfos(
         )
 
         if not flatten:
-            if key not in seqinfos:
-                seqinfos[key] = OrderedDict()
-            seqinfos[key][seqinfo] = series_files
+            seqinfos.setdefault(key, {})[seqinfo] = series_files
         else:
-            seqinfos[seqinfo] = series_files
+            flat_seqinfos[seqinfo] = series_files
+
+    if not flatten:
+        entries = len(seqinfos)
+        subentries = sum(map(len, seqinfos.values()))
+    else:
+        entries = len(flat_seqinfos)
+        subentries = sum(map(len, flat_seqinfos.values()))
 
     if per_studyUID:
         lgr.info(
             "Generated sequence info for %d studies with %d entries total",
-            len(seqinfos),
-            sum(map(len, seqinfos.values())),
+            entries,
+            subentries,
         )
     elif grouping == "accession_number":
         lgr.info(
-            "Generated sequence info for %d accession numbers with %d " "entries total",
-            len(seqinfos),
-            sum(map(len, seqinfos.values())),
+            "Generated sequence info for %d accession numbers with %d entries total",
+            entries,
+            subentries,
         )
     else:
-        lgr.info("Generated sequence info with %d entries", len(seqinfos))
-    return seqinfos
+        lgr.info("Generated sequence info with %d entries", entries)
+    if not flatten:
+        return seqinfos
+    else:
+        return flat_seqinfos
 
 
-def get_reproducible_int(dicom_list: List[str]) -> int:
+def get_reproducible_int(dicom_list: list[str]) -> int:
     """Get integer that can be used to reproducibly sort input DICOMs, which is based on when they were acquired.
 
     Parameters
     ----------
-    dicom_list : List[str]
+    dicom_list : list[str]
         Paths to existing DICOM files
 
     Returns
@@ -413,7 +484,9 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     return None
 
 
-def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
+def compress_dicoms(
+    dicom_list: list[str], out_prefix: str, tempdirs: TempDirs, overwrite: bool
+) -> Optional[str]:
     """Archives DICOMs into a tarball
 
     Also tries to do it reproducibly, so takes the date for files
@@ -426,7 +499,7 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
     out_prefix : str
       output path prefix, including the portion of the output file name
       before .dicom.tgz suffix
-    tempdirs : object
+    tempdirs : TempDirs
       TempDirs object to handle multiple tmpdirs
     overwrite : bool
       Overwrite existing tarfiles
@@ -442,7 +515,7 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
 
     if op.exists(outtar) and not overwrite:
         lgr.info("File {} already exists, will not overwrite".format(outtar))
-        return
+        return None
     # tarfile encodes current time.time inside making those non-reproducible
     # so we should choose which date to use.
     # Solution from DataLad although ugly enough:
@@ -479,7 +552,18 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
     return outtar
 
 
-def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
+# Note: This function is passed to nipype by `embed_metadata_from_dicoms()`,
+# and nipype reparses the function source in a clean namespace that does not
+# have `from __future__ import annotations` enabled.  Thus, we need to use
+# Python 3.7-compatible annotations on this function, and any non-builtin types
+# used in the annotations need to be included by import statements passed to
+# the `nipype.Function` constructor.
+def embed_dicom_and_nifti_metadata(
+    dcmfiles: List[str],
+    niftifile: str,
+    infofile: str | Path,
+    bids_info: Optional[Dict[str, Any]],
+) -> None:
     """Embed metadata from nifti (affine etc) and dicoms into infofile (json)
 
     `niftifile` should exist. Its affine's orientation information is used while
@@ -522,12 +606,13 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
         )
 
     orig_nii = nb.load(niftifile)
-    aff = orig_nii.affine
+    aff = orig_nii.affine  # type: ignore[attr-defined]
     ornt = nb.orientations.io_orientation(aff)
     axcodes = nb.orientations.ornt2axcodes(ornt)
     new_nii = stack.to_nifti(voxel_order="".join(axcodes), embed_meta=True)
-    meta_info = ds.NiftiWrapper(new_nii).meta_ext.to_json()
-    meta_info = json.loads(meta_info)
+    meta_info_str = ds.NiftiWrapper(new_nii).meta_ext.to_json()
+    meta_info = json.loads(meta_info_str)
+    assert isinstance(meta_info, dict)
 
     if bids_info:
         meta_info.update(bids_info)
@@ -537,15 +622,15 @@ def embed_dicom_and_nifti_metadata(dcmfiles, niftifile, infofile, bids_info):
 
 
 def embed_metadata_from_dicoms(
-    bids_options,
-    item_dicoms,
-    outname,
-    outname_bids,
-    prov_file,
-    scaninfo,
-    tempdirs,
-    with_prov,
-):
+    bids_options: Optional[Any],
+    item_dicoms: list[str],
+    outname: str,
+    outname_bids: str,
+    prov_file: str,
+    scaninfo: str,
+    tempdirs: TempDirs,
+    with_prov: bool,
+) -> None:
     """
     Enhance sidecar information file with more information from DICOMs
 
@@ -569,7 +654,8 @@ def embed_metadata_from_dicoms(
     tmpdir = tempdirs(prefix="embedmeta")
 
     # We need to assure that paths are absolute if they are relative
-    item_dicoms = list(map(op.abspath, item_dicoms))
+    # <https://github.com/python/mypy/issues/9864>
+    item_dicoms = list(map(op.abspath, item_dicoms))  # type: ignore[arg-type]
 
     embedfunc = Node(
         Function(
@@ -580,6 +666,10 @@ def embed_metadata_from_dicoms(
                 "bids_info",
             ],
             function=embed_dicom_and_nifti_metadata,
+            imports=[
+                "from pathlib import Path",
+                "from typing import Any, Dict, List, Optional",
+            ],
         ),
         name="embedder",
     )
@@ -615,7 +705,12 @@ def embed_metadata_from_dicoms(
         os.chdir(cwd)
 
 
-def parse_private_csa_header(dcm_data, _public_attr, private_attr, default=None):
+def parse_private_csa_header(
+    dcm_data: dcm.dataset.Dataset,
+    _public_attr: str,
+    private_attr: str,
+    default: Optional[str] = None,
+) -> str:
     """
     Parses CSA header in cases where value is not defined publicly
 
@@ -650,4 +745,5 @@ def parse_private_csa_header(dcm_data, _public_attr, private_attr, default=None)
     except Exception as e:
         lgr.debug("Failed to parse CSA header: %s", str(e))
         val = default or ""
+    assert isinstance(val, str)
     return val

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -410,6 +410,7 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     series_time = dcm_data.get("SeriesTime")
     if not (series_date is None or series_time is None):
         return datetime.datetime.strptime(series_date + series_time, "%Y%m%d%H%M%S.%f")
+    return None
 
 
 def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -632,7 +632,7 @@ def embed_metadata_from_dicoms(
     item_dicoms: list[str],
     outname: str,
     outname_bids: str,
-    prov_file: str,
+    prov_file: Optional[str],
     scaninfo: str,
     tempdirs: TempDirs,
     with_prov: bool,
@@ -702,6 +702,7 @@ def embed_metadata_from_dicoms(
         res = embedfunc.run()
         set_readonly(scaninfo)
         if with_prov:
+            assert isinstance(prov_file, str)
             g = res.provenance.rdf()
             g.parse(prov_file, format="turtle")
             g.serialize(prov_file, format="turtle")

--- a/heudiconv/external/tests/test_dlad.py
+++ b/heudiconv/external/tests/test_dlad.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from pathlib import Path
+
 import pytest
 
 from ..dlad import mark_sensitive
@@ -6,10 +10,10 @@ from ...utils import create_tree
 dl = pytest.importorskip("datalad.api")
 
 
-def test_mark_sensitive(tmpdir):
-    ds = dl.Dataset(str(tmpdir)).create(force=True)
+def test_mark_sensitive(tmp_path: Path) -> None:
+    ds = dl.Dataset(tmp_path).create(force=True)
     create_tree(
-        str(tmpdir),
+        str(tmp_path),
         {
             "f1": "d1",
             "f2": "d2",

--- a/heudiconv/heuristics/banda-bids.py
+++ b/heudiconv/heuristics/banda-bids.py
@@ -1,10 +1,21 @@
-def create_key(template, outtype=("nii.gz", "dicom"), annotation_classes=None):
+from __future__ import annotations
+
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
+
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz", "dicom"),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
     return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(seqinfo: list[SeqInfo]) -> dict[tuple[str, tuple[str, ...], None], list]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -40,7 +51,7 @@ def infotodict(seqinfo):
     dwi_sbref = create_key("sub-{subject}/dwi/sub-{subject}_run-{item:02d}_sbref")
     fmap = create_key("sub-{subject}/fmap/sub-{subject}_dir-{dir}_run-{item:02d}_epi")
 
-    info = {
+    info: dict[tuple[str, tuple[str, ...], None], list] = {
         t1: [],
         t2: [],
         rest: [],

--- a/heudiconv/heuristics/bids_ME.py
+++ b/heudiconv/heuristics/bids_ME.py
@@ -4,14 +4,26 @@ It only cares about converting sequences which have _ME_ in their
 series_description and outputs to BIDS.
 """
 
+from __future__ import annotations
 
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
+
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list[str]]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -25,7 +37,11 @@ def infotodict(seqinfo):
     megre_mag = create_key("sub-{subject}/anat/sub-{subject}_part-mag_MEGRE")
     megre_phase = create_key("sub-{subject}/anat/sub-{subject}_part-phase_MEGRE")
 
-    info = {bold: [], megre_mag: [], megre_phase: []}
+    info: dict[tuple[str, tuple[str, ...], None], list[str]] = {
+        bold: [],
+        megre_mag: [],
+        megre_phase: [],
+    }
     for s in seqinfo:
         if "_ME_" in s.series_description:
             info[bold].append(s.series_id)

--- a/heudiconv/heuristics/bids_PhoenixReport.py
+++ b/heudiconv/heuristics/bids_PhoenixReport.py
@@ -4,14 +4,26 @@ It only cares about converting a series with have PhoenixZIPReport in their
 series_description and outputs **only to sourcedata**.
 """
 
+from __future__ import annotations
 
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
+
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list[dict[str, str]]]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -39,7 +51,11 @@ def infotodict(seqinfo):
         "sub-{subject}/misc/sub-{subject}_phoenix", outtype=("dicom",)
     )
 
-    info = {sbref: [], scout: [], phoenix_doc: []}
+    info: dict[tuple[str, tuple[str, ...], None], list[dict[str, str]]] = {
+        sbref: [],
+        scout: [],
+        phoenix_doc: [],
+    }
     for s in seqinfo:
         if (
             "PhoenixZIPReport" in s.series_description

--- a/heudiconv/heuristics/bids_with_ses.py
+++ b/heudiconv/heuristics/bids_with_ses.py
@@ -1,10 +1,23 @@
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+from __future__ import annotations
+
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
+
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -47,7 +60,7 @@ def infotodict(seqinfo):
         outtype=outdicom,
     )
 
-    info = {
+    info: dict[tuple[str, tuple[str, ...], None], list] = {
         t1: [],
         t2: [],
         dwi_ap: [],

--- a/heudiconv/heuristics/cmrr_heuristic.py
+++ b/heudiconv/heuristics/cmrr_heuristic.py
@@ -1,10 +1,23 @@
-def create_key(template, outtype=("nii.gz", "dicom"), annotation_classes=None):
+from __future__ import annotations
+
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
+
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz", "dicom"),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
     return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -33,7 +46,7 @@ def infotodict(seqinfo):
         "fmap/sub-{subject}_acq-dwi{acq}_dir-{dir}_run-{item:02d}_epi"
     )
 
-    info = {
+    info: dict[tuple[str, tuple[str, ...], None], list] = {
         t1: [],
         t2: [],
         rest: [],

--- a/heudiconv/heuristics/convertall.py
+++ b/heudiconv/heuristics/convertall.py
@@ -1,10 +1,23 @@
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+from __future__ import annotations
+
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
+
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list[str]]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -16,7 +29,7 @@ def infotodict(seqinfo):
     """
 
     data = create_key("run{item:03d}")
-    info = {data: []}
+    info: dict[tuple[str, tuple[str, ...], None], list[str]] = {data: []}
 
     for s in seqinfo:
         """

--- a/heudiconv/heuristics/example.py
+++ b/heudiconv/heuristics/example.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
 # Dictionary to specify options for the `populate_intended_for`.
 # Valid options are defined in 'bids.py' (for 'matching_parameters':
 # ['Shims', 'ImagingVolume',]; for 'criterion': ['First', 'Closest']
@@ -7,13 +13,19 @@ POPULATE_INTENDED_FOR_OPTS = {
 }
 
 
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -40,7 +52,7 @@ def infotodict(seqinfo):
     t1 = create_key("anatomy/T1_{item:03d}")
     asl = create_key("rsfmri/asl_run{item:03d}/asl")
     aslcal = create_key("rsfmri/asl_run{item:03d}/cal_{subindex:03d}")
-    info = {
+    info: dict[tuple[str, tuple[str, ...], None], list] = {
         rs: [],
         boldt1: [],
         boldt2: [],
@@ -60,54 +72,54 @@ def infotodict(seqinfo):
     }
     last_run = len(seqinfo)
     for s in seqinfo:
-        sl, nt = (s[8], s[9])
-        if (sl == 176) and (nt == 1) and ("MPRAGE" in s[12]):
-            info[t1] = [s[2]]
-        elif (nt > 60) and ("ge_func_2x2x2_Resting" in s[12]):
-            if not s[13]:
-                info[rs].append(int(s[2]))
+        sl, nt = (s.dim3, s.dim4)
+        if (sl == 176) and (nt == 1) and ("MPRAGE" in s.protocol_name):
+            info[t1] = [s.series_id]
+        elif (nt > 60) and ("ge_func_2x2x2_Resting" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[rs].append(int(s.series_id))
         elif (
             (nt == 156)
-            and ("ge_functionals_128_PACE_ACPC-30" in s[12])
-            and s[2] < last_run
+            and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name)
+            and s.series_id < last_run
         ):
-            if not s[13]:
-                info[boldt1].append(s[2])
-                last_run = s[2]
-        elif (nt == 155) and ("ge_functionals_128_PACE_ACPC-30" in s[12]):
-            if not s[13]:
-                info[boldt2].append(s[2])
-        elif (nt == 222) and ("ge_functionals_128_PACE_ACPC-30" in s[12]):
-            if not s[13]:
-                info[boldt3].append(s[2])
-        elif (nt == 114) and ("ge_functionals_128_PACE_ACPC-30" in s[12]):
-            if not s[13]:
-                info[boldt4].append(s[2])
-        elif (nt == 156) and ("ge_functionals_128_PACE_ACPC-30" in s[12]):
-            if not s[13] and (s[2] > last_run):
-                info[boldt5].append(s[2])
-        elif (nt == 324) and ("ge_func_3.1x3.1x4_PACE" in s[12]):
-            if not s[13]:
-                info[boldt6].append(s[2])
-        elif (nt == 250) and ("ge_func_3.1x3.1x4_PACE" in s[12]):
-            if not s[13]:
-                info[boldt7].append(s[2])
-        elif (nt == 136) and ("ge_func_3.1x3.1x4_PACE" in s[12]):
-            if not s[13]:
-                info[boldt8].append(s[2])
-        elif (nt == 101) and ("ep2d_pasl_FairQuipssII" in s[12]):
-            if not s[13]:
-                info[asl].append(s[2])
-        elif (nt == 1) and ("ep2d_pasl_FairQuipssII" in s[12]):
-            info[aslcal][0].append(s[2])
-        elif (sl > 1) and (nt == 70) and ("DIFFUSION" in s[12]):
-            info[dwi].append(s[2])
-        elif "field_mapping_128" in s[12]:
-            info[fm1].append(s[2])
-        elif "field_mapping_3.1" in s[12]:
-            info[fm2].append(s[2])
-        elif "field_mapping_Resting" in s[12]:
-            info[fmrest].append(s[2])
+            if not s.is_motion_corrected:
+                info[boldt1].append(s.series_id)
+                last_run = s.series_id
+        elif (nt == 155) and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[boldt2].append(s.series_id)
+        elif (nt == 222) and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[boldt3].append(s.series_id)
+        elif (nt == 114) and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[boldt4].append(s.series_id)
+        elif (nt == 156) and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name):
+            if not s.is_motion_corrected and (s.series_id > last_run):
+                info[boldt5].append(s.series_id)
+        elif (nt == 324) and ("ge_func_3.1x3.1x4_PACE" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[boldt6].append(s.series_id)
+        elif (nt == 250) and ("ge_func_3.1x3.1x4_PACE" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[boldt7].append(s.series_id)
+        elif (nt == 136) and ("ge_func_3.1x3.1x4_PACE" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[boldt8].append(s.series_id)
+        elif (nt == 101) and ("ep2d_pasl_FairQuipssII" in s.protocol_name):
+            if not s.is_motion_corrected:
+                info[asl].append(s.series_id)
+        elif (nt == 1) and ("ep2d_pasl_FairQuipssII" in s.protocol_name):
+            info[aslcal][0].append(s.series_id)
+        elif (sl > 1) and (nt == 70) and ("DIFFUSION" in s.protocol_name):
+            info[dwi].append(s.series_id)
+        elif "field_mapping_128" in s.protocol_name:
+            info[fm1].append(s.series_id)
+        elif "field_mapping_3.1" in s.protocol_name:
+            info[fm2].append(s.series_id)
+        elif "field_mapping_Resting" in s.protocol_name:
+            info[fmrest].append(s.series_id)
         else:
             pass
     return info

--- a/heudiconv/heuristics/example.py
+++ b/heudiconv/heuristics/example.py
@@ -72,20 +72,26 @@ def infotodict(
     }
     last_run = len(seqinfo)
     for s in seqinfo:
+        series_num_str = s.series_id.split('-', 1)[0]
+        if not series_num_str.isdecimal():
+            raise ValueError(
+                f"This heuristic can operate only on data when series_id has form <series-number>-<something else>, "
+                f"and <series-number> is a numeric number. Got series_id={s.series_id}")
+        series_num: int = int(series_num_str)
         sl, nt = (s.dim3, s.dim4)
         if (sl == 176) and (nt == 1) and ("MPRAGE" in s.protocol_name):
             info[t1] = [s.series_id]
         elif (nt > 60) and ("ge_func_2x2x2_Resting" in s.protocol_name):
             if not s.is_motion_corrected:
-                info[rs].append(int(s.series_id))
+                info[rs].append(s.series_id)
         elif (
             (nt == 156)
             and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name)
-            and s.series_id < last_run
+            and series_num < last_run
         ):
             if not s.is_motion_corrected:
                 info[boldt1].append(s.series_id)
-                last_run = s.series_id
+                last_run = series_num
         elif (nt == 155) and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name):
             if not s.is_motion_corrected:
                 info[boldt2].append(s.series_id)
@@ -96,7 +102,7 @@ def infotodict(
             if not s.is_motion_corrected:
                 info[boldt4].append(s.series_id)
         elif (nt == 156) and ("ge_functionals_128_PACE_ACPC-30" in s.protocol_name):
-            if not s.is_motion_corrected and (s.series_id > last_run):
+            if not s.is_motion_corrected and (series_num > last_run):
                 info[boldt5].append(s.series_id)
         elif (nt == 324) and ("ge_func_3.1x3.1x4_PACE" in s.protocol_name):
             if not s.is_motion_corrected:

--- a/heudiconv/heuristics/multires_7Tbold.py
+++ b/heudiconv/heuristics/multires_7Tbold.py
@@ -1,13 +1,25 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pydicom as dcm
+
+from heudiconv.utils import SeqInfo
+
 scaninfo_suffix = ".json"
 
 
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def filter_dicom(dcmdata):
+def filter_dicom(dcmdata: dcm.dataset.Dataset) -> bool:
     """Return True if a DICOM dataset should be filtered out, else False"""
     comments = getattr(dcmdata, "ImageComments", "")
     if len(comments):
@@ -17,7 +29,7 @@ def filter_dicom(dcmdata):
     return False
 
 
-def extract_moco_params(basename, _outypes, dicoms):
+def extract_moco_params(basename: str, _outypes, dicoms) -> None:
     if "_rec-dico" not in basename:
         return
     from pydicom import dcmread
@@ -47,7 +59,9 @@ def extract_moco_params(basename, _outypes, dicoms):
 custom_callable = extract_moco_params
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list[str]]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -58,17 +72,17 @@ def infotodict(seqinfo):
     subindex: sub index within group
     """
 
-    info = {}
+    info: dict[tuple[str, tuple[str, ...], None], list[str]] = {}
     for s in seqinfo:
-        if "_bold_" not in s[12]:
+        if "_bold_" not in s.protocol_name:
             continue
-        if "_coverage" not in s[12]:
+        if "_coverage" not in s.protocol_name:
             label = "orientation%s_run-{item:02d}"
         else:
             label = "coverage%s"
-        resolution = s[12].split("_")[5][:-3]
+        resolution = s.protocol_name.split("_")[5][:-3]
         assert float(resolution)
-        if s[13] is True:
+        if s.is_motion_corrected:
             label = label % ("_rec-dico",)
         else:
             label = label % ("",)
@@ -83,6 +97,6 @@ def infotodict(seqinfo):
 
         if key not in info:
             info[key] = []
-        info[key].append(s[2])
+        info[key].append(s.series_id)
 
     return info

--- a/heudiconv/heuristics/multires_7Tbold.py
+++ b/heudiconv/heuristics/multires_7Tbold.py
@@ -29,7 +29,9 @@ def filter_dicom(dcmdata: dcm.dataset.Dataset) -> bool:
     return False
 
 
-def extract_moco_params(basename: str, _outypes, dicoms) -> None:
+def extract_moco_params(
+    basename: str, _outypes: tuple[str, ...], dicoms: list[str]
+) -> None:
     if "_rec-dico" not in basename:
         return
     from pydicom import dcmread

--- a/heudiconv/heuristics/studyforrest_phase2.py
+++ b/heudiconv/heuristics/studyforrest_phase2.py
@@ -1,13 +1,25 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
 scaninfo_suffix = ".json"
 
 
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list[str]]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -23,11 +35,11 @@ def infotodict(seqinfo):
         "retmap": "retmap",
         "visloc": "objectcategories",
     }
-    info = {}
+    info: dict[tuple[str, tuple[str, ...], None], list[str]] = {}
     for s in seqinfo:
-        if "EPI_3mm" not in s[12]:
+        if "EPI_3mm" not in s.protocol_name:
             continue
-        label = s[12].split("_")[2].split()[0].strip("1234567890").lower()
+        label = s.protocol_name.split("_")[2].split()[0].strip("1234567890").lower()
         if label in ("movie", "retmap", "visloc"):
             key = create_key(
                 "ses-localizer/func/{subject}_ses-localizer_task-%s_run-{item:01d}_bold"
@@ -41,14 +53,14 @@ def infotodict(seqinfo):
         elif label == "r":
             key = create_key(
                 "ses-movie/func/{subject}_ses-movie_task-movie_run-%i_bold"
-                % int(s[12].split("_")[2].split()[0][-1])
+                % int(s.protocol_name.split("_")[2].split()[0][-1])
             )
         else:
-            raise (RuntimeError, "YOU SHALL NOT PASS!")
+            raise RuntimeError("YOU SHALL NOT PASS!")
 
         if key not in info:
             info[key] = []
 
-        info[key].append(s[2])
+        info[key].append(s.series_id)
 
     return info

--- a/heudiconv/heuristics/test_b0dwi_for_fmap.py
+++ b/heudiconv/heuristics/test_b0dwi_for_fmap.py
@@ -6,14 +6,26 @@ chooses to extract as fmap (pepolar case) doesn't produce _bvecs/
 _bvals json files, while it does for dwi images
 """
 
+from __future__ import annotations
 
-def create_key(template, outtype=("nii.gz",), annotation_classes=None):
+from typing import Optional
+
+from heudiconv.utils import SeqInfo
+
+
+def create_key(
+    template: Optional[str],
+    outtype: tuple[str, ...] = ("nii.gz",),
+    annotation_classes: None = None,
+) -> tuple[str, tuple[str, ...], None]:
     if template is None or not template:
         raise ValueError("Template must be a valid format string")
-    return template, outtype, annotation_classes
+    return (template, outtype, annotation_classes)
 
 
-def infotodict(seqinfo):
+def infotodict(
+    seqinfo: list[SeqInfo],
+) -> dict[tuple[str, tuple[str, ...], None], list[str]]:
     """Heuristic evaluator for determining which runs belong where
 
     allowed template fields - follow python string module:
@@ -26,7 +38,7 @@ def infotodict(seqinfo):
     fmap = create_key("sub-{subject}/fmap/sub-{subject}_acq-b0dwi_epi")
     dwi = create_key("sub-{subject}/dwi/sub-{subject}_acq-b0dwi_dwi")
 
-    info = {fmap: [], dwi: []}
+    info: dict[tuple[str, tuple[str, ...], None], list[str]] = {fmap: [], dwi: []}
     for s in seqinfo:
         if "DIFFUSION" in s.image_type:
             info[fmap].append(s.series_id)

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -17,6 +17,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
+    "Typing :: Typed",
 ]
 
 PYTHON_REQUIRES = ">=3.7"

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -74,11 +74,11 @@ def process_extra_commands(
         Heudiconv command to run
     files : list of str
         List of files
-    heuristic : str
+    heuristic : str or None
         Path to heuristic file or name of builtin heuristic.
-    session : str
+    session : str or None
         Session identifier
-    subjs : list of str
+    subjs : None or list of str
         List of subject identifiers
     grouping : {'studyUID', 'accession_number', 'all', 'custom'}
         How to group dicoms.
@@ -203,7 +203,7 @@ def workflow(
     dicom_dir_template: Optional[str] = None,
     files: Optional[list[str]] = None,
     subjs: Optional[list[str]] = None,
-    converter: Optional[str] = "dcm2niix",
+    converter: str = "dcm2niix",
     outdir: str = ".",
     locator: Optional[str] = None,
     conv_outdir: Optional[str] = None,
@@ -242,10 +242,10 @@ def workflow(
         List of subjects - required for dicom template. If not
         provided, DICOMS would first be "sorted" and subject IDs
         deduced by the heuristic. Default is None.
-    converter : {'dcm2niix', None}, optional
-        Tool to use for DICOM conversion. Setting to None disables
+    converter : {'dcm2niix', 'none'}, optional
+        Tool to use for DICOM conversion. Setting to 'none' disables
         the actual conversion step -- useful for testing heuristics.
-        Default is None.
+        Default is 'dcm2niix'.
     outdir : str, optional
         Output directory for conversion setup (for further
         customization and future reference. This directory will refer

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -415,10 +415,10 @@ def workflow(
     # processed_studydirs = set()
 
     locator_manual, session_manual = locator, session
-    for (locator, session, sid), files_or_seqinfo in study_sessions.items():
+    for (locator, session_, sid), files_or_seqinfo in study_sessions.items():
         # Allow for session to be overloaded from command line
         if session_manual is not None:
-            session = session_manual
+            session_ = session_manual
         if locator_manual is not None:
             locator = locator_manual
         if not len(files_or_seqinfo):
@@ -437,9 +437,11 @@ def workflow(
             lgr.warning("Skipping unknown locator dataset")
             continue
 
-        anon_sid = anonymize_sid(sid, anon_cmd) if anon_cmd else None
-        if anon_cmd:
+        if anon_cmd and sid is not None:
+            anon_sid = anonymize_sid(sid, anon_cmd)
             lgr.info("Anonymized {} to {}".format(sid, anon_sid))
+        else:
+            anon_sid = None
 
         study_outdir = op.join(outdir, locator or "")
         anon_outdir = conv_outdir or outdir
@@ -453,7 +455,7 @@ def workflow(
                 anon_study_outdir,
                 anon_outdir,
                 dlad_sid,
-                session,
+                session_,
                 seqinfo,
                 dicoms,
                 bids_options,
@@ -461,7 +463,7 @@ def workflow(
 
         lgr.info(
             "PROCESSING STARTS: {0}".format(
-                str(dict(subject=sid, outdir=study_outdir, session=session))
+                str(dict(subject=sid, outdir=study_outdir, session=session_))
             )
         )
 
@@ -474,7 +476,7 @@ def workflow(
             anon_sid=anon_sid,
             anon_outdir=anon_study_outdir,
             with_prov=with_prov,
-            ses=session,
+            ses=session_,
             bids_options=bids_options,
             seqinfo=seqinfo,
             min_meta=minmeta,
@@ -485,7 +487,7 @@ def workflow(
 
         lgr.info(
             "PROCESSING DONE: {0}".format(
-                str(dict(subject=sid, outdir=study_outdir, session=session))
+                str(dict(subject=sid, outdir=study_outdir, session=session_))
             )
         )
 

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -13,7 +13,7 @@ from types import ModuleType
 from typing import Any, Optional
 
 from .dicoms import group_dicoms_into_seqinfos
-from .utils import StudySessionInfo, TempDirs, docstring_parameter
+from .utils import SeqInfo, StudySessionInfo, TempDirs, docstring_parameter
 
 lgr = logging.getLogger(__name__)
 tempdirs = TempDirs()
@@ -254,7 +254,7 @@ def get_study_sessions(
             )
 
             def infotoids(
-                seqinfos: Iterable[str], outdir: str  # noqa: U100
+                seqinfos: Iterable[SeqInfo], outdir: str  # noqa: U100
             ) -> dict[str, Optional[str]]:
                 return {"locator": None, "session": None, "subject": None}
 

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -285,7 +285,7 @@ def get_study_sessions(
                         "Existing study session with the same values (%r)."
                         " Skipping DICOMS %s",
                         study_session_info,
-                        *seqinfo.values(),
+                        seqinfo.values(),
                     )
                     continue
             study_sessions[study_session_info] = seqinfo

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -10,7 +10,7 @@ import os.path as op
 import re
 import shutil
 from types import ModuleType
-from typing import Any, Optional
+from typing import Optional
 
 from .dicoms import group_dicoms_into_seqinfos
 from .utils import SeqInfo, StudySessionInfo, TempDirs, docstring_parameter
@@ -156,7 +156,7 @@ def get_study_sessions(
     session: Optional[str],
     sids: Optional[list[str]],
     grouping: str = "studyUID",
-) -> dict[StudySessionInfo, Any]:
+) -> dict[StudySessionInfo, list[str] | dict[SeqInfo, list[str]]]:
     """Sort files or dicom seqinfos into study_sessions.
 
     study_sessions put together files for a single session of a subject
@@ -168,7 +168,7 @@ def get_study_sessions(
 
     - if files_opt is provided, sorts all DICOMs it can find under those paths
     """
-    study_sessions: dict[StudySessionInfo, Any] = {}
+    study_sessions: dict[StudySessionInfo, list[str] | dict[SeqInfo, list[str]]] = {}
     if dicom_dir_template:
         dicom_dir_template = op.abspath(dicom_dir_template)
 

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import atexit
 from collections import defaultdict
+from collections.abc import ItemsView, Iterable, Iterator
 from glob import glob
 import logging
 import os
 import os.path as op
 import re
 import shutil
-from typing import DefaultDict, ItemsView, Iterable, List, Optional
+from types import ModuleType
+from typing import Any, Optional
 
 from .dicoms import group_dicoms_into_seqinfos
 from .utils import StudySessionInfo, TempDirs, docstring_parameter
@@ -22,18 +26,24 @@ _UNPACK_FORMATS = tuple(sum((x[1] for x in shutil.get_unpack_formats()), []))
 
 
 @docstring_parameter(_VCS_REGEX)
-def find_files(regex, topdir=op.curdir, exclude=None, exclude_vcs=True, dirs=False):
+def find_files(
+    regex: str,
+    topdir: list[str] | tuple[str, ...] | str = op.curdir,
+    exclude: Optional[str] = None,
+    exclude_vcs: bool = True,
+    dirs: bool = False,
+) -> Iterator[str]:
     """Generator to find files matching regex
 
     Parameters
     ----------
-    regex: basestring
-    exclude: basestring, optional
+    regex: string
+    exclude: string, optional
       Matches to exclude
     exclude_vcs:
       If True, excludes commonly known VCS subdirectories.  If string, used
       as regex to exclude those files (regex: `{}`)
-    topdir: basestring or list, optional
+    topdir: string or list, optional
       Directory where to search
     dirs: bool, optional
       Either to match directories as well as files
@@ -60,7 +70,7 @@ def find_files(regex, topdir=op.curdir, exclude=None, exclude_vcs=True, dirs=Fal
             yield path
 
 
-def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], List[str]]:
+def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], list[str]]:
     """Given a collection of files and/or directories, list out and possibly
     extract the contents from archives.
 
@@ -95,12 +105,13 @@ def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], List[str
     the unarchived file. If there are multiple archived files, they are grouped
     into separate sessions.
     """
-    sessions: DefaultDict[Optional[int], List[str]] = defaultdict(list)
+    sessions: dict[Optional[int], list[str]] = defaultdict(list)
 
     # keep track of session manually to ensure that the variable is bound
     # when it is used after the loop (e.g., consider situation with
     # fl being empty)
     session = 0
+
     # needs sorting to keep the generated "session" label deterministic
     for _, t in enumerate(sorted(fl)):
         if not t.endswith(_UNPACK_FORMATS):
@@ -138,8 +149,14 @@ def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], List[str
 
 
 def get_study_sessions(
-    dicom_dir_template, files_opt, heuristic, outdir, session, sids, grouping="studyUID"
-):
+    dicom_dir_template: Optional[str],
+    files_opt: Optional[list[str]],
+    heuristic: ModuleType,
+    outdir: str,
+    session: Optional[str],
+    sids: Optional[list[str]],
+    grouping: str = "studyUID",
+) -> dict[StudySessionInfo, Any]:
     """Sort files or dicom seqinfos into study_sessions.
 
     study_sessions put together files for a single session of a subject
@@ -151,13 +168,13 @@ def get_study_sessions(
 
     - if files_opt is provided, sorts all DICOMs it can find under those paths
     """
-    study_sessions = {}
+    study_sessions: dict[StudySessionInfo, Any] = {}
     if dicom_dir_template:
         dicom_dir_template = op.abspath(dicom_dir_template)
 
         # MG - should be caught by earlier checks
         # assert not files_opt  # see above TODO
-        # assert sids
+        assert sids
         # expand the input template
 
         if "{subject}" not in dicom_dir_template:
@@ -167,8 +184,7 @@ def get_study_sessions(
             )
         for sid in sids:
             sdir = dicom_dir_template.format(subject=sid, session=session)
-            files = sorted(glob(sdir))
-            for session_, files_ in get_extracted_dicoms(files):
+            for session_, files_ in get_extracted_dicoms(sorted(glob(sdir))):
                 if session_ is not None and session:
                     lgr.warning(
                         "We had session specified (%s) but while analyzing "
@@ -186,8 +202,8 @@ def get_study_sessions(
         # MG - should be caught on initial run
         # YOH - what if it is the initial run?
         # prep files
-        # assert files_opt
-        files = []
+        assert files_opt
+        files: list[str] = []
         for f in files_opt:
             if op.isdir(f):
                 files += sorted(
@@ -197,13 +213,13 @@ def get_study_sessions(
                 files.append(f)
 
         # in this scenario we don't care about sessions obtained this way
-        files_ = []
+        extracted_files: list[str] = []
         for _, files_ex in get_extracted_dicoms(files):
-            files_ += files_ex
+            extracted_files += files_ex
 
         # sort all DICOMS using heuristic
         seqinfo_dict = group_dicoms_into_seqinfos(
-            files_,
+            extracted_files,
             grouping,
             file_filter=getattr(heuristic, "filter_files", None),
             dcmfilter=getattr(heuristic, "filter_dicom", None),
@@ -237,10 +253,12 @@ def get_study_sessions(
                 sid,
             )
 
-            def infotoids(seqinfos, outdir):  # noqa: U100
+            def infotoids(
+                seqinfos: Iterable[str], outdir: str  # noqa: U100
+            ) -> dict[str, Optional[str]]:
                 return {"locator": None, "session": None, "subject": None}
 
-            heuristic.infotoids = infotoids
+            heuristic.infotoids = infotoids  # type: ignore[attr-defined]
 
         for _studyUID, seqinfo in seqinfo_dict.items():
             # so we have a single study, we need to figure out its
@@ -267,7 +285,7 @@ def get_study_sessions(
                         "Existing study session with the same values (%r)."
                         " Skipping DICOMS %s",
                         study_session_info,
-                        *seqinfo.values()
+                        *seqinfo.values(),
                     )
                     continue
             study_sessions[study_session_info] = seqinfo

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -70,7 +70,7 @@ def find_files(
             yield path
 
 
-def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], list[str]]:
+def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[str], list[str]]:
     """Given a collection of files and/or directories, list out and possibly
     extract the contents from archives.
 
@@ -81,7 +81,7 @@ def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], list[str
 
     Returns
     -------
-    ItemsView[int | None, list[str]]
+    ItemsView[str | None, list[str]]
         The absolute paths of (possibly newly extracted) files.
 
     Notes
@@ -105,7 +105,7 @@ def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], list[str
     the unarchived file. If there are multiple archived files, they are grouped
     into separate sessions.
     """
-    sessions: dict[Optional[int], list[str]] = defaultdict(list)
+    sessions: dict[Optional[str], list[str]] = defaultdict(list)
 
     # keep track of session manually to ensure that the variable is bound
     # when it is used after the loop (e.g., consider situation with
@@ -136,14 +136,14 @@ def get_extracted_dicoms(fl: Iterable[str]) -> ItemsView[Optional[int], list[str
             os.chmod(f, mode=0o700)
         # store full paths to each file, so we don't need to drag along
         # tmpdir as some basedir
-        sessions[session] = archive_content
+        sessions[str(session)] = archive_content
         session += 1
 
     if session == 1:
         # we had only 1 session (and at least 1), so not really multiple
         # sessions according to classical 'heudiconv' assumptions, thus
         # just move them all into None
-        sessions[None] += sessions.pop(0)
+        sessions[None] += sessions.pop("0")
 
     return sessions.items()
 

--- a/heudiconv/queue.py
+++ b/heudiconv/queue.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import logging
 import os
 import subprocess
 import sys
+from typing import Optional
 
 from nipype.utils.filemanip import which
 
 lgr = logging.getLogger(__name__)
 
 
-def queue_conversion(queue, iterarg, iterables, queue_args=None):
+def queue_conversion(
+    queue: str, iterarg: str, iterables: int, queue_args: Optional[str] = None
+) -> None:
     """
     Write out conversion arguments to file and submit to a job scheduler.
     Parses `sys.argv` for heudiconv arguments.
@@ -51,7 +56,7 @@ def queue_conversion(queue, iterarg, iterables, queue_args=None):
     lgr.info("Submitted %d jobs", iterables)
 
 
-def clean_args(hargs, iterarg, iteridx):
+def clean_args(hargs: list[str], iterarg: str, iteridx: int) -> list[str]:
     """
     Filters arguments for batch submission.
 
@@ -80,9 +85,9 @@ def clean_args(hargs, iterarg, iteridx):
     """
 
     if iterarg == "subjects":
-        iterarg = ["-s", "--subjects"]
+        iterargs = ["-s", "--subjects"]
     elif iterarg == "files":
-        iterarg = ["--files"]
+        iterargs = ["--files"]
     else:
         raise ValueError("Cannot index %s" % iterarg)
 
@@ -104,7 +109,7 @@ def clean_args(hargs, iterarg, iteridx):
             if iteridx != itercount:
                 indices.append(i)
             itercount += 1
-        if arg in iterarg:
+        if arg in iterargs:
             is_iterarg = True
         if arg in queue_args:
             indices.extend([i, i + 1])

--- a/heudiconv/tests/anonymize_script.py
+++ b/heudiconv/tests/anonymize_script.py
@@ -5,12 +5,16 @@ import re
 import sys
 
 
-def bids_id_(sid):
-    parsed_id = re.compile(r"^(?:sub-|)(.+)$").search(sid).group(1)
-    return hashlib.md5(parsed_id.encode()).hexdigest()[:8]
+def bids_id_(sid: str) -> str:
+    m = re.compile(r"^(?:sub-|)(.+)$").search(sid)
+    if m:
+        parsed_id = m.group(1)
+        return hashlib.md5(parsed_id.encode()).hexdigest()[:8]
+    else:
+        raise ValueError("invalid sid")
 
 
-def main():
+def main() -> str:
     sid = sys.argv[1]
     return bids_id_(sid)
 

--- a/heudiconv/tests/conftest.py
+++ b/heudiconv/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True, scope="session")
-def git_env():
+def git_env() -> None:
     os.environ["GIT_AUTHOR_EMAIL"] = "maxm@example.com"
     os.environ["GIT_AUTHOR_NAME"] = "Max Mustermann"
     os.environ["GIT_COMMITTER_EMAIL"] = "maxm@example.com"

--- a/heudiconv/tests/test_archives.py
+++ b/heudiconv/tests/test_archives.py
@@ -51,7 +51,7 @@ def test_get_extracted_dicoms_multple_session_integers(
         for session, _ in get_extracted_dicoms(get_dicoms_gztar + get_dicoms_gztar)
     ]
 
-    assert sessions == [0, 1]
+    assert sessions == ["0", "1"]
 
 
 @pytest.mark.parametrize(

--- a/heudiconv/tests/test_archives.py
+++ b/heudiconv/tests/test_archives.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from glob import glob
 import os
 import os.path as op
 from pathlib import Path
 import shutil
 import stat
-from typing import List
 
 import pytest
 
@@ -12,7 +13,7 @@ from .utils import TESTS_DATA_PATH
 from ..parser import get_extracted_dicoms
 
 
-def _get_dicoms_archive(tmpdir: Path, fmt: str) -> List[str]:
+def _get_dicoms_archive(tmpdir: Path, fmt: str) -> list[str]:
     tmp_file = tmpdir / "dicom"
     archive = shutil.make_archive(
         str(tmp_file), format=fmt, root_dir=TESTS_DATA_PATH, base_dir="01-anat-scout"
@@ -21,26 +22,30 @@ def _get_dicoms_archive(tmpdir: Path, fmt: str) -> List[str]:
 
 
 @pytest.fixture
-def get_dicoms_archive(tmpdir: Path, request: pytest.FixtureRequest) -> List[str]:
+def get_dicoms_archive(tmpdir: Path, request: pytest.FixtureRequest) -> list[str]:
     return _get_dicoms_archive(tmpdir, fmt=request.param)
 
 
 @pytest.fixture
-def get_dicoms_gztar(tmpdir: Path) -> List[str]:
+def get_dicoms_gztar(tmpdir: Path) -> list[str]:
     return _get_dicoms_archive(tmpdir, "gztar")
 
 
 @pytest.fixture
-def get_dicoms_list() -> List[str]:
+def get_dicoms_list() -> list[str]:
     return glob(op.join(TESTS_DATA_PATH, "01-anat-scout", "*"))
 
 
-def test_get_extracted_dicoms_single_session_is_none(get_dicoms_gztar: List[str]):
+def test_get_extracted_dicoms_single_session_is_none(
+    get_dicoms_gztar: list[str],
+) -> None:
     for session_, _ in get_extracted_dicoms(get_dicoms_gztar):
         assert session_ is None
 
 
-def test_get_extracted_dicoms_multple_session_integers(get_dicoms_gztar: List[str]):
+def test_get_extracted_dicoms_multple_session_integers(
+    get_dicoms_gztar: list[str],
+) -> None:
     sessions = [
         session
         for session, _ in get_extracted_dicoms(get_dicoms_gztar + get_dicoms_gztar)
@@ -52,7 +57,7 @@ def test_get_extracted_dicoms_multple_session_integers(get_dicoms_gztar: List[st
 @pytest.mark.parametrize(
     "get_dicoms_archive", ("tar", "gztar", "zip", "bztar", "xztar"), indirect=True
 )
-def test_get_extracted_dicoms_from_archives(get_dicoms_archive: List[str]):
+def test_get_extracted_dicoms_from_archives(get_dicoms_archive: list[str]) -> None:
     for _, files in get_extracted_dicoms(get_dicoms_archive):
         # check that the only file is the one called "0001.dcm"
         endswith = all(file.endswith("0001.dcm") for file in files)
@@ -66,17 +71,17 @@ def test_get_extracted_dicoms_from_archives(get_dicoms_archive: List[str]):
         assert all([endswith, mode, absolute])
 
 
-def test_get_extracted_dicoms_from_file_list(get_dicoms_list: List[str]):
+def test_get_extracted_dicoms_from_file_list(get_dicoms_list: list[str]) -> None:
     for _, files in get_extracted_dicoms(get_dicoms_list):
         assert all(op.isfile(file) for file in files)
 
 
 def test_get_extracted_dicoms_from_mixed_list(
-    get_dicoms_list: List[str], get_dicoms_gztar: List[str]
-):
+    get_dicoms_list: list[str], get_dicoms_gztar: list[str]
+) -> None:
     for _, files in get_extracted_dicoms(get_dicoms_list + get_dicoms_gztar):
         assert all(op.isfile(file) for file in files)
 
 
-def test_get_extracted_from_empty_list():
+def test_get_extracted_from_empty_list() -> None:
     assert not len(get_extracted_dicoms([]))

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -66,6 +66,7 @@ def test_maybe_na() -> None:
 
 
 def test_treat_age() -> None:
+    assert treat_age(None) is None
     assert treat_age(0) == "0"
     assert treat_age("0") == "0"
     assert treat_age("0000") == "0"

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -1,15 +1,20 @@
 """Test functions in heudiconv.bids module.
 """
 
+from __future__ import annotations
+
 from collections import OrderedDict
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from glob import glob
+import itertools
 import os
 import os.path as op
 from pathlib import Path
 from random import choice, random, seed, shuffle
 import re
 import string
+from typing import Any, Dict, List, Optional, Tuple
 
 import nibabel
 from numpy import testing as np_testing
@@ -32,7 +37,7 @@ from heudiconv.bids import (
     treat_age,
 )
 from heudiconv.cli.run import main as runner
-from heudiconv.utils import create_tree, load_json, remove_suffix, save_json
+from heudiconv.utils import Load, create_tree, load_json, remove_suffix, save_json
 
 from .utils import TESTS_DATA_PATH, fetch_data, gen_heudiconv_args
 
@@ -43,7 +48,7 @@ except ImportError:
     have_datalad = False
 
 
-def gen_rand_label(label_size, label_seed, seed_stdout=True):
+def gen_rand_label(label_size: int, label_seed: int, seed_stdout: bool = True) -> str:
     seed(label_seed)
     rand_char = "".join(choice(string.ascii_letters) for _ in range(label_size - 1))
     seed(label_seed)
@@ -53,14 +58,14 @@ def gen_rand_label(label_size, label_seed, seed_stdout=True):
     return rand_char + rand_num
 
 
-def test_maybe_na():
+def test_maybe_na() -> None:
     for na in "", " ", None, "n/a", "N/A", "NA":
         assert maybe_na(na) == "n/a"
     for notna in 0, 1, False, True, "value":
         assert maybe_na(notna) == str(notna)
 
 
-def test_treat_age():
+def test_treat_age() -> None:
     assert treat_age(0) == "0"
     assert treat_age("0") == "0"
     assert treat_age("0000") == "0"
@@ -79,9 +84,9 @@ LABEL_SEED = int.from_bytes(os.urandom(8), byteorder="big")
 A_SHIM = [random() for i in range(SHIM_LENGTH)]
 
 
-def test_get_shim_setting(tmpdir):
+def test_get_shim_setting(tmp_path: Path) -> None:
     """Tests for get_shim_setting"""
-    json_dir = op.join(str(tmpdir), "foo")
+    json_dir = op.join(tmp_path, "foo")
     if not op.exists(json_dir):
         os.makedirs(json_dir)
     json_name = op.join(json_dir, "sub-foo.json")
@@ -95,7 +100,9 @@ def test_get_shim_setting(tmpdir):
     assert get_shim_setting(json_name) == A_SHIM
 
 
-def test_get_key_info_for_fmap_assignment(tmpdir, label_size=4, label_seed=LABEL_SEED):
+def test_get_key_info_for_fmap_assignment(
+    tmp_path: Path, label_size: int = 4, label_seed: int = LABEL_SEED
+) -> None:
     """
     Test get_key_info_for_fmap_assignment.
 
@@ -136,7 +143,7 @@ def test_get_key_info_for_fmap_assignment(tmpdir, label_size=4, label_seed=LABEL
 
     # 5) matching_parameter = 'ModalityAcquisitionLabel'
     for d in ["fmap", "func", "dwi", "anat"]:
-        Path(op.join(str(tmpdir), d)).mkdir(parents=True, exist_ok=True)
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
     for dirname, fname, expected_key_info in [
         ("fmap", "sub-foo_acq-fmri_epi.json", "func"),
         ("fmap", "sub-foo_acq-bold_epi.json", "func"),
@@ -148,7 +155,7 @@ def test_get_key_info_for_fmap_assignment(tmpdir, label_size=4, label_seed=LABEL
         ("dwi", "sub-foo_dwi.json", "dwi"),
         ("anat", "sub-foo_T1w.json", "anat"),
     ]:
-        json_name = op.join(str(tmpdir), dirname, fname)
+        json_name = op.join(tmp_path, dirname, fname)
         save_json(json_name, {SHIM_KEY: A_SHIM})
         assert [expected_key_info] == get_key_info_for_fmap_assignment(
             json_name, matching_parameter="ModalityAcquisitionLabel"
@@ -157,7 +164,7 @@ def test_get_key_info_for_fmap_assignment(tmpdir, label_size=4, label_seed=LABEL
     # 6) matching_parameter = 'CustomAcquisitionLabel'
     A_LABEL = gen_rand_label(label_size, label_seed)
     for d in ["fmap", "func", "dwi", "anat"]:
-        Path(op.join(str(tmpdir), d)).mkdir(parents=True, exist_ok=True)
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
 
     for dirname, fname, expected_key_info in [
         ("fmap", f"sub-foo_acq-{A_LABEL}_epi.json", A_LABEL),
@@ -165,7 +172,7 @@ def test_get_key_info_for_fmap_assignment(tmpdir, label_size=4, label_seed=LABEL
         ("dwi", f"sub-foo_acq-{A_LABEL}_dwi.json", A_LABEL),
         ("anat", f"sub-foo_acq-{A_LABEL}_T1w.json", A_LABEL),
     ]:
-        json_name = op.join(str(tmpdir), dirname, fname)
+        json_name = op.join(tmp_path, dirname, fname)
         save_json(json_name, {SHIM_KEY: A_SHIM})
         assert [expected_key_info] == get_key_info_for_fmap_assignment(
             json_name, matching_parameter="CustomAcquisitionLabel"
@@ -177,7 +184,7 @@ def test_get_key_info_for_fmap_assignment(tmpdir, label_size=4, label_seed=LABEL
     )
 
 
-def generate_scans_tsv(session_struct):
+def generate_scans_tsv(session_struct: dict[str, dict[str, Any]]) -> str:
     """
     Generates the contents of the "_scans.tsv" file, given a session structure.
     Currently, it will have the columns "filename" and "acq_time".
@@ -209,7 +216,15 @@ def generate_scans_tsv(session_struct):
     return "\n".join(scans_file_content)
 
 
-def create_dummy_pepolar_bids_session(session_path):
+DummySession = Tuple[
+    Dict[str, Load],
+    Dict[str, Optional[List[str]]],
+    Dict[str, List[str]],
+    Dict[str, Dict[str, List[str]]],
+]
+
+
+def create_dummy_pepolar_bids_session(session_path: str) -> DummySession:
     """
     Creates a dummy BIDS session, with slim json files and empty nii.gz
     The fmap files are pepolar
@@ -217,7 +232,7 @@ def create_dummy_pepolar_bids_session(session_path):
 
     Parameters
     ----------
-    session_path : str or os.path
+    session_path : str
         path to the session (or subject) level folder
 
     Returns
@@ -249,15 +264,17 @@ def create_dummy_pepolar_bids_session(session_path):
 
     # Dict with the file structure for the session:
     # -anat:
-    anat_struct = {
-        "{p}_{m}.{e}".format(p=prefix, m=mod, e=ext): dummy_content
-        for ext, dummy_content in zip(
-            ["nii.gz", "json"], ["", {"ShimSetting": anat_shims}]
-        )
-        for mod in ["T1w", "T2w"]
+    anat_struct: dict[str, str | dict[str, list[float]]] = {
+        "{p}_{m}.nii.gz".format(p=prefix, m=mod): "" for mod in ["T1w", "T2w"]
     }
+    anat_struct.update(
+        {
+            "{p}_{m}.json".format(p=prefix, m=mod): {"ShimSetting": anat_shims}
+            for mod in ["T1w", "T2w"]
+        }
+    )
     # -dwi:
-    dwi_struct = {
+    dwi_struct: dict[str, str | dict[str, list[float]]] = {
         "{p}_acq-A_run-{r}_dwi.nii.gz".format(p=prefix, r=runNo): "" for runNo in [1, 2]
     }
     dwi_struct.update(
@@ -269,7 +286,7 @@ def create_dummy_pepolar_bids_session(session_path):
         }
     )
     # -func:
-    func_struct = {
+    func_struct: dict[str, str | dict[str, list[float]]] = {
         "{p}_acq-{a}_bold.nii.gz".format(p=prefix, a=acq): ""
         for acq in ["A", "B", "unmatched"]
     }
@@ -284,7 +301,7 @@ def create_dummy_pepolar_bids_session(session_path):
     )
     # -fmap:
     #  * NIfTI files:
-    fmap_struct = {
+    fmap_struct: dict[str, str | dict[str, list[float]]] = {
         "{p}_acq-{a}_dir-{d}_run-{r}_epi.nii.gz".format(p=prefix, a=acq, d=d, r=r): ""
         for acq in ["dwi", "fMRI"]
         for d in ["AP", "PA"]
@@ -331,23 +348,24 @@ def create_dummy_pepolar_bids_session(session_path):
         }
     )
     # structure for the full session (init the OrderedDict as a list to preserve order):
-    session_struct = OrderedDict(
-        [
-            ("fmap", fmap_struct),
-            ("anat", anat_struct),
-            ("dwi", dwi_struct),
-            ("func", func_struct),
-        ]
-    )
+    session_struct = {
+        "fmap": fmap_struct,
+        "anat": anat_struct,
+        "dwi": dwi_struct,
+        "func": func_struct,
+    }
     # add "_scans.tsv" file to the session_struct
     scans_file_content = generate_scans_tsv(session_struct)
-    session_struct.update({"{p}_scans.tsv".format(p=prefix): scans_file_content})
+    session_struct2: dict[str, Load] = {
+        **session_struct,
+        f"{prefix}_scans.tsv": scans_file_content,
+    }
 
-    create_tree(session_path, session_struct)
+    create_tree(session_path, session_struct2)
 
     # 2) Now, let's create a dict with the fmap groups compatible for each run
     # -anat: empty
-    expected_compatible_fmaps = {
+    expected_compatible_fmaps: dict[str, dict[str, list[str]]] = {
         "{p}_{m}.json".format(p=op.join(session_path, "anat", prefix), m=mod): {}
         for mod in ["T1w", "T2w"]
     }
@@ -431,14 +449,14 @@ def create_dummy_pepolar_bids_session(session_path):
     )
 
     return (
-        session_struct,
+        session_struct2,
         expected_result,
         expected_fmap_groups,
         expected_compatible_fmaps,
     )
 
 
-def create_dummy_no_shim_settings_bids_session(session_path):
+def create_dummy_no_shim_settings_bids_session(session_path: str) -> DummySession:
     """
     Creates a dummy BIDS session, with slim json files and empty nii.gz
     The fmap files are pepolar
@@ -446,7 +464,7 @@ def create_dummy_no_shim_settings_bids_session(session_path):
 
     Parameters
     ----------
-    session_path : str or os.path
+    session_path : str
         path to the session (or subject) level folder
 
     Returns
@@ -471,33 +489,18 @@ def create_dummy_no_shim_settings_bids_session(session_path):
     # Dict with the file structure for the session.
     # All json files will be empty.
     # -anat:
-    anat_struct = {
-        "{p}_{m}.{e}".format(p=prefix, m=mod, e=ext): dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for mod in ["T1w", "T2w"]
-    }
+    anat_struct = mkstruct(f"{prefix}_{{0}}.{{ext}}", ["T1w", "T2w"])
     # -dwi:
-    dwi_struct = {
-        "{p}_acq-A_run-{r}_dwi.{e}".format(p=prefix, r=runNo, e=ext): dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for runNo in [1, 2]
-    }
+    dwi_struct = mkstruct(f"{prefix}_acq-A_run-{{0}}_dwi.{{ext}}", [1, 2])
     # -func:
-    func_struct = {
-        "{p}_acq-{a}_bold.{e}".format(p=prefix, a=acq, e=ext): dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for acq in ["A", "B"]
-    }
+    func_struct = mkstruct(f"{prefix}_acq-{{0}}_bold.{{ext}}", ["A", "B"])
     # -fmap:
-    fmap_struct = {
-        "{p}_acq-{a}_dir-{d}_run-{r}_epi.{e}".format(
-            p=prefix, a=acq, d=d, r=r, e=ext
-        ): dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for acq in ["dwi", "fMRI"]
-        for d in ["AP", "PA"]
-        for r in [1, 2]
-    }
+    fmap_struct = mkstruct(
+        f"{prefix}_acq-{{0}}_dir-{{1}}_run-{{2}}_epi.{{ext}}",
+        ["dwi", "fMRI"],
+        ["AP", "PA"],
+        [1, 2],
+    )
     expected_fmap_groups = {
         "{p}_acq-{a}_run-{r}_epi".format(p=prefix, a=acq, r=r): [
             "{p}_acq-{a}_dir-{d}_run-{r}_epi.json".format(
@@ -520,13 +523,16 @@ def create_dummy_no_shim_settings_bids_session(session_path):
     )
     # add "_scans.tsv" file to the session_struct
     scans_file_content = generate_scans_tsv(session_struct)
-    session_struct.update({"{p}_scans.tsv".format(p=prefix): scans_file_content})
+    session_struct2: dict[str, Load] = {
+        **session_struct,
+        f"{prefix}_scans.tsv": scans_file_content,
+    }
 
-    create_tree(session_path, session_struct)
+    create_tree(session_path, session_struct2)
 
     # 2) Now, let's create a dict with the fmap groups compatible for each run
     # -anat: empty
-    expected_compatible_fmaps = {
+    expected_compatible_fmaps: dict[str, dict[str, list[str]]] = {
         "{p}_{m}.json".format(p=op.join(session_path, "anat", prefix), m=mod): {}
         for mod in ["T1w", "T2w"]
     }
@@ -616,7 +622,7 @@ def create_dummy_no_shim_settings_bids_session(session_path):
     )
 
     return (
-        session_struct,
+        session_struct2,
         expected_result,
         expected_fmap_groups,
         expected_compatible_fmaps,
@@ -624,8 +630,8 @@ def create_dummy_no_shim_settings_bids_session(session_path):
 
 
 def create_dummy_no_shim_settings_custom_label_bids_session(
-    session_path, label_size=4, label_seed=LABEL_SEED
-):
+    session_path: str, label_size: int = 4, label_seed: int = LABEL_SEED
+) -> DummySession:
     """
     Creates a dummy BIDS session, with slim json files and empty nii.gz
     The fmap files are pepolar
@@ -636,7 +642,7 @@ def create_dummy_no_shim_settings_custom_label_bids_session(
 
     Parameters
     ----------
-    session_path : str or os.path
+    session_path : str
         path to the session (or subject) level folder
     label_size : int, optional
         size of the random label
@@ -665,35 +671,25 @@ def create_dummy_no_shim_settings_custom_label_bids_session(
     # Dict with the file structure for the session.
     # All json files will be empty.
     # -anat:
-    anat_struct = {
-        f"{prefix}_{mod}.{ext}": dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for mod in ["T1w", "T2w"]
-    }
+    anat_struct = mkstruct(f"{prefix}_{{0}}.{{ext}}", ["T1w", "T2w"])
     # -dwi:
     label_seed += 1
     DWI_LABEL = gen_rand_label(label_size, label_seed)
-    dwi_struct = {
-        f"{prefix}_acq-{DWI_LABEL}_run-{runNo}_dwi.{ext}": dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for runNo in [1, 2]
-    }
+    dwi_struct = mkstruct(f"{prefix}_acq-{DWI_LABEL}_run-{{0}}_dwi.{{ext}}", [1, 2])
     # -func:
     label_seed += 1
     FUNC_LABEL = gen_rand_label(label_size, label_seed)
-    func_struct = {
-        f"{prefix}_task-{FUNC_LABEL}_acq-{acq}_bold.{ext}": dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for acq in ["A", "B"]
-    }
+    func_struct = mkstruct(
+        f"{prefix}_task-{FUNC_LABEL}_acq-{{0}}_bold.{{ext}}",
+        ["A", "B"],
+    )
     # -fmap:
-    fmap_struct = {
-        f"{prefix}_acq-{acq}_dir-{d}_run-{r}_epi.{ext}": dummy_content
-        for ext, dummy_content in zip(["nii.gz", "json"], ["", {}])
-        for acq in [DWI_LABEL, FUNC_LABEL]
-        for d in ["AP", "PA"]
-        for r in [1, 2]
-    }
+    fmap_struct = mkstruct(
+        f"{prefix}_acq-{{0}}_dir-{{1}}_run-{{2}}_epi.{{ext}}",
+        [DWI_LABEL, FUNC_LABEL],
+        ["AP", "PA"],
+        [1, 2],
+    )
     expected_fmap_groups = {
         f"{prefix}_acq-{acq}_run-{r}_epi": [
             f'{op.join(session_path, "fmap", prefix)}_acq-{acq}_dir-{d}_run-{r}_epi.json'
@@ -714,13 +710,16 @@ def create_dummy_no_shim_settings_custom_label_bids_session(
     )
     # add "_scans.tsv" file to the session_struct
     scans_file_content = generate_scans_tsv(session_struct)
-    session_struct.update({"{p}_scans.tsv".format(p=prefix): scans_file_content})
+    session_struct2: dict[str, Load] = {
+        **session_struct,
+        f"{prefix}_scans.tsv": scans_file_content,
+    }
 
-    create_tree(session_path, session_struct)
+    create_tree(session_path, session_struct2)
 
     # 2) Now, let's create a dict with the fmap groups compatible for each run
     # -anat: empty
-    expected_compatible_fmaps = {
+    expected_compatible_fmaps: dict[str, dict[str, list[str]]] = {
         f'{op.join(session_path, "anat", prefix)}_{mod}.json': {}
         for mod in ["T1w", "T2w"]
     }
@@ -800,14 +799,14 @@ def create_dummy_no_shim_settings_custom_label_bids_session(
     )
 
     return (
-        session_struct,
+        session_struct2,
         expected_result,
         expected_fmap_groups,
         expected_compatible_fmaps,
     )
 
 
-def create_dummy_magnitude_phase_bids_session(session_path):
+def create_dummy_magnitude_phase_bids_session(session_path: str) -> DummySession:
     """
     Creates a dummy BIDS session, with slim json files and empty nii.gz
     The fmap files are a magnitude/phase pair
@@ -817,7 +816,7 @@ def create_dummy_magnitude_phase_bids_session(session_path):
 
     Parameters
     ----------
-    session_path : str or os.path
+    session_path : str
         path to the session (or subject) level folder
 
     Returns
@@ -845,7 +844,7 @@ def create_dummy_magnitude_phase_bids_session(session_path):
 
     # Dict with the file structure for the session:
     # -dwi:
-    dwi_struct = {
+    dwi_struct: dict[str, str | dict[str, list[float]]] = {
         "{p}_acq-A_run-{r}_dwi.nii.gz".format(p=prefix, r=runNo): "" for runNo in [1, 2]
     }
     dwi_struct.update(
@@ -857,7 +856,7 @@ def create_dummy_magnitude_phase_bids_session(session_path):
         }
     )
     # -func:
-    func_struct = {
+    func_struct: dict[str, str | dict[str, list[float]]] = {
         "{p}_acq-{a}_bold.nii.gz".format(p=prefix, a=acq): ""
         for acq in ["A", "B", "unmatched"]
     }
@@ -872,7 +871,7 @@ def create_dummy_magnitude_phase_bids_session(session_path):
     )
     # -fmap:
     #    * Case 1 in https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#fieldmap-data
-    fmap_struct = {
+    fmap_struct: dict[str, str | dict[str, list[float]]] = {
         "{p}_acq-case1_{s}.nii.gz".format(p=prefix, s=suffix): ""
         for suffix in ["phasediff", "magnitude1", "magnitude2"]
     }
@@ -940,9 +939,12 @@ def create_dummy_magnitude_phase_bids_session(session_path):
     )
     # add "_scans.tsv" file to the session_struct
     scans_file_content = generate_scans_tsv(session_struct)
-    session_struct.update({"{p}_scans.tsv".format(p=prefix): scans_file_content})
+    session_struct2: dict[str, Load] = {
+        **session_struct,
+        f"{prefix}_scans.tsv": scans_file_content,
+    }
 
-    create_tree(session_path, session_struct)
+    create_tree(session_path, session_struct2)
 
     # 2) Now, let's create a dict with the fmap groups compatible for each run
     # -dwi: each of the runs (1, 2) is compatible with case1 fmap:
@@ -985,7 +987,7 @@ def create_dummy_magnitude_phase_bids_session(session_path):
     expected_prefix = session_path.split(sub_str)[-1].split(op.sep)[-1]
 
     # dict, with fmap names as keys and the expected "IntendedFor" as values.
-    expected_result = {
+    expected_result: dict[str, Optional[list[str]]] = {
         "{p}_acq-case1_{s}.json".format(p=prefix, s="phasediff"): [
             op.join(
                 expected_prefix,
@@ -1012,11 +1014,21 @@ def create_dummy_magnitude_phase_bids_session(session_path):
     )
 
     return (
-        session_struct,
+        session_struct2,
         expected_result,
         expected_fmap_groups,
         expected_compatible_fmaps,
     )
+
+
+def mkstruct(template: str, *params: list) -> dict[str, str | dict[str, str]]:
+    struct: dict[str, str | dict[str, str]] = {
+        template.format(*ps, ext="nii.gz"): "" for ps in itertools.product(*params)
+    }
+    struct.update(
+        {template.format(*ps, ext="json"): {} for ps in itertools.product(*params)}
+    )
+    return struct
 
 
 # Test cases:
@@ -1031,9 +1043,11 @@ def create_dummy_magnitude_phase_bids_session(session_path):
         create_dummy_magnitude_phase_bids_session,
     ],
 )
-def test_find_fmap_groups(tmpdir, simulation_function):
+def test_find_fmap_groups(
+    tmp_path: Path, simulation_function: Callable[[str], DummySession]
+) -> None:
     """Test for find_fmap_groups"""
-    folder = op.join(str(tmpdir), "sub-foo")
+    folder = op.join(tmp_path, "sub-foo")
     _, _, expected_fmap_groups, _ = simulation_function(folder)
     fmap_groups = find_fmap_groups(op.join(folder, "fmap"))
     assert fmap_groups == expected_fmap_groups
@@ -1055,19 +1069,21 @@ def test_find_fmap_groups(tmpdir, simulation_function):
         (create_dummy_magnitude_phase_bids_session, "Shims"),
     ],
 )
-def test_find_compatible_fmaps_for_run(tmpdir, simulation_function, match_param):
+def test_find_compatible_fmaps_for_run(
+    tmp_path: Path, simulation_function: Callable[[str], DummySession], match_param: str
+) -> None:
     """
     Test find_compatible_fmaps_for_run.
 
     Parameters
     ----------
-    tmpdir
+    tmp_path
     simulation_function : function
         function to create the directory tree and expected results
     match_param : str
         matching_parameter for assigning fmaps
     """
-    folder = op.join(str(tmpdir), "sub-foo")
+    folder = op.join(tmp_path, "sub-foo")
     _, _, expected_fmap_groups, expected_compatible_fmaps = simulation_function(folder)
     for modality in ["anat", "dwi", "func"]:
         for json_file in glob(op.join(folder, modality, "*.json")):
@@ -1103,16 +1119,20 @@ def test_find_compatible_fmaps_for_run(tmpdir, simulation_function, match_param)
     ],
 )
 def test_find_compatible_fmaps_for_session(
-    tmpdir, folder, expected_prefix, simulation_function, match_param
-):
+    tmp_path: Path,
+    folder: str,
+    expected_prefix: str,
+    simulation_function: Callable[[str], DummySession],
+    match_param: str,
+) -> None:
     """
     Test find_compatible_fmaps_for_session.
 
     Parameters
     ----------
-    tmpdir
-    folder : str or os.path
-        path to BIDS study to be simulated, relative to tmpdir
+    tmp_path
+    folder : str
+        path to BIDS study to be simulated, relative to tmp_path
     expected_prefix : str
         expected start of the "IntendedFor" elements
     simulation_function : function
@@ -1120,7 +1140,7 @@ def test_find_compatible_fmaps_for_session(
     match_param : str
         matching_parameter for assigning fmaps
     """
-    session_folder = op.join(str(tmpdir), folder)
+    session_folder = op.join(tmp_path, folder)
     _, _, _, expected_compatible_fmaps = simulation_function(session_folder)
 
     compatible_fmaps = find_compatible_fmaps_for_session(
@@ -1152,10 +1172,13 @@ def test_find_compatible_fmaps_for_session(
     ],
 )
 def test_select_fmap_from_compatible_groups(
-    tmpdir, folder, expected_prefix, simulation_function
-):
+    tmp_path: Path,
+    folder: str,
+    expected_prefix: str,
+    simulation_function: Callable[[str], DummySession],
+) -> None:
     """Test select_fmap_from_compatible_groups"""
-    session_folder = op.join(str(tmpdir), folder)
+    session_folder = op.join(tmp_path, folder)
     _, _, _, expected_compatible_fmaps = simulation_function(session_folder)
 
     for json_file, fmap_groups in expected_compatible_fmaps.items():
@@ -1208,15 +1231,19 @@ def test_select_fmap_from_compatible_groups(
     ],
 )
 def test_populate_intended_for(
-    tmpdir, folder, expected_prefix, simulation_function, match_param
-):
+    tmp_path: Path,
+    folder: str,
+    expected_prefix: str,
+    simulation_function: Callable[[str], DummySession],
+    match_param: str,
+) -> None:
     """
     Test populate_intended_for.
     Parameters
     ----------
-    tmpdir
-    folder : str or os.path
-        path to BIDS study to be simulated, relative to tmpdir
+    tmp_path
+    folder : str
+        path to BIDS study to be simulated, relative to tmp_path
     expected_prefix : str
         expected start of the "IntendedFor" elements
     simulation_function : function
@@ -1225,7 +1252,7 @@ def test_populate_intended_for(
         matching_parameter for assigning fmaps
     """
 
-    session_folder = op.join(str(tmpdir), folder)
+    session_folder = op.join(tmp_path, folder)
     session_struct, expected_result, _, _ = simulation_function(session_folder)
     populate_intended_for(
         session_folder, matching_parameters=match_param, criterion="First"
@@ -1234,7 +1261,9 @@ def test_populate_intended_for(
     # Now, loop through the jsons in the fmap folder and make sure it matches
     # the expected result:
     fmap_folder = op.join(session_folder, "fmap")
-    for j in session_struct["fmap"].keys():
+    fmap = session_struct["fmap"]
+    assert isinstance(fmap, dict)
+    for j in fmap.keys():
         if j.endswith(".json"):
             assert j in expected_result.keys()
             data = load_json(op.join(fmap_folder, j))
@@ -1252,7 +1281,7 @@ def test_populate_intended_for(
                 assert "IntendedFor" not in data.keys()
 
 
-def test_BIDSFile():
+def test_BIDSFile() -> None:
     """Tests for the BIDSFile class"""
 
     # define entities in the correct order:
@@ -1305,7 +1334,7 @@ def test_BIDSFile():
     # Complain if entity 'sub' is not set:
     with pytest.raises(ValueError) as e_info:
         assert str(BIDSFile.parse("dir-reversed.json"))
-        assert "sub-" in e_info.value
+        assert "sub-" in str(e_info.value)
 
     # Test set method:
     # -for a new entity, just set it without a complaint:
@@ -1322,20 +1351,25 @@ def test_BIDSFile():
 
 
 @pytest.mark.skipif(not have_datalad, reason="no datalad")
-def test_ME_mag_phase_conversion(tmpdir, subID="MEGRE", heuristic="bids_ME.py"):
+def test_ME_mag_phase_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    subID: str = "MEGRE",
+    heuristic: str = "bids_ME.py",
+) -> None:
     """Unit test for the case of multi-echo GRE data with
     magnitude and phase.
     The different echoes should be labeled automatically.
     """
-    tmpdir.chdir()
-    tmppath = tmpdir.strpath
+    monkeypatch.chdir(tmp_path)
     try:
-        datadir = fetch_data(tmppath, f"dicoms/velasco/{subID}")
+        datadir = fetch_data(tmp_path, f"dicoms/velasco/{subID}")
     except IncompleteResultsError as exc:
         pytest.skip("Failed to fetch test data: %s" % str(exc))
 
-    outdir = tmpdir.mkdir("out").strpath
-    args = gen_heudiconv_args(datadir, outdir, subID, heuristic)
+    outdir = tmp_path / "out"
+    outdir.mkdir()
+    args = gen_heudiconv_args(datadir, str(outdir), subID, heuristic)
     runner(args)  # run conversion
 
     # Check that the expected files have been extracted.
@@ -1349,7 +1383,7 @@ def test_ME_mag_phase_conversion(tmpdir, subID="MEGRE", heuristic="bids_ME.py"):
                 )
 
 
-def test_sanitize_label():
+def test_sanitize_label() -> None:
     assert sanitize_label("az XZ-@09") == "azXZ09"
     with pytest.raises(ValueError):
         sanitize_label(" @ ")

--- a/heudiconv/tests/test_convert.py
+++ b/heudiconv/tests/test_convert.py
@@ -259,8 +259,8 @@ def test_populate_intended_for(
         populate_intended_for_opts=getattr(
             heuristic_mod, "POPULATE_INTENDED_FOR_OPTS", None
         ),
-        with_prov=None,
-        bids_options=[],
+        with_prov=False,
+        bids_options="",
         outdir=outdir,
         min_meta=True,
         overwrite=False,

--- a/heudiconv/tests/test_convert.py
+++ b/heudiconv/tests/test_convert.py
@@ -1,7 +1,11 @@
 """Test functions in heudiconv.convert module.
 """
+from __future__ import annotations
+
 from glob import glob
 import os.path as op
+from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -19,7 +23,7 @@ from heudiconv.utils import load_heuristic
 from .utils import TESTS_DATA_PATH
 
 
-def test_update_complex_name():
+def test_update_complex_name() -> None:
     """Unit testing for heudiconv.convert.update_complex_name(), which updates
     filenames with the part field if appropriate.
     """
@@ -56,7 +60,7 @@ def test_update_complex_name():
     assert out_fn_test == base_fn
 
 
-def test_update_multiecho_name():
+def test_update_multiecho_name() -> None:
     """Unit testing for heudiconv.convert.update_multiecho_name(), which updates
     filenames with the echo field if appropriate.
     """
@@ -99,7 +103,7 @@ def test_update_multiecho_name():
         update_multiecho_name(metadata, base_fn, set(echo_times))
 
 
-def test_update_uncombined_name():
+def test_update_uncombined_name() -> None:
     """Unit testing for heudiconv.convert.update_uncombined_name(), which updates
     filenames with the ch field if appropriate.
     """
@@ -138,7 +142,7 @@ def test_update_uncombined_name():
         update_uncombined_name(metadata, base_fn, set(channel_names))
 
 
-def test_b0dwi_for_fmap(tmpdir, caplog):
+def test_b0dwi_for_fmap(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     """Make sure we raise a warning when .bvec and .bval files
     are present but the modality is not dwi.
     We check it by extracting a few DICOMs from a series with
@@ -147,13 +151,12 @@ def test_b0dwi_for_fmap(tmpdir, caplog):
     import logging
 
     caplog.set_level(logging.WARNING)
-    tmppath = tmpdir.strpath
     subID = "b0dwiForFmap"
     args = [
         "-c",
         "dcm2niix",
         "-o",
-        str(tmpdir),
+        str(tmp_path),
         "-b",
         "-f",
         "test_b0dwi_for_fmap",
@@ -167,18 +170,16 @@ def test_b0dwi_for_fmap(tmpdir, caplog):
     # assert that it raised a warning that the fmap directory will contain
     # bvec and bval files.
     expected_msg = DW_IMAGE_IN_FMAP_FOLDER_WARNING.format(
-        folder=op.join(tmppath, "sub-%s", "fmap") % subID
+        folder=op.join(tmp_path, f"sub-{subID}", "fmap")
     )
     assert any(expected_msg in c.message for c in caplog.records)
 
     # check that both 'fmap' and 'dwi' directories have been extracted and they contain
     # *.bvec and a *.bval files
     for mod in ["fmap", "dwi"]:
-        assert op.isdir(op.join(tmppath, "sub-%s", mod) % (subID))
+        assert op.isdir(op.join(tmp_path, f"sub-{subID}", mod))
         for ext in ["bval", "bvec"]:
-            assert glob(
-                op.join(tmppath, "sub-%s", mod, "sub-%s_*.%s") % (subID, subID, ext)
-            )
+            assert glob(op.join(tmp_path, f"sub-{subID}", mod, f"sub-{subID}_*.{ext}"))
 
 
 # Test two scenarios for each case:
@@ -197,8 +198,14 @@ def test_b0dwi_for_fmap(tmpdir, caplog):
     ["example", "reproin", None],  # heuristics/example.py, heuristics/reproin.py
 )
 def test_populate_intended_for(
-    tmpdir, monkeypatch, capfd, subjects, sesID, _expected_session_folder, heuristic
-):
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+    subjects: list[str],
+    sesID: Optional[str],
+    _expected_session_folder: str,
+    heuristic: Optional[str],
+) -> None:
     """
     Test convert
 
@@ -208,22 +215,23 @@ def test_populate_intended_for(
     """
 
     def mock_populate_intended_for(
-        session, matching_parameters="Shims", criterion="Closest"
-    ):
+        session: str,
+        matching_parameters: str | list[str] = "Shims",
+        criterion: str = "Closest",
+    ) -> None:
         """
         Pretend we run populate_intended_for, but just print out the arguments.
         """
         print("session: {}".format(session))
         print("matching_parameters: {}".format(matching_parameters))
         print("criterion: {}".format(criterion))
-        return
 
     # mock the "populate_intended_for":
     monkeypatch.setattr(
         heudiconv.convert, "populate_intended_for", mock_populate_intended_for
     )
 
-    outdir = op.join(str(tmpdir), "foo")
+    outdir = op.join(tmp_path, "foo")
     outfolder = (
         op.join(outdir, "sub-{sID}", "ses-{ses}")
         if sesID
@@ -233,7 +241,7 @@ def test_populate_intended_for(
 
     # items are a list of tuples, with each tuple having three elements:
     #   prefix, outtypes, item_dicoms
-    items = [
+    items: list[tuple[str, tuple[str, ...], list[str]]] = [
         (
             op.join(outfolder, "anat", sub_ses + "_T1w").format(sID=s, ses=sesID),
             ("",),
@@ -242,14 +250,14 @@ def test_populate_intended_for(
         for s in subjects
     ]
 
-    heuristic = load_heuristic(heuristic) if heuristic else None
+    heuristic_mod = load_heuristic(heuristic) if heuristic else None
     heudiconv.convert.convert(
         items,
         converter="",
         scaninfo_suffix=".json",
         custom_callable=None,
         populate_intended_for_opts=getattr(
-            heuristic, "POPULATE_INTENDED_FOR_OPTS", None
+            heuristic_mod, "POPULATE_INTENDED_FOR_OPTS", None
         ),
         with_prov=None,
         bids_options=[],
@@ -260,7 +268,7 @@ def test_populate_intended_for(
     output = capfd.readouterr()
     # if the heuristic module has a 'POPULATE_INTENDED_FOR_OPTS' field, we expect
     # to get the output of the mock_populate_intended_for, otherwise, no output:
-    pif_cfg = getattr(heuristic, "POPULATE_INTENDED_FOR_OPTS", None)
+    pif_cfg = getattr(heuristic_mod, "POPULATE_INTENDED_FOR_OPTS", None)
     if pif_cfg:
         assert all(
             [

--- a/heudiconv/tests/test_convert.py
+++ b/heudiconv/tests/test_convert.py
@@ -100,7 +100,7 @@ def test_update_multiecho_name() -> None:
     # Providing echo times as something other than a list should raise a TypeError
     base_fn = "sub-X_ses-Y_task-Z_run-01_bold"
     with pytest.raises(TypeError):
-        update_multiecho_name(metadata, base_fn, set(echo_times))
+        update_multiecho_name(metadata, base_fn, set(echo_times))  # type: ignore[arg-type]
 
 
 def test_update_uncombined_name() -> None:
@@ -139,7 +139,7 @@ def test_update_uncombined_name() -> None:
     # Providing echo times as something other than a list should raise a TypeError
     base_fn = "sub-X_ses-Y_task-Z_run-01_bold"
     with pytest.raises(TypeError):
-        update_uncombined_name(metadata, base_fn, set(channel_names))
+        update_uncombined_name(metadata, base_fn, set(channel_names))  # type: ignore[arg-type]
 
 
 def test_b0dwi_for_fmap(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -31,7 +31,7 @@ def test_private_csa_header(tmp_path: Path) -> None:
     for pub, priv in DICOM_FIELDS_TO_TEST.items():
         # ensure missing public tag
         with pytest.raises(AttributeError):
-            dcm.pub
+            dcm.pub  # type: ignore[attr-defined]
         # ensure private tag is found
         assert parse_private_csa_header(dcm_data, pub, priv) != ""
         # and quickly run heudiconv with no conversion

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -31,7 +31,7 @@ def test_private_csa_header(tmp_path: Path) -> None:
     for pub, priv in DICOM_FIELDS_TO_TEST.items():
         # ensure missing public tag
         with pytest.raises(AttributeError):
-            dcm.pub  # type: ignore[attr-defined]
+            getattr(dcm, pub)
         # ensure private tag is found
         assert parse_private_csa_header(dcm_data, pub, priv) != ""
         # and quickly run heudiconv with no conversion

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -12,7 +12,6 @@ import pytest
 from heudiconv.cli.run import main as runner
 from heudiconv.convert import nipype_convert
 from heudiconv.dicoms import (
-    OrderedDict,
     embed_dicom_and_nifti_metadata,
     get_datetime_from_dcm,
     get_reproducible_int,
@@ -92,7 +91,7 @@ def test_group_dicoms_into_seqinfos() -> None:
 
     seqinfo = group_dicoms_into_seqinfos(dcmfiles, "studyUID", flatten=True)
 
-    assert type(seqinfo) is OrderedDict
+    assert type(seqinfo) is dict
     assert len(seqinfo) == len(dcmfiles)
     assert [s.series_description for s in seqinfo] == [
         "AAHead_Scout_32ch-head-coil",

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -354,7 +354,6 @@ def test_populate_intended_for(
         bids_folder,
         "populate-intended-for",
         [],
-        "",
         "example",
         session,
         subjects,
@@ -381,7 +380,7 @@ def test_populate_intended_for(
         if session:
             os.makedirs(opj(subj_dir, "ses-" + session))
     process_extra_commands(
-        outdir, "populate-intended-for", [], "", "example", None, [], "all"
+        outdir, "populate-intended-for", [], "example", None, [], "all"
     )
     for s in subjects:
         expected_info = 'Adding "IntendedFor" to the fieldmaps in ' + opj(

--- a/heudiconv/tests/test_main.py
+++ b/heudiconv/tests/test_main.py
@@ -121,7 +121,7 @@ def test_prepare_for_datalad(tmp_path: Path) -> None:
     os.makedirs(studydir_)
     populate_bids_templates(studydir_)
 
-    add_to_datalad(str(tmp_path), studydir_, None, False)
+    add_to_datalad(str(tmp_path), studydir_, None, None)
 
     from datalad.api import Dataset
 
@@ -155,7 +155,7 @@ def test_prepare_for_datalad(tmp_path: Path) -> None:
     # Above call to add_to_datalad does not create .heudiconv subds since
     # directory does not exist (yet).
     # Let's first check that it is safe to call it again
-    add_to_datalad(str(tmp_path), studydir_, None, False)
+    add_to_datalad(str(tmp_path), studydir_, None, None)
     assert not ds.repo.dirty
 
     old_hexsha = ds.repo.get_hexsha()
@@ -167,7 +167,7 @@ def test_prepare_for_datalad(tmp_path: Path) -> None:
     create_file_if_missing(dummy_path, "")
     ds.save(dummy_path, message="added a dummy file")
     # next call must not fail, should just issue a warning
-    add_to_datalad(str(tmp_path), studydir_, None, False)
+    add_to_datalad(str(tmp_path), studydir_, None, None)
     ds.repo.is_under_annex(dummy_path)
     assert not ds.repo.dirty
     assert ".heudiconv/dummy.nii.gz" in ds.repo.get_files()
@@ -176,7 +176,7 @@ def test_prepare_for_datalad(tmp_path: Path) -> None:
     ds.repo.call_git(["reset", "--hard", old_hexsha])
     # now we do not add dummy to git
     create_file_if_missing(dummy_path, "")
-    add_to_datalad(str(tmp_path), studydir_, None, False)
+    add_to_datalad(str(tmp_path), studydir_, None, None)
     assert ".heudiconv" in ds.subdatasets(result_xfm="relpaths")
     assert not ds.repo.dirty
     assert ".heudiconv/dummy.nii.gz" not in ds.repo.get_files()

--- a/heudiconv/tests/test_monitor.py
+++ b/heudiconv/tests/test_monitor.py
@@ -1,5 +1,8 @@
-from collections import namedtuple
+from __future__ import annotations
+
 import os.path as op
+from pathlib import Path
+from typing import NamedTuple, Optional
 from unittest.mock import patch
 
 import pytest
@@ -13,7 +16,12 @@ from subprocess import CalledProcessError
 try:
     from heudiconv.cli.monitor import MASK_NEWDIR, monitor, process, run_heudiconv
 
-    Header = namedtuple("header", ["wd", "mask", "cookie", "len"])
+    class Header(NamedTuple):
+        wd: int
+        mask: int
+        cookie: int
+        len: int
+
     header = Header(5, MASK_NEWDIR, 5, 5)
     watch_path = b"WATCHME"
     filename = b"FILE"
@@ -33,7 +41,7 @@ except AttributeError:
     pytestmark = pytest.mark.skip(reason="Unable to import inotify")
 
 
-class MockInotifyTree(object):
+class MockInotifyTree:
     def __init__(self, events):
         self.events = iter(events)
 
@@ -45,7 +53,7 @@ class MockInotifyTree(object):
         return self
 
 
-class MockTime(object):
+class MockTime:
     def __init__(self, time):
         self.time = time
 
@@ -56,7 +64,7 @@ class MockTime(object):
 @pytest.mark.skip(reason="TODO")
 @patch("inotify.adapters.InotifyTree", MockInotifyTree(my_events))
 @patch("time.time", MockTime(42))
-def test_monitor(capsys):
+def test_monitor(capsys: pytest.CaptureFixture[str]) -> None:
     monitor(watch_path.decode(), check_ptrn="")
     out, err = capsys.readouterr()
     desired_output = "{0}/{1} {2}\n".format(watch_path.decode(), filename.decode(), 42)
@@ -69,15 +77,21 @@ def test_monitor(capsys):
 @pytest.mark.skip(reason="TODO")
 @patch("time.time", MockTime(42))
 @pytest.mark.parametrize(
-    "side_effect,success", [(None, 1), (CalledProcessError("mycmd", 1), 0)]
+    "side_effect,success", [(None, 1), (CalledProcessError(1, "mycmd"), 0)]
 )
-def test_process(tmpdir, capsys, side_effect, success):
-    db_fn = tmpdir.join("database.json")
-    log_dir = tmpdir.mkdir("log")
-    db = TinyDB(db_fn.strpath)
+def test_process(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    side_effect: Optional[BaseException],
+    success: int,
+) -> None:
+    db_fn = tmp_path / "database.json"
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+    db = TinyDB(str(db_fn))
     process_me = "/my/path/A12345"
     accession_number = op.basename(process_me)
-    paths2process = {process_me: 42}
+    paths2process = {process_me: 42.0}
     with patch("subprocess.Popen") as mocked_popen:
         stdout = b"INFO: PROCESSING STARTS: {'just': 'a test'}"
         mocked_popen_instance = mocked_popen.return_value
@@ -86,21 +100,21 @@ def test_process(tmpdir, capsys, side_effect, success):
         # set return value for wait
         mocked_popen_instance.wait.return_value = 1 - success
         # mock also communicate to get the supposed stdout
-        process(paths2process, db, wait=-30, logdir=log_dir.strpath)
+        process(paths2process, db, wait=-30, logdir=str(log_dir))
         out, err = capsys.readouterr()
-        log_fn = log_dir.join(accession_number + ".log")
+        log_fn = log_dir / (accession_number + ".log")
 
         mocked_popen.assert_called_once()
-        assert log_fn.check()
-        assert log_fn.read() == stdout.decode("utf-8")
-        assert db_fn.check()
+        assert log_fn.exists()
+        assert log_fn.read_text() == stdout.decode("utf-8")
+        assert db_fn.exists()
         # dictionary should be empty
         assert not paths2process
         assert out == "Time to process {0}\n".format(process_me)
 
         # check what we have in the database
-        Path = Query()
-        query = db.get(Path.input_path == process_me)
+        path = Query()
+        query = db.get(path.input_path == process_me)
         assert len(db) == 1
         assert query
         assert query["success"] == success
@@ -109,10 +123,10 @@ def test_process(tmpdir, capsys, side_effect, success):
 
 
 @pytest.mark.skip(reason="TODO")
-def test_run_heudiconv():
+def test_run_heudiconv() -> None:
     # echo should succeed always
     mydict = {"key1": "value1", "key2": "value2", "success": 1}
-    cmd = "echo INFO: PROCESSING STARTS: {0}".format(str(mydict))
-    stdout, info_dict = run_heudiconv(cmd)
+    args = ["echo", "INFO:", "PROCESSING", "STARTS:", str(mydict)]
+    stdout, info_dict = run_heudiconv(args)
     assert info_dict == mydict
-    assert "echo " + stdout.strip() == cmd
+    assert stdout.strip() == " ".join(args[1:])

--- a/heudiconv/tests/test_monitor.py
+++ b/heudiconv/tests/test_monitor.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 import os.path as op
 from pathlib import Path
-from typing import NamedTuple, Optional
+import sys
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, Optional, TypeVar
 from unittest.mock import patch
 
 import pytest
@@ -41,23 +43,33 @@ except AttributeError:
     pytestmark = pytest.mark.skip(reason="Unable to import inotify")
 
 
-class MockInotifyTree:
-    def __init__(self, events):
-        self.events = iter(events)
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
-    def event_gen(self):
+
+T = TypeVar("T")
+
+
+class MockInotifyTree(Generic[T]):
+    def __init__(self, events: Iterable[T]) -> None:
+        self.events: Iterator[T] = iter(events)
+
+    def event_gen(self) -> Iterator[T]:
         for e in self.events:
             yield e
 
-    def __call__(self, _topdir):
+    def __call__(self, _topdir: Any) -> Self:
         return self
 
 
 class MockTime:
-    def __init__(self, time):
+    def __init__(self, time: float) -> None:
         self.time = time
 
-    def __call__(self):
+    def __call__(self) -> float:
         return self.time
 
 

--- a/heudiconv/tests/test_queue.py
+++ b/heudiconv/tests/test_queue.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 
+from nipype.utils.filemanip import which
 import pytest
 
 from heudiconv.cli.run import main as runner
-from heudiconv.queue import clean_args, which
+from heudiconv.queue import clean_args
 
 from .utils import TESTS_DATA_PATH
 

--- a/heudiconv/tests/test_queue.py
+++ b/heudiconv/tests/test_queue.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from pathlib import Path
 import sys
 
 import pytest
@@ -18,39 +21,36 @@ from .utils import TESTS_DATA_PATH
         ["-d", f"{TESTS_DATA_PATH}/{{subject}}/*", "-s", "01-fmap_acq-3mm"],
     ],
 )
-def test_queue_no_slurm(tmpdir, hargs):
-    tmpdir.chdir()
+def test_queue_no_slurm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hargs: list[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
     hargs.extend(["-f", "reproin", "-b", "--minmeta", "--queue", "SLURM"])
 
     # simulate command-line call
-    _sys_args = sys.argv
-    sys.argv = ["heudiconv"] + hargs
+    monkeypatch.setattr(sys, "argv", ["heudiconv"] + hargs)
 
-    try:
-        with pytest.raises(OSError):  # SLURM should not be installed
-            runner(hargs)
-        # should have generated a slurm submission script
-        slurm_cmd_file = (tmpdir / "heudiconv-SLURM.sh").strpath
-        assert slurm_cmd_file
-        # check contents and ensure args match
-        with open(slurm_cmd_file) as fp:
-            lines = fp.readlines()
-        assert lines[0] == "#!/bin/bash\n"
-        cmd = lines[1]
+    with pytest.raises(OSError):  # SLURM should not be installed
+        runner(hargs)
+    # should have generated a slurm submission script
+    slurm_cmd_file = str(tmp_path / "heudiconv-SLURM.sh")
+    assert slurm_cmd_file
+    # check contents and ensure args match
+    with open(slurm_cmd_file) as fp:
+        lines = fp.readlines()
+    assert lines[0] == "#!/bin/bash\n"
+    cmd = lines[1]
 
-        # check that all flags we gave still being called
-        for arg in hargs:
-            # except --queue <queue>
-            if arg in ["--queue", "SLURM"]:
-                assert arg not in cmd
-            else:
-                assert arg in cmd
-    finally:
-        # revert before breaking something
-        sys.argv = _sys_args
+    # check that all flags we gave still being called
+    for arg in hargs:
+        # except --queue <queue>
+        if arg in ["--queue", "SLURM"]:
+            assert arg not in cmd
+        else:
+            assert arg in cmd
 
 
-def test_argument_filtering():
+def test_argument_filtering() -> None:
     cmd_files = [
         "heudiconv",
         "--files",

--- a/heudiconv/tests/test_tarballs.py
+++ b/heudiconv/tests/test_tarballs.py
@@ -18,8 +18,8 @@ def test_reproducibility(tmp_path: Path) -> None:
     tempdirs = TempDirs()
 
     tarball = compress_dicoms(dicom_list, prefix, tempdirs, True)
+    assert tarball is not None
     md5 = file_md5sum(tarball)
-    assert tarball
     # must not override, ensure overwrite is set to False
     assert compress_dicoms(dicom_list, prefix, tempdirs, False) is None
 
@@ -27,6 +27,6 @@ def test_reproducibility(tmp_path: Path) -> None:
 
     time.sleep(1.1)  # need to guarantee change of time
     tarball_ = compress_dicoms(dicom_list, prefix, tempdirs, True)
-    md5_ = file_md5sum(tarball_)
     assert tarball == tarball_
+    md5_ = file_md5sum(tarball_)
     assert md5 == md5_

--- a/heudiconv/tests/test_tarballs.py
+++ b/heudiconv/tests/test_tarballs.py
@@ -1,31 +1,32 @@
+from __future__ import annotations
+
 from glob import glob
 import os
-from os.path import dirname
 from os.path import join as opj
+from pathlib import Path
 import time
 
 from heudiconv.dicoms import compress_dicoms
 from heudiconv.utils import TempDirs, file_md5sum
 
-tests_datadir = opj(dirname(__file__), "data")
+from .utils import TESTS_DATA_PATH
 
 
-def test_reproducibility(tmpdir):
-    prefix = str(tmpdir.join("precious"))
-    args = [glob(opj(tests_datadir, "01-fmap_acq-3mm", "*")), prefix, TempDirs(), True]
-    tarball = compress_dicoms(*args)
+def test_reproducibility(tmp_path: Path) -> None:
+    dicom_list = glob(opj(TESTS_DATA_PATH, "01-fmap_acq-3mm", "*"))
+    prefix = str(tmp_path / "precious")
+    tempdirs = TempDirs()
+
+    tarball = compress_dicoms(dicom_list, prefix, tempdirs, True)
     md5 = file_md5sum(tarball)
     assert tarball
     # must not override, ensure overwrite is set to False
-    args[-1] = False
-    assert compress_dicoms(*args) is None
-    # reset this
-    args[-1] = True
+    assert compress_dicoms(dicom_list, prefix, tempdirs, False) is None
 
     os.unlink(tarball)
 
     time.sleep(1.1)  # need to guarantee change of time
-    tarball_ = compress_dicoms(*args)
+    tarball_ = compress_dicoms(dicom_list, prefix, tempdirs, True)
     md5_ = file_md5sum(tarball_)
     assert tarball == tarball_
     assert md5 == md5_

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from json.decoder import JSONDecodeError
 import os
 import os.path as op
 from pathlib import Path
@@ -10,7 +11,6 @@ from unittest.mock import patch
 import pytest
 
 from heudiconv.utils import (
-    JSONDecodeError,
     create_tree,
     get_datetime,
     get_heuristic_description,

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import json
 import os
 import os.path as op
+from pathlib import Path
+from typing import IO, Any
 from unittest.mock import patch
 
 import pytest
@@ -23,7 +27,7 @@ from heudiconv.utils import (
 from .utils import HEURISTICS_PATH
 
 
-def test_get_known_heuristics_with_descriptions():
+def test_get_known_heuristics_with_descriptions() -> None:
     d = get_known_heuristics_with_descriptions()
     assert {"reproin", "convertall"}.issubset(d)
     # ATM we include all, not only those two
@@ -32,7 +36,7 @@ def test_get_known_heuristics_with_descriptions():
     assert len(d["reproin"].split(os.sep)) == 1  # but just one line
 
 
-def test_get_heuristic_description():
+def test_get_heuristic_description() -> None:
     desc = get_heuristic_description("reproin", full=True)
     assert len(desc) > 1000
     # and we describe such details as
@@ -42,7 +46,7 @@ def test_get_heuristic_description():
     assert "ReproNim" in desc
 
 
-def test_load_heuristic():
+def test_load_heuristic() -> None:
     by_name = load_heuristic("reproin")
     from_file = load_heuristic(op.join(HEURISTICS_PATH, "reproin.py"))
 
@@ -56,7 +60,7 @@ def test_load_heuristic():
         load_heuristic(op.join(HEURISTICS_PATH, "unknownsomething.py"))
 
 
-def test_json_dumps_pretty():
+def test_json_dumps_pretty() -> None:
     pretty = json_dumps_pretty
     assert (
         pretty({"SeriesDescription": "Trace:Nov 13 2017 14-36-14 EST"})
@@ -82,11 +86,11 @@ def test_json_dumps_pretty():
     assert pretty({"WipMemBlock": tstr}) == '{\n  "WipMemBlock": "%s"\n}' % tstr
 
 
-def test_load_json(tmpdir, caplog):
+def test_load_json(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     # test invalid json
     ifname = "invalid.json"
-    invalid_json_file = str(tmpdir / ifname)
-    create_tree(str(tmpdir), {ifname: "I'm Jason Bourne"})
+    invalid_json_file = str(tmp_path / ifname)
+    create_tree(str(tmp_path), {ifname: "I'm Jason Bourne"})
 
     with pytest.raises(JSONDecodeError):
         load_json(str(invalid_json_file))
@@ -103,7 +107,7 @@ def test_load_json(tmpdir, caplog):
     # test valid json
     vcontent = {"secret": "spy"}
     vfname = "valid.json"
-    valid_json_file = str(tmpdir / vfname)
+    valid_json_file = str(tmp_path / vfname)
     save_json(valid_json_file, vcontent)
 
     assert load_json(valid_json_file) == vcontent
@@ -111,7 +115,7 @@ def test_load_json(tmpdir, caplog):
     calls = [0]
     json_load = json.load
 
-    def json_load_patched(fp):
+    def json_load_patched(fp: IO[str]) -> Any:
         calls[0] += 1
         if calls[0] == 1:
             # just reuse bad file
@@ -125,11 +129,11 @@ def test_load_json(tmpdir, caplog):
         assert load_json(valid_json_file, retry=3) == vcontent
 
 
-def test_update_json(tmpdir):
+def test_update_json(tmp_path: Path) -> None:
     """
     Test utils.update_json()
     """
-    dummy_json_file = str(tmpdir / "dummy.json")
+    dummy_json_file = str(tmp_path / "dummy.json")
     some_content = {"name": "Jason", "age": 30, "city": "New York"}
     save_json(dummy_json_file, some_content, pretty=True)
 
@@ -152,7 +156,7 @@ def test_update_json(tmpdir):
     assert data == some_content
 
 
-def test_get_datetime():
+def test_get_datetime() -> None:
     """
     Test utils.get_datetime()
     """
@@ -164,7 +168,7 @@ def test_get_datetime():
     )
 
 
-def test_remove_suffix():
+def test_remove_suffix() -> None:
     """
     Test utils.remove_suffix()
     """
@@ -174,7 +178,7 @@ def test_remove_suffix():
     assert remove_suffix(s, ".bourne") == "jason"
 
 
-def test_remove_prefix():
+def test_remove_prefix() -> None:
     """
     Test utils.remove_prefix()
     """

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -57,18 +57,18 @@ class SeqInfo(NamedTuple):
     protocol_name: str  # 12
     is_motion_corrected: bool  # 13
     is_derived: bool  # 14
-    patient_id: Any  # 15
+    patient_id: Optional[str]  # 15
     study_description: str  # 16
     referring_physician_name: str  # 17
     series_description: str  # 18
     sequence_name: str  # 19
     image_type: tuple[str, ...]  # 20
     accession_number: str  # 21
-    patient_age: Any  # 22
-    patient_sex: Any  # 23
-    date: Any  # 24
-    series_uid: Any  # 25
-    time: Any  # 26
+    patient_age: Optional[str]  # 22
+    patient_sex: Optional[str]  # 23
+    date: Optional[str]  # 24
+    series_uid: Optional[str]  # 25
+    time: Optional[str]  # 26
 
 
 class StudySessionInfo(NamedTuple):
@@ -356,7 +356,7 @@ def treat_infofile(filename: str) -> None:
     set_readonly(filename)
 
 
-def slim_down_info(j: Any) -> Any:
+def slim_down_info(j: dict[str, Any]) -> dict[str, Any]:
     """Given an aggregated info structure, removes excessive details
 
     Such as CSA fields, and SourceImageSequence which on Siemens files could be

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -57,12 +57,12 @@ class SeqInfo(NamedTuple):
     is_motion_corrected: bool  # 13
     is_derived: bool  # 14
     patient_id: Any  # 15
-    study_description: Any  # 16
+    study_description: str  # 16
     referring_physician_name: str  # 17
     series_description: str  # 18
     sequence_name: str  # 19
     image_type: tuple[str, ...]  # 20
-    accession_number: Any  # 21
+    accession_number: str  # 21
     patient_age: Any  # 22
     patient_sex: Any  # 23
     date: Any  # 24

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -1,5 +1,8 @@
 """Utility objects and functions"""
+from __future__ import annotations
+
 from collections import namedtuple
+from collections.abc import Callable
 import copy
 from datetime import datetime
 from glob import glob
@@ -17,40 +20,47 @@ from subprocess import check_output
 import sys
 import tempfile
 from time import sleep
+from types import ModuleType
+from typing import Any, AnyStr, Dict, List, Optional, Tuple, TypeVar, Union, overload
 
 lgr = logging.getLogger(__name__)
 
-seqinfo_fields = [
-    "total_files_till_now",  # 0
-    "example_dcm_file",  # 1
-    "series_id",  # 2
-    "dcm_dir_name",  # 3
-    "series_files",  # 4
-    "unspecified",  # 5
-    "dim1",
-    "dim2",
-    "dim3",
-    "dim4",  # 6, 7, 8, 9
-    "TR",
-    "TE",  # 10, 11
-    "protocol_name",  # 12
-    "is_motion_corrected",  # 13
-    "is_derived",  # 14
-    "patient_id",  # 15
-    "study_description",  # 16
-    "referring_physician_name",  # 17
-    "series_description",  # 18
-    "sequence_name",  # 19
-    "image_type",  # 20
-    "accession_number",  # 21
-    "patient_age",  # 22
-    "patient_sex",  # 23
-    "date",  # 24
-    "series_uid",  # 25
-    "time",  # 26
-]
+T = TypeVar("T")
+V = TypeVar("V")
 
-SeqInfo = namedtuple("SeqInfo", seqinfo_fields)
+
+SeqInfo = namedtuple(
+    "SeqInfo",
+    [
+        "total_files_till_now",  # 0
+        "example_dcm_file",  # 1
+        "series_id",  # 2
+        "dcm_dir_name",  # 3
+        "series_files",  # 4
+        "unspecified",  # 5
+        "dim1",
+        "dim2",
+        "dim3",
+        "dim4",  # 6, 7, 8, 9
+        "TR",
+        "TE",  # 10, 11
+        "protocol_name",  # 12
+        "is_motion_corrected",  # 13
+        "is_derived",  # 14
+        "patient_id",  # 15
+        "study_description",  # 16
+        "referring_physician_name",  # 17
+        "series_description",  # 18
+        "sequence_name",  # 19
+        "image_type",  # 20
+        "accession_number",  # 21
+        "patient_age",  # 22
+        "patient_sex",  # 23
+        "date",  # 24
+        "series_uid",  # 25
+        "time",  # 26
+    ],
+)
 
 StudySessionInfo = namedtuple(
     "StudySessionInfo",
@@ -68,26 +78,28 @@ StudySessionInfo = namedtuple(
 )
 
 
-class TempDirs(object):
+class TempDirs:
     """A helper to centralize handling and cleanup of dirs"""
 
-    def __init__(self):
-        self.dirs = []
-        self.exists = op.exists
-        self.lgr = logging.getLogger("tempdirs")
+    def __init__(self) -> None:
+        self.dirs: list[str] = []
+        self.lgr: logging.Logger = logging.getLogger("tempdirs")
 
-    def __call__(self, prefix=None):
+    def __call__(self, prefix: Optional[str] = None) -> str:
         tmpdir = tempfile.mkdtemp(prefix=prefix)
         self.dirs.append(tmpdir)
         return tmpdir
 
-    def __del__(self):
+    def __del__(self) -> None:
         try:
             self.cleanup()
         except AttributeError:
             pass
 
-    def cleanup(self):
+    def exists(self, path: str) -> bool:
+        return op.exists(path)
+
+    def cleanup(self) -> None:
         self.lgr.debug("Removing %d temporary directories", len(self.dirs))
         for t in self.dirs[:]:
             self.lgr.debug("Removing %s", t)
@@ -95,24 +107,25 @@ class TempDirs(object):
                 self.rmtree(t)
         self.dirs = []
 
-    def rmtree(self, tmpdir):
+    def rmtree(self, tmpdir: str) -> None:
         if self.exists(tmpdir):
             shutil.rmtree(tmpdir)
         if tmpdir in self.dirs:
             self.dirs.remove(tmpdir)
 
 
-def docstring_parameter(*sub):
+def docstring_parameter(*sub: str) -> Callable[[T], T]:
     """Borrowed from https://stackoverflow.com/a/10308363/6145776"""
 
-    def dec(obj):
+    def dec(obj: T) -> T:
+        assert obj.__doc__ is not None
         obj.__doc__ = obj.__doc__.format(*sub)
         return obj
 
     return dec
 
 
-def anonymize_sid(sid, anon_sid_cmd):
+def anonymize_sid(sid: AnyStr, anon_sid_cmd: str) -> AnyStr:
     """
     Raises
     ------
@@ -120,7 +133,7 @@ def anonymize_sid(sid, anon_sid_cmd):
       if script returned an empty string (after whitespace stripping),
       or output with multiple words/lines.
     """
-    cmd = [anon_sid_cmd, sid]
+    cmd: list[str | bytes] = [anon_sid_cmd, sid]
     shell_return = check_output(cmd)
 
     if isinstance(shell_return, bytes) and isinstance(sid, str):
@@ -138,7 +151,7 @@ def anonymize_sid(sid, anon_sid_cmd):
     return anon_sid
 
 
-def create_file_if_missing(filename, content):
+def create_file_if_missing(filename: str, content: str) -> bool:
     """Create file if missing, so we do not
     override any possibly introduced changes"""
     if op.lexists(filename):
@@ -151,20 +164,20 @@ def create_file_if_missing(filename, content):
     return True
 
 
-def read_config(infile):
-    with open(infile, "rt") as fp:
+def read_config(infile: str) -> Any:
+    with open(infile, "r") as fp:
         info = eval(fp.read())
     return info
 
 
-def write_config(outfile, info):
+def write_config(outfile: str, info: Any) -> None:
     from pprint import PrettyPrinter
 
-    with open(outfile, "wt") as fp:
+    with open(outfile, "w") as fp:
         fp.writelines(PrettyPrinter().pformat(info))
 
 
-def load_json(filename, retry=0):
+def load_json(filename: str, retry: int = 0) -> Any:
     """Load data from a json file
 
     Parameters
@@ -202,13 +215,19 @@ def load_json(filename, retry=0):
     return data
 
 
-def assure_no_file_exists(path):
+def assure_no_file_exists(path: str | Path) -> None:
     """Check if file or symlink (git-annex?) exists, and if so -- remove"""
     if os.path.lexists(path):
         os.unlink(path)
 
 
-def save_json(filename, data, indent=2, sort_keys=True, pretty=False):
+def save_json(
+    filename: str | Path,
+    data: Any,
+    indent: int = 2,
+    sort_keys: bool = True,
+    pretty: bool = False,
+) -> None:
     """Save data to a json file
 
     Parameters
@@ -223,11 +242,10 @@ def save_json(filename, data, indent=2, sort_keys=True, pretty=False):
 
     """
     assure_no_file_exists(filename)
-    dumps_kw = dict(sort_keys=sort_keys, indent=indent)
-    j = None
+    j: Optional[str] = None
     if pretty:
         try:
-            j = json_dumps_pretty(data, **dumps_kw)
+            j = json_dumps_pretty(data, sort_keys=sort_keys, indent=indent)
         except AssertionError as exc:
             pretty = False
             lgr.warning(
@@ -237,18 +255,18 @@ def save_json(filename, data, indent=2, sort_keys=True, pretty=False):
                 "that file (%s) with HeuDiConv developers" % (str(exc), filename)
             )
     if not pretty:
-        j = json_dumps(data, **dumps_kw)
+        j = json_dumps(data, sort_keys=sort_keys, indent=indent)
     assert j is not None  # one way or another it should have been set to a str
     with open(filename, "w") as fp:
         fp.write(j)
 
 
-def json_dumps(json_obj, indent=2, sort_keys=True):
+def json_dumps(json_obj: Any, indent: int = 2, sort_keys: bool = True) -> str:
     """Unified (default indent and sort_keys) invocation of json.dumps"""
     return json.dumps(json_obj, indent=indent, sort_keys=sort_keys)
 
 
-def json_dumps_pretty(j, indent=2, sort_keys=True):
+def json_dumps_pretty(j: Any, indent: int = 2, sort_keys: bool = True) -> str:
     """Given a json structure, pretty print it by colliding numeric arrays
     into a line.
 
@@ -293,7 +311,9 @@ def json_dumps_pretty(j, indent=2, sort_keys=True):
     return js_
 
 
-def update_json(json_file, new_data, pretty=False):
+def update_json(
+    json_file: str | Path, new_data: dict[str, Any], pretty: bool = False
+) -> None:
     """
     Adds a given field (and its value) to a json file
 
@@ -321,7 +341,7 @@ def update_json(json_file, new_data, pretty=False):
     save_json(json_file, data, pretty=pretty)
 
 
-def treat_infofile(filename):
+def treat_infofile(filename: str) -> None:
     """Tune up generated .json file (slim down, pretty-print for humans)."""
     j = load_json(filename)
     j_slim = slim_down_info(j)
@@ -329,7 +349,7 @@ def treat_infofile(filename):
     set_readonly(filename)
 
 
-def slim_down_info(j):
+def slim_down_info(j: Any) -> Any:
     """Given an aggregated info structure, removes excessive details
 
     Such as CSA fields, and SourceImageSequence which on Siemens files could be
@@ -337,7 +357,7 @@ def slim_down_info(j):
     If needed, could be recovered from stored DICOMs
     """
     j = copy.deepcopy(j)  # we will do in-place modification on a copy
-    dicts = []
+    dicts: list[dict[str, Any]] = []
     # poor man programming for now
     if "const" in j.get("global", {}):
         dicts.append(j["global"]["const"])
@@ -350,7 +370,7 @@ def slim_down_info(j):
     return j
 
 
-def get_known_heuristic_names():
+def get_known_heuristic_names() -> list[str]:
     """Return a list of heuristic names present under heudiconv/heuristics"""
     import heudiconv.heuristics
 
@@ -364,7 +384,7 @@ def get_known_heuristic_names():
     )
 
 
-def load_heuristic(heuristic):
+def load_heuristic(heuristic: str) -> ModuleType:
     """Load heuristic from the file, return the module"""
     if os.path.sep in heuristic or os.path.lexists(heuristic):
         heuristic_file = op.realpath(heuristic)
@@ -373,7 +393,7 @@ def load_heuristic(heuristic):
             old_syspath = sys.path[:]
             sys.path.insert(0, path)
             mod = __import__(fname.split(".")[0])
-            mod.filename = heuristic_file
+            mod.filename = heuristic_file  # type: ignore[attr-defined]
         finally:
             sys.path = old_syspath
     else:
@@ -381,13 +401,15 @@ def load_heuristic(heuristic):
 
         try:
             mod = import_module("heudiconv.heuristics.%s" % heuristic)
-            mod.filename = mod.__file__.rstrip("co")  # remove c or o from pyc/pyo
+            assert mod.__file__ is not None
+            # remove c or o from pyc/pyo
+            mod.filename = mod.__file__.rstrip("co")  # type: ignore[attr-defined]
         except Exception as exc:
             raise ImportError("Failed to import heuristic %s: %s" % (heuristic, exc))
     return mod
 
 
-def get_heuristic_description(name, full=False):
+def get_heuristic_description(name: str, full: bool = False) -> str:
     try:
         mod = load_heuristic(name)
         desc = (getattr(mod, "__doc__", "") or "").strip()
@@ -396,7 +418,7 @@ def get_heuristic_description(name, full=False):
         return "Failed to load: %s" % exc
 
 
-def get_known_heuristics_with_descriptions():
+def get_known_heuristics_with_descriptions() -> dict[str, str]:
     from collections import OrderedDict
 
     heuristics = OrderedDict()
@@ -405,17 +427,17 @@ def get_known_heuristics_with_descriptions():
     return heuristics
 
 
-def safe_copyfile(src, dest, overwrite=False):
+def safe_copyfile(src: str, dest: str, overwrite: bool = False) -> None:
     """Copy file but blow if destination name already exists"""
-    return _safe_op_file(src, dest, "copyfile", overwrite=overwrite)
+    _safe_op_file(src, dest, "copyfile", overwrite=overwrite)
 
 
-def safe_movefile(src, dest, overwrite=False):
+def safe_movefile(src: str, dest: str, overwrite: bool = False) -> None:
     """Move file but blow if destination name already exists"""
-    return _safe_op_file(src, dest, "move", overwrite=overwrite)
+    _safe_op_file(src, dest, "move", overwrite=overwrite)
 
 
-def _safe_op_file(src, dest, operation, overwrite=False):
+def _safe_op_file(src: str, dest: str, operation: str, overwrite: bool = False) -> None:
     """Copy or move file but blow if destination name already exists
 
     Parameters
@@ -443,7 +465,7 @@ ALL_CAN_READ = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
 assert ALL_CAN_READ >> 1 == ALL_CAN_WRITE  # Assumption in the code
 
 
-def set_readonly(path, read_only=True):
+def set_readonly(path: str, read_only: bool = True) -> int:
     """Make file read only or writeable while preserving "access levels"
 
     So if file was not readable by others, it should remain not readable by
@@ -474,7 +496,7 @@ def set_readonly(path, read_only=True):
     return new_perms
 
 
-def is_readonly(path):
+def is_readonly(path: str) -> bool:
     """Return True if it is a fully read-only file (dereferences the symlink)"""
     # get current permissions
     perms = stat.S_IMODE(os.lstat(os.path.realpath(path)).st_mode)
@@ -482,7 +504,7 @@ def is_readonly(path):
     return not bool(perms & ALL_CAN_WRITE)
 
 
-def clear_temp_dicoms(item_dicoms):
+def clear_temp_dicoms(item_dicoms: list[str]) -> None:
     """Ensures DICOM temporary directories are safely cleared"""
     try:
         tmp = Path(op.commonprefix(item_dicoms)).parents[1]
@@ -491,26 +513,26 @@ def clear_temp_dicoms(item_dicoms):
     if (
         str(tmp.parent) == tempfile.gettempdir()
         and str(tmp.stem).startswith("heudiconvDCM")
-        and op.exists(str(tmp))
+        and op.exists(tmp)
     ):
         # clean up directory holding dicoms
-        shutil.rmtree(str(tmp))
+        shutil.rmtree(tmp)
 
 
-def file_md5sum(filename):
+def file_md5sum(filename: str) -> str:
     with open(filename, "rb") as f:
         return hashlib.md5(f.read()).hexdigest()
 
 
 # Borrowed from DataLad (MIT license), with "archives" functionality commented
 # out
-class File(object):
+class File:
     """Helper for a file entry in the create_tree/@with_tree
 
     It allows to define additional settings for entries
     """
 
-    def __init__(self, name, executable=False):
+    def __init__(self, name: str, executable: bool = False) -> None:
         """
 
         Parameters
@@ -523,11 +545,20 @@ class File(object):
         self.name = name
         self.executable = executable
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
-def create_tree(path, tree, archives_leading_dir=True):
+TreeSpec = Union[
+    Tuple[Tuple[Union[str, File], "Load"], ...],
+    List[Tuple[Union[str, File], "Load"]],
+    Dict[Union[str, File], "Load"],
+]
+
+Load = Union[str, "TreeSpec"]
+
+
+def create_tree(path: str, tree: TreeSpec, archives_leading_dir: bool = True) -> None:
     """Given a list of tuples (name, load) or a dict create such a tree
 
     if load is a tuple or a dict itself -- that would create either a subtree
@@ -539,7 +570,7 @@ def create_tree(path, tree, archives_leading_dir=True):
         os.makedirs(path)
 
     if isinstance(tree, dict):
-        tree = tree.items()
+        tree = list(tree.items())
 
     for file_, load in tree:
         if isinstance(file_, File):
@@ -565,7 +596,21 @@ def create_tree(path, tree, archives_leading_dir=True):
             os.chmod(full_name, os.stat(full_name).st_mode | stat.S_IEXEC)
 
 
-def get_typed_attr(obj, attr, _type, default=None):
+@overload
+def get_typed_attr(obj: Any, attr: str, _type: type[T], default: V) -> T | V:
+    ...
+
+
+@overload
+def get_typed_attr(
+    obj: Any, attr: str, _type: type[T], default: None = None
+) -> T | None:
+    ...
+
+
+def get_typed_attr(
+    obj: Any, attr: str, _type: type[T], default: Optional[V] = None
+) -> T | V | None:
     """
     Typecasts an object's named attribute. If the attribute cannot be
     converted, the default value is returned instead.
@@ -578,13 +623,13 @@ def get_typed_attr(obj, attr, _type, default=None):
     default: value, optional
     """
     try:
-        val = _type(getattr(obj, attr, default))
+        val = _type(getattr(obj, attr, default))  # type: ignore[call-arg]
     except (TypeError, ValueError):
         return default
     return val
 
 
-def get_datetime(date, time, *, microseconds=True):
+def get_datetime(date: str, time: str, *, microseconds: bool = True) -> str:
     """
     Combine date and time from dicom to isoformat.
 
@@ -614,7 +659,7 @@ def get_datetime(date, time, *, microseconds=True):
     return datetime_str
 
 
-def remove_suffix(s, suf):
+def remove_suffix(s: str, suf: str) -> str:
     """
     Remove suffix from the end of the string
 
@@ -633,7 +678,7 @@ def remove_suffix(s, suf):
     return s
 
 
-def remove_prefix(s, pre):
+def remove_prefix(s: str, pre: str) -> str:
     """
     Remove prefix from the beginning of the string
 

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -31,6 +31,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
     overload,
 )
 
@@ -170,13 +171,13 @@ def create_file_if_missing(filename: str, content: str) -> bool:
     return True
 
 
-def read_config(infile: str) -> Any:
+def read_config(infile: str) -> dict:
     with open(infile, "r") as fp:
-        info = eval(fp.read())
+        info = cast(dict, eval(fp.read()))
     return info
 
 
-def write_config(outfile: str, info: Any) -> None:
+def write_config(outfile: str, info: dict) -> None:
     from pprint import PrettyPrinter
 
     with open(outfile, "w") as fp:

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -1,7 +1,6 @@
 """Utility objects and functions"""
 from __future__ import annotations
 
-from collections import namedtuple
 from collections.abc import Callable
 from collections.abc import Mapping as MappingABC
 import copy
@@ -41,38 +40,34 @@ T = TypeVar("T")
 V = TypeVar("V")
 
 
-SeqInfo = namedtuple(
-    "SeqInfo",
-    [
-        "total_files_till_now",  # 0
-        "example_dcm_file",  # 1
-        "series_id",  # 2
-        "dcm_dir_name",  # 3
-        "series_files",  # 4
-        "unspecified",  # 5
-        "dim1",
-        "dim2",
-        "dim3",
-        "dim4",  # 6, 7, 8, 9
-        "TR",
-        "TE",  # 10, 11
-        "protocol_name",  # 12
-        "is_motion_corrected",  # 13
-        "is_derived",  # 14
-        "patient_id",  # 15
-        "study_description",  # 16
-        "referring_physician_name",  # 17
-        "series_description",  # 18
-        "sequence_name",  # 19
-        "image_type",  # 20
-        "accession_number",  # 21
-        "patient_age",  # 22
-        "patient_sex",  # 23
-        "date",  # 24
-        "series_uid",  # 25
-        "time",  # 26
-    ],
-)
+class SeqInfo(NamedTuple):
+    total_files_till_now: int  # 0
+    example_dcm_file: str  # 1
+    series_id: str  # 2
+    dcm_dir_name: str  # 3
+    series_files: int  # 4
+    unspecified: str  # 5
+    dim1: int  # 6
+    dim2: int  # 7
+    dim3: int  # 8
+    dim4: int  # 9
+    TR: float  # 10
+    TE: float  # 11
+    protocol_name: str  # 12
+    is_motion_corrected: bool  # 13
+    is_derived: bool  # 14
+    patient_id: Any  # 15
+    study_description: Any  # 16
+    referring_physician_name: str  # 17
+    series_description: str  # 18
+    sequence_name: str  # 19
+    image_type: tuple[str, ...]  # 20
+    accession_number: Any  # 21
+    patient_age: Any  # 22
+    patient_sex: Any  # 23
+    date: Any  # 24
+    series_uid: Any  # 25
+    time: Any  # 26
 
 
 class StudySessionInfo(NamedTuple):

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -78,7 +78,7 @@ class StudySessionInfo(NamedTuple):
     # StudyInstanceUID into some place within hierarchy
     locator: Optional[str]
 
-    session: Optional[str | int]
+    session: Optional[str]
 
     # should be some ID defined either in cmdline or deduced
     subject: Optional[str]

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -21,7 +21,18 @@ import sys
 import tempfile
 from time import sleep
 from types import ModuleType
-from typing import Any, AnyStr, Dict, List, Optional, Tuple, TypeVar, Union, overload
+from typing import (
+    Any,
+    AnyStr,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
 
 lgr = logging.getLogger(__name__)
 
@@ -62,20 +73,19 @@ SeqInfo = namedtuple(
     ],
 )
 
-StudySessionInfo = namedtuple(
-    "StudySessionInfo",
-    [
-        "locator",  # possible prefix identifying the study, e.g.
-        # PI/dataset or just a dataset or empty (default)
-        # Note that ATM there should be no multiple DICOMs with the
-        # same StudyInstanceUID which would collide, i.e point to
-        # the same subject/session. So 'locator' is pretty much an
-        # assignment from StudyInstanceUID into some place within
-        # hierarchy
-        "session",  # could be None
-        "subject",  # should be some ID defined either in cmdline or deduced
-    ],
-)
+
+class StudySessionInfo(NamedTuple):
+    # possible prefix identifying the study, e.g.  PI/dataset or just a dataset
+    # or empty (default) Note that ATM there should be no multiple DICOMs with
+    # the same StudyInstanceUID which would collide, i.e point to the same
+    # subject/session. So 'locator' is pretty much an assignment from
+    # StudyInstanceUID into some place within hierarchy
+    locator: Optional[str]
+
+    session: Optional[str | int]
+
+    # should be some ID defined either in cmdline or deduced
+    subject: Optional[str]
 
 
 class TempDirs:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,17 @@
 [mypy]
-# Empty section to force mypy to recognize the [mypy-*] sections
+allow_incomplete_defs = False
+# TODO: Uncomment this once everything's annotated:
+#allow_untyped_defs = False
+no_implicit_optional = True
+#implicit_reexport = False
+local_partial_types = True
+pretty = True
+show_error_codes = True
+show_traceback = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
 
 [mypy-datalad.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -28,5 +28,10 @@ ignore_missing_imports = True
 [mypy-inotify.*]
 ignore_missing_imports = True
 
+[mypy-nibabel.*]
+# The CI runs type-checking using Python 3.7, yet nibabel only added type
+# annotations in v5.1.0, which requires Python 3.8+.
+ignore_missing_imports = True
+
 [mypy-nipype.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,10 @@ strict_equality = True
 warn_redundant_casts = True
 warn_return_any = True
 warn_unreachable = True
+exclude = due\.py
+
+[mypy-heudiconv.due]
+follow_imports = skip
 
 [mypy-datalad.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,20 @@
+[mypy]
+# Empty section to force mypy to recognize the [mypy-*] sections
+
+[mypy-datalad.*]
+ignore_missing_imports = True
+
+[mypy-dcmstack.*]
+ignore_missing_imports = True
+
+[mypy-duecredit.*]
+ignore_missing_imports = True
+
+[mypy-etelemetry.*]
+ignore_missing_imports = True
+
+[mypy-inotify.*]
+ignore_missing_imports = True
+
+[mypy-nipype.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,6 @@
 [mypy]
 allow_incomplete_defs = False
-# TODO: Uncomment this once everything's annotated:
-#allow_untyped_defs = False
+allow_untyped_defs = False
 no_implicit_optional = True
 #implicit_reexport = False
 local_partial_types = True

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ def main():
         install_requires=ldict["REQUIRES"],
         extras_require=ldict["EXTRA_REQUIRES"],
         package_data={
+            "heudiconv": ["py.typed"],
             "heudiconv.tests": [
                 op.join("data", "*.dcm"),
                 op.join("data", "*", "*.dcm"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,26 @@
 [tox]
-envlist = lint,py3
+envlist = lint,typing,py3
 
 [testenv]
 extras = all
 commands = pytest -s -v {posargs} heudiconv
+
+[testenv:lint]
+skip_install = True
+deps =
+    flake8
+    flake8-bugbear
+    flake8-builtins
+    flake8-unused-arguments
+commands =
+    flake8 heudiconv
+
+[testenv:typing]
+deps =
+    mypy
+extras = all
+commands =
+    mypy heudiconv
 
 [pytest]
 #  monitor.py requires optional linotify, but would blow tests discovery, does not contain tests within
@@ -27,16 +44,6 @@ filterwarnings =
 [coverage:run]
 include = heudiconv/*
           setup.py
-
-[testenv:lint]
-skip_install = True
-deps =
-    flake8
-    flake8-bugbear
-    flake8-builtins
-    flake8-unused-arguments
-commands =
-    flake8 heudiconv
 
 [flake8]
 doctests = True


### PR DESCRIPTION
Closes #653.

---

Problems encountered so far with applying type annotations:

* `heudiconv.dicoms.group_dicoms_into_seqinfos()`: If `grouping == "custom"` and `custom_grouping` is a callable, the return value is the result of applying `custom_grouping()` to some arguments; otherwise, the return value is something else.  Normally, this could be annotated by using overloads and `Literal["custom"]`, but whenever `group_dicoms_into_seqinfos()` is called in the heudiconv code, `grouping` (if present) is always passed as a variable rather than a string literal, and so `Literal` is unusable here.
* The docstring for `heudiconv.dicoms.create_seqinfo()` states that the first argument is of type `nibabel.nicom.dicomwrappers.MosaicWrapper`, yet [here](https://github.com/nipy/heudiconv/blob/012895dfc1d940ffa42213e0fec15d8392f5b7f3/heudiconv/dicoms.py#L280) the supplied argument (obtained from `validate_dicom()`) is just a `nibabel.nicom.dicomwrappers.Wrapper`.
* `SeqInfo.series_id` is clearly meant to be a `str`, yet there are several places in `heudiconv/heuristics/example.py` where this field is compared against or assigned to an `int` variable.