### PR TITLE
Use `pydicom.dcmread()` instead of `pydicom.read_file()`

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -561,7 +561,7 @@ def get_formatted_scans_key_row(dcm_fn) -> typing.List[str]:
         [ISO acquisition time, performing physician name, random string]
 
     """
-    dcm_data = dcm.read_file(dcm_fn, stop_before_pixels=True, force=True)
+    dcm_data = dcm.dcmread(dcm_fn, stop_before_pixels=True, force=True)
     # we need to store filenames and acquisition datetimes
     acq_datetime = dicoms.get_datetime_from_dcm(dcm_data=dcm_data)
     # add random string

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -360,7 +360,7 @@ def get_reproducible_int(dicom_list: List[str]) -> int:
     """
     import calendar
 
-    dicom = dcm.read_file(dicom_list[0], stop_before_pixels=True, force=True)
+    dicom = dcm.dcmread(dicom_list[0], stop_before_pixels=True, force=True)
     dicom_datetime = get_datetime_from_dcm(dicom)
     if dicom_datetime:
         return calendar.timegm(dicom_datetime.timetuple())

--- a/heudiconv/heuristics/multires_7Tbold.py
+++ b/heudiconv/heuristics/multires_7Tbold.py
@@ -20,18 +20,18 @@ def filter_dicom(dcmdata):
 def extract_moco_params(basename, _outypes, dicoms):
     if "_rec-dico" not in basename:
         return
-    from pydicom import read_file as dcm_read
+    from pydicom import dcmread
 
     # get acquisition time for all dicoms
     dcm_times = [
-        (d, float(dcm_read(d, stop_before_pixels=True).AcquisitionTime)) for d in dicoms
+        (d, float(dcmread(d, stop_before_pixels=True).AcquisitionTime)) for d in dicoms
     ]
     # store MoCo info from image comments sorted by acquisition time
     moco = [
         "\t".join(
             [
                 str(float(i))
-                for i in dcm_read(fn, stop_before_pixels=True)
+                for i in dcmread(fn, stop_before_pixels=True)
                 .ImageComments.split()[1]
                 .split(",")
             ]

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -26,7 +26,7 @@ DICOM_FIELDS_TO_TEST = {"ProtocolName": "tProtocolName"}
 
 def test_private_csa_header(tmp_path: Path) -> None:
     dcm_file = op.join(TESTS_DATA_PATH, "axasc35.dcm")
-    dcm_data = dcm.read_file(dcm_file, stop_before_pixels=True)
+    dcm_data = dcm.dcmread(dcm_file, stop_before_pixels=True)
     for pub, priv in DICOM_FIELDS_TO_TEST.items():
         # ensure missing public tag
         with pytest.raises(AttributeError):

--- a/heudiconv/tests/test_regression.py
+++ b/heudiconv/tests/test_regression.py
@@ -118,7 +118,7 @@ def test_grouping(tmpdir, subject):
     dicoms = [op.join(TESTS_DATA_PATH, fl) for fl in ["axasc35.dcm", "phantom.dcm"]]
     # ensure DICOMs are different studies
     studyuids = {
-        dcm.read_file(fl, stop_before_pixels=True).StudyInstanceUID for fl in dicoms
+        dcm.dcmread(fl, stop_before_pixels=True).StudyInstanceUID for fl in dicoms
     }
     assert len(studyuids) == len(dicoms)
     # symlink to common location


### PR DESCRIPTION
`read_file()` was deprecated in pydicom v2.2.0 and will be removed in v3.0.  Code should instead use `dcmread()`, which has been an alias of `read_file()` since pydicom v1.0.0.