### PR TITLE
Revert "Add CITATION.cff validation to lint workflow"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade tox
-          python -m pip install --upgrade cffconvert pyyaml
 
       - name: Run linters
         run: tox -e lint
-
-      - name: Validate CITATION.cff
-        run: cffconvert --validate


### PR DESCRIPTION
This reverts commit dcff5666bd789f7b1eff1ec33a4952fdb87aa389.

As we no longer have CITATION.cff and this was causing linters to fail.

We also need to trigger yet another release since zenodo integration for some reason was off.