### PR TITLE
Just INFO not WARNING if heuristic is missing intotoids

### DIFF
--- a/heudiconv/parser.py
+++ b/heudiconv/parser.py
@@ -247,7 +247,7 @@ def get_study_sessions(
                     "`infotoids` to heuristic file or "
                     "provide `--subjects` option"
                 )
-            lgr.warning(
+            lgr.info(
                 "Heuristic is missing an `infotoids` method, assigning "
                 "empty method and using provided subject id %s. "
                 "Provide `session` and `locator` fields for best results.",


### PR DESCRIPTION
It is only reproin which provides such handling and in general there should really be no harm -- we already raise exception if subject id is not provided/degenerate, so shold be safe to just inform instead of WARN the user.

Closes #783