### PR TITLE
test-compare-two-versions.sh: also ignore differences in HeudiconvVersion field in jsons since we have it there now

### DIFF
--- a/utils/test-compare-two-versions.sh
+++ b/utils/test-compare-two-versions.sh
@@ -54,7 +54,7 @@ function show_diff() {
 	#git remote add rolando "$outdir/rolando"
 	#git fetch rolando
 	# git diff --stat rolando/master..
-	if diff  -Naur --exclude=.git --ignore-matching-lines='^\s*id\s*=.*' "$v1" "$v2" >| "$diff_full"; then
+	if diff  -Naur --exclude=.git  --ignore-matching-lines='^\s*\(id\s*=.*\|"HeudiconvVersion": \)' "$v1" "$v2" >| "$diff_full"; then
 		echo "Results are identical"
 	else
 		echo "Results differ: $diff_full"


### PR DESCRIPTION
FWIW, attn @neurorepro - might be of interest. I used it e.g. now to compare effects of #684 . Might come handy in your "hacking heudiconv" days.