### PR TITLE
Require nibabel >= 5.3.1 (fixes issues with enhanced DICOMs), and drop Python 3.8 support 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.auto-version.outputs.version != ''
         uses: actions/setup-python@v5
         with:
-          python-version: '^3.8'
+          python-version: '^3.9'
 
       - name: Install Python dependencies
         if: steps.auto-version.outputs.version != ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -11,7 +11,6 @@ CLASSIFIERS = [
     "Environment :: Console",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -19,7 +18,7 @@ CLASSIFIERS = [
     "Typing :: Typed",
 ]
 
-PYTHON_REQUIRES = ">=3.8"
+PYTHON_REQUIRES = ">=3.9"
 
 REQUIRES = [
     # not usable in some use cases since might be just a downloader, not binary

--- a/heudiconv/info.py
+++ b/heudiconv/info.py
@@ -27,7 +27,7 @@ REQUIRES = [
     "dcmstack>=0.8",
     "etelemetry",
     "filelock>=3.0.12",
-    "nibabel",
+    "nibabel>=5.3.1",
     "nipype >=1.2.3",
     "pydicom >= 1.0.0",
 ]


### PR DESCRIPTION
to avoid a bunch of enhanced dicoms issues, notably through dcmstack. 
eg. 
```
dcmstack.dcmmeta.InvalidExtensionError: The extension is not valid: Missing required base classification time
``` 
should be fixed.