### PR TITLE
Add `sample_nifti.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ _build/
 _version.py
 build/
 dist/
+sample_nifti.json
 venvs/


### PR DESCRIPTION
One of the tests creates a `sample_nifti.json` file in the `heudiconv/tests/data/` directory, and this file needs to be in the same directory as some of the files that are already in the `data/` directory (and so creating it in a temp directory won't work).  This PR thus adds the file to `.gitignore` so that it will be ignored by Git.