### PR TITLE
Don't call `logging.basicConfig()` in `__init__.py`

### DIFF
--- a/heudiconv/__init__.py
+++ b/heudiconv/__init__.py
@@ -1,16 +1,9 @@
-# set logger handler
 import logging
-import os
 
 from ._version import __version__
 from .info import __packagename__
 
 __all__ = ["__packagename__", "__version__"]
 
-# Rudimentary logging support.
 lgr = logging.getLogger(__name__)
-logging.basicConfig(
-    format="%(levelname)s: %(message)s",
-    level=getattr(logging, os.environ.get("HEUDICONV_LOG_LEVEL", "INFO")),
-)
 lgr.debug("Starting the abomination")  # just to "run-test" logging

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -12,6 +12,10 @@ lgr = logging.getLogger(__name__)
 
 
 def main(argv=None):
+    logging.basicConfig(
+        format="%(levelname)s: %(message)s",
+        level=getattr(logging, os.environ.get("HEUDICONV_LOG_LEVEL", "INFO")),
+    )
     parser = get_parser()
     args = parser.parse_args(argv)
     # exit if nothing to be done


### PR DESCRIPTION
Calling `logging.basicConfig()` when your library is imported is incredibly rude, as it infringes upon the importing code's ability to configure the logging itself.  The only time (if any) the `heudiconv` package should call `logging.basicConfig()` is in the `main()` function for a command-line entry point.

See also <https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library>.