### PR TITLE
Run tests weekly to ensure we are still good

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   pull_request:
   push:
+  schedule:
+    # run weekly to ensure that we are still good
+    - cron: '1 2 * * 3'
 
 jobs:
   test:


### PR DESCRIPTION
also to check what the current state is since in fresh runs for
- https://github.com/nipy/heudiconv/pull/753
by @bpinsard we start getting

```
_____________________ test_embed_dicom_and_nifti_metadata ______________________
/home/runner/work/heudiconv/heudiconv/heudiconv/tests/test_dicoms.py:57: in test_embed_dicom_and_nifti_metadata
    embed_dicom_and_nifti_metadata(dcmfiles, out_prefix + ".nii.gz", infofile, None)
/home/runner/work/heudiconv/heudiconv/heudiconv/dicoms.py:659: in embed_dicom_and_nifti_metadata
    stack = ds.parse_and_stack(dcmfiles, force=True).values()
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/dcmstack/dcmstack.py:1156: in parse_and_stack
    results = parse_and_group(src_paths,
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/dcmstack/dcmstack.py:1046: in parse_and_group
    dcm = pydicom.read_file(dcm_path, force=force)
E   AttributeError: module 'pydicom' has no attribute 'read_file'
```

that is with 

```
Downloading pydicom-3.0.0-py3-none-any.whl.metadata (9.4 kB)
```

and pydicom released 5 days ago :-/  https://github.com/pydicom/pydicom/releases/tag/v3.0.0 says

- read_file() and write_file() have been removed, use [dcmread()](https://pydicom.github.io/pydicom/stable/reference/generated/pydicom.filereader.dcmread.html) and [dcmwrite()](https://pydicom.github.io/pydicom/stable/reference/generated/pydicom.filewriter.dcmwrite.html) instead.

heh, so we should also fix codebase (in a separate PR)