### PR TITLE
datalad sensitive marking fixes

### DIFF
--- a/heudiconv/external/dlad.py
+++ b/heudiconv/external/dlad.py
@@ -152,7 +152,7 @@ def add_to_datalad(
         # not in effect! ?
         # annex_add_opts=['--include-dotfiles']
     )
-    annexed_files = [sr["path"] for sr in save_res if sr["key"]]
+    annexed_files = [sr["path"] for sr in save_res if sr.get("key", None)]
 
     # Provide metadata for sensitive information
     sensitive_patterns = [

--- a/heudiconv/external/dlad.py
+++ b/heudiconv/external/dlad.py
@@ -182,7 +182,7 @@ def add_to_datalad(
     """
 
 
-def mark_sensitive(ds: Dataset, path_glob: str, files: list[str] = None) -> None:
+def mark_sensitive(ds: Dataset, path_glob: str, files: list[str] | None = None) -> None:
     """
 
     Parameters

--- a/heudiconv/external/tests/test_dlad.py
+++ b/heudiconv/external/tests/test_dlad.py
@@ -30,7 +30,7 @@ def test_mark_sensitive(tmp_path: Path) -> None:
     assert all_meta == {"f1": target_rec, "f2": target_rec, "g2": target_rec}
 
 
-def test_mark_sensitive_last_commit(tmp_path: Path) -> None:
+def test_mark_sensitive_subset(tmp_path: Path) -> None:
     ds = dl.Dataset(tmp_path).create(force=True)
     create_tree(
         str(tmp_path),
@@ -42,9 +42,10 @@ def test_mark_sensitive_last_commit(tmp_path: Path) -> None:
         },
     )
     ds.save(".")
-    mark_sensitive(ds, "f*", "HEAD")
+    mark_sensitive(ds, "f*", [str(tmp_path / "f1")])
     all_meta = dict(ds.repo.get_metadata("."))
     target_rec = {"distribution-restrictions": ["sensitive"]}
     # g2 since the same content
     assert not all_meta.pop("g1", None)  # nothing or empty record
-    assert all_meta == {"f1": target_rec, "f2": target_rec, "g2": target_rec}
+    assert not all_meta.pop("f2", None)  # nothing or empty record
+    assert all_meta == {"f1": target_rec, "g2": target_rec}

--- a/heudiconv/external/tests/test_dlad.py
+++ b/heudiconv/external/tests/test_dlad.py
@@ -28,3 +28,23 @@ def test_mark_sensitive(tmp_path: Path) -> None:
     # g2 since the same content
     assert not all_meta.pop("g1", None)  # nothing or empty record
     assert all_meta == {"f1": target_rec, "f2": target_rec, "g2": target_rec}
+
+
+def test_mark_sensitive_last_commit(tmp_path: Path) -> None:
+    ds = dl.Dataset(tmp_path).create(force=True)
+    create_tree(
+        str(tmp_path),
+        {
+            "f1": "d1",
+            "f2": "d2",
+            "g1": "d3",
+            "g2": "d1",
+        },
+    )
+    ds.save(".")
+    mark_sensitive(ds, "f*", "HEAD")
+    all_meta = dict(ds.repo.get_metadata("."))
+    target_rec = {"distribution-restrictions": ["sensitive"]}
+    # g2 since the same content
+    assert not all_meta.pop("g1", None)  # nothing or empty record
+    assert all_meta == {"f1": target_rec, "f2": target_rec, "g2": target_rec}


### PR DESCRIPTION
# Mark sensitive files added in the commit not all globbed.

Currently all globbed files in the current tree get marked as sensitive which could overwrite previously removed metas (eg after defacing), it now filter file in the commit where converted files are added.

# Add metadata rather than init to fix reruns issue.

If one runs heudiconv on a branch, remove the metadata (eg after defacing) then remove that branch and then rerun the same conversion on the same dataset, it seems like the new files with same names inherit the absence of metadata from the previous files (from git-annex branch). This is unexpected as the git-annex hash should differ so `.met` file should not be picked-up, but there is some git-annex black magic going on here. The issue is that sensitive files do not get marked as non-sensitive. 