### PR TITLE
Make .subsecond optional in BIDS/DICOM datetime entries

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -6,7 +6,6 @@ __docformat__ = "numpy"
 
 from collections import OrderedDict
 import csv
-from datetime import datetime
 import errno
 from glob import glob
 import hashlib
@@ -32,6 +31,7 @@ from .utils import (
     remove_suffix,
     save_json,
     set_readonly,
+    strptime_micr,
     update_json,
 )
 
@@ -369,7 +369,9 @@ def tuneup_bids_json_files(json_files: list[str]) -> None:
                 set_readonly(json_phasediffname)
 
 
-def add_participant_record(studydir: str, subject: str, age: str | None, sex: str | None) -> None:
+def add_participant_record(
+    studydir: str, subject: str, age: str | None, sex: str | None
+) -> None:
     participants_tsv = op.join(studydir, "participants.tsv")
     participant_id = "sub-%s" % subject
 
@@ -945,17 +947,17 @@ def select_fmap_from_compatible_groups(
             k for k, v in acq_times_fmaps.items() if v == first_acq_time
         ][0]
     elif criterion == "Closest":
-        json_acq_time = datetime.strptime(
+        json_acq_time = strptime_micr(
             acq_times[
                 # remove session folder and '.json', add '.nii.gz':
                 remove_suffix(remove_prefix(json_file, sess_folder + op.sep), ".json")
                 + ".nii.gz"
             ],
-            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S[.%f]",
         )
         # differences in acquisition time (abs value):
         diff_fmaps_acq_times = {
-            k: abs(datetime.strptime(v, "%Y-%m-%dT%H:%M:%S.%f") - json_acq_time)
+            k: abs(strptime_micr(v, "%Y-%m-%dT%H:%M:%S[.%f]") - json_acq_time)
             for k, v in acq_times_fmaps.items()
         }
         min_diff_acq_times = sorted(diff_fmaps_acq_times.values())[0]

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -15,7 +15,14 @@ import warnings
 
 import pydicom as dcm
 
-from .utils import SeqInfo, TempDirs, get_typed_attr, load_json, set_readonly
+from .utils import (
+    SeqInfo,
+    TempDirs,
+    get_typed_attr,
+    load_json,
+    set_readonly,
+    strptime_micr,
+)
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 8):
@@ -481,16 +488,16 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     acq_date = dcm_data.get("AcquisitionDate")
     acq_time = dcm_data.get("AcquisitionTime")
     if not (acq_date is None or acq_time is None):
-        return datetime.datetime.strptime(acq_date + acq_time, "%Y%m%d%H%M%S.%f")
+        return strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")
 
     acq_dt = dcm_data.get("AcquisitionDateTime")
     if acq_dt is not None:
-        return datetime.datetime.strptime(acq_dt, "%Y%m%d%H%M%S.%f")
+        return strptime_micr(acq_dt, "%Y%m%d%H%M%S[.%f]")
 
     series_date = dcm_data.get("SeriesDate")
     series_time = dcm_data.get("SeriesTime")
     if not (series_date is None or series_time is None):
-        return datetime.datetime.strptime(series_date + series_time, "%Y%m%d%H%M%S.%f")
+        return strptime_micr(series_date + series_time, "%Y%m%d%H%M%S[.%f]")
     return None
 
 

--- a/heudiconv/tests/test_utils.py
+++ b/heudiconv/tests/test_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import json
 from json.decoder import JSONDecodeError
 import os
@@ -21,6 +22,7 @@ from heudiconv.utils import (
     remove_prefix,
     remove_suffix,
     save_json,
+    strptime_micr,
     update_json,
 )
 
@@ -165,6 +167,24 @@ def test_get_datetime() -> None:
     assert (
         get_datetime("20200512", "162130.5", microseconds=False)
         == "2020-05-12T16:21:30"
+    )
+
+
+@pytest.mark.parametrize(
+    "dt, fmt",
+    [
+        ("20230310190100", "%Y%m%d%H%M%S"),
+        ("2023-04-02T11:47:09", "%Y-%m-%dT%H:%M:%S"),
+    ],
+)
+def test_strptime_micr(dt: str, fmt: str) -> None:
+    target = datetime.strptime(dt, fmt)
+    assert strptime_micr(dt, fmt) == target
+    assert strptime_micr(dt, fmt + "[.%f]") == target
+    assert strptime_micr(dt + ".0", fmt + "[.%f]") == target
+    assert strptime_micr(dt + ".000000", fmt + "[.%f]") == target
+    assert strptime_micr(dt + ".1", fmt + "[.%f]") == datetime.strptime(
+        dt + ".1", fmt + ".%f"
     )
 
 

--- a/heudiconv/utils.py
+++ b/heudiconv/utils.py
@@ -666,6 +666,27 @@ def get_datetime(date: str, time: str, *, microseconds: bool = True) -> str:
     return datetime_str
 
 
+def strptime_micr(date_string: str, fmt: str) -> datetime:
+    r"""
+    Decorate strptime while supporting optional [.%f] in the format at the end
+
+    Parameters
+    ----------
+    date_string: str
+      Date string to parse
+    fmt: str
+      Format string. If it ends with [.%f], we keep it if date_string ends with
+      '.\d+' regex and not if it does not.
+    """
+
+    optional_micr = "[.%f]"
+    if fmt.endswith(optional_micr):
+        fmt = fmt[: -len(optional_micr)]
+        if re.search(r"\.\d+$", date_string):
+            fmt += ".%f"
+    return datetime.strptime(date_string, fmt)
+
+
 def remove_suffix(s: str, suf: str) -> str:
     """
     Remove suffix from the end of the string


### PR DESCRIPTION
I  think overall it closes #657 and should address the issue reported on https://neurostars.org/t/heudiconv-time-format-error/25806 