### PR TITLE
ENH: set and expose global dicom compresslevel var

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -20,6 +20,7 @@ with warnings.catch_warnings():
 
 lgr = logging.getLogger(__name__)
 total_files = 0
+compresslevel = 9
 
 
 def create_seqinfo(mw, series_files, series_id):
@@ -459,7 +460,8 @@ def compress_dicoms(dicom_list, out_prefix, tempdirs, overwrite):
         try:
             if op.lexists(outtar):
                 os.unlink(outtar)
-            with tarfile.open(outtar, "w:gz", dereference=True) as tar:
+            with tarfile.open(outtar, "w:gz", compresslevel=compresslevel,
+                              dereference=True) as tar:
                 for filename in dicom_list:
                     outfile = op.join(tmpdir, op.basename(filename))
                     if not op.islink(outfile):

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -20,6 +20,8 @@ with warnings.catch_warnings():
 
 lgr = logging.getLogger(__name__)
 total_files = 0
+# Might be monkey patched by user heuristic to tune desired compression level
+# Preferably do not move/rename unless 
 compresslevel = 9
 
 


### PR DESCRIPTION
Python's tarfile is using a compression level of 9 by default (back to and including python 3.5): https://docs.python.org/3/library/tarfile.html#tarfile.open

We see cases where this leads to a large waste of cpu cycles with minimal gain as opposed to compress level 5 or even 1. 

Setting a global `compresslevel` variable makes it easy to override from our heuristics, keeping the default with minimal code impact.