### PR TITLE
Boost claimed BIDS version to 1.8.0 from 1.4.1

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -68,7 +68,7 @@ class BIDSError(Exception):
     pass
 
 
-BIDS_VERSION = "1.4.1"
+BIDS_VERSION = "1.8.0"
 
 # List defining allowed parameter matching for fmap assignment:
 SHIM_KEY = "ShimSetting"


### PR DESCRIPTION
AFAIK there were no relevant to us breakages. So just boosting the version to seemingly be up to date with BIDS.

Closes #698