### PR TITLE
Specify license in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -147,3 +147,4 @@ keywords:
 message: If you use this software, please cite it using these metadata.
 title: >-
   HeuDiConv: flexible DICOM conversion into structured directory layouts
+license: Apache-2.0


### PR DESCRIPTION
Is important for JOSS paper requirements and hopefully would set license on zenodo instead of (default?) CC 4.0