### PR TITLE
Check if acq_time has ms and add .0 if not

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -487,6 +487,9 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     """
     acq_date = dcm_data.get("AcquisitionDate")
     acq_time = dcm_data.get("AcquisitionTime")
+    if not '.' in acq_time:
+        acq_time = acq_time + '.0'
+
     if not (acq_date is None or acq_time is None):
         return strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")
 


### PR DESCRIPTION
* In python 3.11.2, `strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")` does not make ms optional
* A simple solution to make the code work regardless of whether ms are recorded or not is:
```
if not '.' in acq_time:
    acq_time = acq_time + '.0'
```