### PR TITLE
Handle cases where dates/times in DICOM are empty strings, not Nones (e.g. after some anonymization)

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -526,18 +526,18 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     3. SeriesDate & SeriesTime  (0008,0021); (0008,0031)
 
     """
-    acq_date = dcm_data.get("AcquisitionDate")
-    acq_time = dcm_data.get("AcquisitionTime")
-    if not (acq_date is None or acq_time is None):
+    acq_date = dcm_data.get("AcquisitionDate", "").strip()
+    acq_time = dcm_data.get("AcquisitionTime", "").strip()
+    if len(acq_date) > 0 and len(acq_time) > 0:
         return strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")
 
-    acq_dt = dcm_data.get("AcquisitionDateTime")
-    if acq_dt is not None:
+    acq_dt = dcm_data.get("AcquisitionDateTime", "").strip()
+    if len(acq_dt) > 0:
         return strptime_micr(acq_dt, "%Y%m%d%H%M%S[.%f]")
 
-    series_date = dcm_data.get("SeriesDate")
-    series_time = dcm_data.get("SeriesTime")
-    if not (series_date is None or series_time is None):
+    series_date = dcm_data.get("SeriesDate", "").strip()
+    series_time = dcm_data.get("SeriesTime", "").strip()
+    if len(series_date) > 0 and len(series_time) > 0:
         return strptime_micr(series_date + series_time, "%Y%m%d%H%M%S[.%f]")
     return None
 

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -528,16 +528,16 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     """
     acq_date = dcm_data.get("AcquisitionDate", "").strip()
     acq_time = dcm_data.get("AcquisitionTime", "").strip()
-    if len(acq_date) > 0 and len(acq_time) > 0:
+    if acq_date and acq_time:
         return strptime_micr(acq_date + acq_time, "%Y%m%d%H%M%S[.%f]")
 
     acq_dt = dcm_data.get("AcquisitionDateTime", "").strip()
-    if len(acq_dt) > 0:
+    if acq_dt:
         return strptime_micr(acq_dt, "%Y%m%d%H%M%S[.%f]")
 
     series_date = dcm_data.get("SeriesDate", "").strip()
     series_time = dcm_data.get("SeriesTime", "").strip()
-    if len(series_date) > 0 and len(series_time) > 0:
+    if series_date and series_time:
         return strptime_micr(series_date + series_time, "%Y%m%d%H%M%S[.%f]")
     return None
 


### PR DESCRIPTION
https://github.com/nipy/heudiconv/pull/755 but with my commit added -- I was not allowed to tune that PR.

Closes #755 

attn @jennan