### PR TITLE
Fix inconsistent behavior of existing session when using -d compared to --files option: raise an AssertionError instead of just a warning

### DIFF
--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -278,15 +278,10 @@ def get_study_sessions(
             )
             lgr.info("Study session for %r", study_session_info)
 
-            if study_session_info in study_sessions:
-                if grouping != "all":
-                    # MG - should this blow up to mimic -d invocation?
-                    lgr.warning(
-                        "Existing study session with the same values (%r)."
-                        " Skipping DICOMS %s",
-                        study_session_info,
-                        seqinfo.values(),
-                    )
-                    continue
+            if grouping != "all":
+                assert (
+                        study_session_info not in study_sessions
+                    ), f"Existing study session {study_session_info} already in analyzed sessions {study_sessions.keys()}"
+                
             study_sessions[study_session_info] = seqinfo
     return study_sessions

--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -279,9 +279,8 @@ def get_study_sessions(
             lgr.info("Study session for %r", study_session_info)
 
             if grouping != "all":
-                assert (
-                        study_session_info not in study_sessions
-                    ), f"Existing study session {study_session_info} already in analyzed sessions {study_sessions.keys()}"
-                
+                assert (study_session_info not in study_sessions), (
+                    f"Existing study session {study_session_info} "
+                    f"already in analyzed sessions {study_sessions.keys()}")
             study_sessions[study_session_info] = seqinfo
     return study_sessions


### PR DESCRIPTION
This is described in #683 