### PR TITLE
Replace deprecated "_phase" suffix in reproin heuristic with "part-phase" entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -556,7 +556,7 @@ target output directory during conversion.
   name later on), which avoids hitting file size limits of /tmp ([#481][]) and
   helped to avoid a regression in dcm2nixx 1.0.20201102
 - [#477][] replaced `rec-<magnitude|phase>` with `part-<mag|phase>` now
-  hat BIDSsupports the part entity
+  that BIDS supports the part entity
 - [#473][] made default for CogAtlasID to be a TODO URL
 - [#459][] made AcquisitionTime used for acq_time scans file field
 - [#451][] retained sub-second resolution in scans files

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -527,25 +527,6 @@ def infotodict(
             if datatype == "func":
                 if "_pace_" in series_spec:
                     datatype_suffix = "pace"  # or should it be part of seq-
-                elif (
-                    "P" in curr_seqinfo.image_type
-                    and not curr_seqinfo.series_description.endswith("_SBRef")
-                ):
-                    datatype_suffix = "bold"
-                    series_info["part"] = "phase"
-                elif "M" in curr_seqinfo.image_type:
-                    datatype_suffix = "bold"
-
-                    # if next one is phase fMRI, we should set part to mag
-                    if (
-                        (
-                            next_seqinfo.series_description
-                            == curr_seqinfo.series_description
-                        )
-                        and (next_dcm_image_iod_spec == "P")
-                        and not curr_seqinfo.series_description.endswith("_SBRef")
-                    ):
-                        series_info["part"] = "mag"
                 else:
                     # assume bold by default
                     datatype_suffix = "bold"
@@ -564,6 +545,20 @@ def infotodict(
             elif datatype == "dwi":
                 # label for dwi as well
                 datatype_suffix = "dwi"
+
+            # Add "part" entity as needed
+            if datatype != "fmap" and not curr_seqinfo.series_description.endswith(
+                "_SBRef"
+            ):
+                if "P" in curr_seqinfo.image_type:
+                    series_info["part"] = "phase"
+                elif "M" in curr_seqinfo.image_type:
+                    # if next one is phase from same scan, we should set part to mag
+                    if (
+                        next_seqinfo.series_description
+                        == curr_seqinfo.series_description
+                    ) and (next_dcm_image_iod_spec == "P"):
+                        series_info["part"] = "mag"
 
         #
         # Even if datatype_suffix was provided, for some data we might need to override,

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -416,7 +416,6 @@ def infotodict(
             continue
 
         if i_acq == 0:
-            prev_seqinfo = None
             prev_dcm_image_iod_spec = None
         else:
             prev_seqinfo = seqinfo[i_acq - 1]
@@ -428,7 +427,7 @@ def infotodict(
             prev_dcm_image_iod_spec = prev_seqinfo.image_type[2]
 
         if i_acq == (len(seqinfo) - 1):
-            next_seqinfo = None
+            next_series_description = None
             next_dcm_image_iod_spec = None
         else:
             next_seqinfo = seqinfo[i_acq + 1]
@@ -437,6 +436,7 @@ def infotodict(
                     **{f: getattr(next_seqinfo, f).format(**next_seqinfo._asdict())}
                 )
 
+            next_series_description = next_seqinfo.series_description
             next_dcm_image_iod_spec = next_seqinfo.image_type[2]
 
         # possibly apply present formatting in the series_description or protocol name
@@ -555,8 +555,7 @@ def infotodict(
                 elif "M" in curr_seqinfo.image_type:
                     # if next one is phase from same scan, we should set part to mag
                     if (
-                        next_seqinfo.series_description
-                        == curr_seqinfo.series_description
+                        next_series_description == curr_seqinfo.series_description
                     ) and (next_dcm_image_iod_spec == "P"):
                         series_info["part"] = "mag"
 

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -61,7 +61,6 @@ where
             (e.g. _task-memory_run-01, _task-oddball_run-02)
      fmap - field maps
      dwi  - diffusion weighted imaging (also can as well have runs)
-     perf - perfusion imaging
 
    The other BIDS modalities are not known ATM and their data will not be
    converted and will be just skipped (with a warning). Full list of datatypes
@@ -218,7 +217,7 @@ POPULATE_INTENDED_FOR_OPTS = {
 }
 
 
-KNOWN_DATATYPES = {"anat", "func", "dwi", "behav", "fmap", "perf"}
+KNOWN_DATATYPES = {"anat", "func", "dwi", "behav", "fmap"}
 
 
 def _delete_chars(from_str: str, deletechars: str) -> str:


### PR DESCRIPTION
Closes #769. This is working on DICOMs associated with https://openneuro.org/datasets/ds005250.

Changes proposed:

- Track previous and next sequence info in ReproIn's `infotodict`.
- ~~Rename `s` variable to `curr_seqinfo` for improved clarity.~~ Moved to #779.
- For non-SBRef, non-fieldmap scans, set "part" entity to "phase" for phase data instead of setting the suffix to "phase".
- For magnitude non-SBRef, non-fieldmap scans, check if the _next_ sequence has the same `series_description` and is a phase scan. If it is, set "part" to "mag".