### PR TITLE
fix code failure when dicom time fields are empty

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -526,18 +526,18 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     3. SeriesDate & SeriesTime  (0008,0021); (0008,0031)
 
     """
-    acq_date = dcm_data.get("AcquisitionDate")
-    acq_time = dcm_data.get("AcquisitionTime")
-    if not (acq_date is None or acq_time is None):
+    acq_date = dcm_data.get("AcquisitionDate", "").strip()
+    acq_time = dcm_data.get("AcquisitionTime", "").strip()
+    if len(acq_date) > 0 and len(acq_time) > 0:
         return strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")
 
-    acq_dt = dcm_data.get("AcquisitionDateTime")
-    if acq_dt is not None:
+    acq_dt = dcm_data.get("AcquisitionDateTime", "").strip()
+    if len(acq_dt) > 0:
         return strptime_micr(acq_dt, "%Y%m%d%H%M%S[.%f]")
 
-    series_date = dcm_data.get("SeriesDate")
-    series_time = dcm_data.get("SeriesTime")
-    if not (series_date is None or series_time is None):
+    series_date = dcm_data.get("SeriesDate", "").strip()
+    series_time = dcm_data.get("SeriesTime", "").strip()
+    if len(series_date) > 0 and len(series_time) > 0:
         return strptime_micr(series_date + series_time, "%Y%m%d%H%M%S[.%f]")
     return None
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -532,7 +532,7 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
         return strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")
 
     acq_dt = dcm_data.get("AcquisitionDateTime", "").strip()
-    if len(acq_dt) > 0:
+    if acq_dt:
         return strptime_micr(acq_dt, "%Y%m%d%H%M%S[.%f]")
 
     series_date = dcm_data.get("SeriesDate", "").strip()

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -537,7 +537,7 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
 
     series_date = dcm_data.get("SeriesDate", "").strip()
     series_time = dcm_data.get("SeriesTime", "").strip()
-    if len(series_date) > 0 and len(series_time) > 0:
+    if series_date and series_time:
         return strptime_micr(series_date + series_time, "%Y%m%d%H%M%S[.%f]")
     return None
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -528,7 +528,7 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     """
     acq_date = dcm_data.get("AcquisitionDate", "").strip()
     acq_time = dcm_data.get("AcquisitionTime", "").strip()
-    if len(acq_date) > 0 and len(acq_time) > 0:
+    if acq_date and acq_time:
         return strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")
 
     acq_dt = dcm_data.get("AcquisitionDateTime", "").strip()


### PR DESCRIPTION
Hello,

This pull request is meant to fix an error we are encountering when processing data with empty date/time fields due to anonymization. Please note the fields are not missing but contain an empty string.

I have adapted the code of `get_datetime_from_dcm` to handle this scenario the same way as if the date/time was missing.

Please let me know if you need more details or changes to this pull request.

Thank you :).