### PR TITLE
Fix assignment of sensitive git-annex metadata data via glob patterns (regression introduced by #739)

### DIFF
--- a/heudiconv/external/dlad.py
+++ b/heudiconv/external/dlad.py
@@ -156,12 +156,12 @@ def add_to_datalad(
 
     # Provide metadata for sensitive information
     sensitive_patterns = [
-        "sourcedata",
+        "sourcedata/**",
         "*_scans.tsv",  # top level
         "*/*_scans.tsv",  # within subj
         "*/*/*_scans.tsv",  # within sess/subj
-        "*/anat",  # within subj
-        "*/*/anat",  # within ses/subj
+        "*/anat/*",  # within subj
+        "*/*/anat/*",  # within ses/subj
     ]
     for sp in sensitive_patterns:
         mark_sensitive(ds, sp, annexed_files)

--- a/heudiconv/tests/test_regression.py
+++ b/heudiconv/tests/test_regression.py
@@ -55,6 +55,7 @@ def test_conversion(
         heuristic,
         anon_cmd,
         template="sourcedata/sub-{subject}/*/*/*.tgz",
+        xargs=["--datalad"],
     )
     runner(args)  # run conversion
 
@@ -95,6 +96,18 @@ def test_conversion(
     keys = ["EchoTime", "MagneticFieldStrength", "Manufacturer", "SliceTiming"]
     for key in keys:
         assert orig[key] == conv[key]
+
+    # validate sensitive marking
+    from datalad.api import Dataset
+
+    ds = Dataset(outdir)
+    all_meta = dict(ds.repo.get_metadata("."))
+    target_rec = {"distribution-restrictions": ["sensitive"]}
+    for pth, meta in all_meta.items():
+        if "anat" in pth or "scans.tsv" in pth:
+            assert meta == target_rec
+        else:
+            assert meta == {}
 
 
 @pytest.mark.skipif(not have_datalad, reason="no datalad")


### PR DESCRIPTION
I introduced a regression in #739, and it was not flagged by the tests.

This PR fixes the glob pattern to properly flag the files as sensitive. 
This is critical as if any data management pipeline rely on heudiconv setting this metadata, then sensitive data might not be handled appropriately/exposed.
I added that feature to the regression test, as this already require datalad to download data.
@yarikoptic let me know if you prefer this test to be it in a separate function.

