### PR TITLE
Remove grants from .zenodo.json for now

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -134,9 +134,6 @@
             "affiliation": "Departments of Psychiatry and Radiology, University of Massachusetts Chan Medical School, Worcester, MA, USA"
         }
     ],
-    "grants": [
-        { "id": "10.13039/100000002::2P41EB019936" }
-    ],
     "keywords": [
         "Python",
         "neuroscience",


### PR DESCRIPTION
Got

    {
        "errors": "Invalid value 01cwqze88::2P41EB019936."
    }

So it does not like something about that value. Later

