### PR TITLE
[WIP] Handle dcm2niix not compressing nifti files

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -491,7 +491,7 @@ def save_scans_key(
     for bids_file in bids_files:
         # get filenames
         f_name = "/".join(bids_file.split("/")[-2:])
-        f_name = f_name.replace("json", "nii.gz")
+        f_name = f_name.replace("json", outtype_from_bidsfile(bids_file))
         rows[f_name] = get_formatted_scans_key_row(item[-1][0])
         subj_, ses_ = find_subj_ses(f_name)
         if not subj_:
@@ -938,9 +938,9 @@ def select_fmap_from_compatible_groups(
     # acq_times for the compatible fmaps:
     acq_times_fmaps = {
         k: acq_times[
-            # remove session folder and '.json', add '.nii.gz':
+            # remove session folder and '.json', add outtype:
             remove_suffix(remove_prefix(v[0], sess_folder + op.sep), ".json")
-            + ".nii.gz"
+            + '.' + outtype_from_bidsfile(v[0])
         ]
         for k, v in compatible_fmap_groups.items()
     }
@@ -956,7 +956,7 @@ def select_fmap_from_compatible_groups(
             acq_times[
                 # remove session folder and '.json', add '.nii.gz':
                 remove_suffix(remove_prefix(json_file, sess_folder + op.sep), ".json")
-                + ".nii.gz"
+                + '.' + outtype_from_bidsfile(json_file)
             ]
         )
         # differences in acquisition time (abs value):
@@ -1209,3 +1209,22 @@ def sanitize_label(label: str) -> str:
             clean_label,
         )
     return clean_label
+
+
+def outtype_from_bidsfile(json_file: str) -> str:
+    """Returns outtype ('nii' or 'nii.gz') for an existing json bids file
+
+    Parameters
+    ----------
+    filename: string
+
+    Returns
+    -------
+    fileext: string
+        file extension / outtype
+    """
+    json_path = Path(json_file)
+    for suffix in ['nii.gz', 'nii']:
+        if op.exists(json_path.with_suffix('.' + suffix)):
+            return suffix
+    raise RuntimeError('No accompanying file found for %s' % json_file)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -10,6 +10,7 @@ import random
 import re
 import shutil
 import sys
+import json
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, List, Optional, cast
 
@@ -620,15 +621,39 @@ def convert(
                     description="DICOM to NIfTI + .json sidecar conversion utility",
                     tags=["implementation"],
                 )
-                outname, scaninfo = (prefix + "." + outtype, prefix + scaninfo_suffix)
+                outnames = [prefix + "." + t for t in ["nii", "nii.gz"]]
+                scaninfo = prefix + scaninfo_suffix
 
-                if not op.exists(outname) or overwrite:
+                if not any([op.exists(outname) for outname in outnames]) or overwrite:
                     tmpdir = tempdirs("dcm2niix")
+
+                    # demote outtype if dcmconfig explicitly disables compression
+                    # and issue a warning (user supplied mixed signals here)
+                    if dcmconfig is not None:
+                        with open(dcmconfig) as f:
+                            dcmconfig_dict = json.loads(f.read())
+                        if dcmconfig_dict.get('compress', 'y') == 'n':
+                            outtype = 'nii'
+                            lgr.warning("Demoting outtype to uncompressed nifti, because "
+                                        "compress is set to 'n' in supplied dcmconfig")
 
                     # run conversion through nipype
                     res, prov_file = nipype_convert(
                         item_dicoms, prefix, with_prov, bids_options, tmpdir, dcmconfig
                     )
+
+                    # try to handle compression failures from dcm2niix
+                    if outtype == 'nii.gz':
+                        converted_files = res.outputs.converted_files
+                        if isinstance(converted_files, list):
+                            # we do not handle mixed compression results from dcm2niix, yet
+                            # fail, if any of the outputs weren't compressed properly
+                            assert all([x.endswith('nii.gz') for x in converted_files])
+                        else:
+                            if converted_files.endswith('nii'):
+                                lgr.warning("Conversion returned uncompressed nifti (>4GB?) - "
+                                            "demoting outtype to 'nii'")
+                                outtype = 'nii'
 
                     bids_outfiles = save_converted_files(
                         res,
@@ -653,8 +678,8 @@ def convert(
                     tempdirs.rmtree(tmpdir)
                 else:
                     raise RuntimeError(
-                        "was asked to convert into %s but destination already exists"
-                        % (outname)
+                        "was asked to convert into %s.nii[.gz] but destination already exists"
+                        % (prefix)
                     )
 
         # add the taskname field to the json file(s):


### PR DESCRIPTION
So, we were hit by https://github.com/rordenlab/dcm2niix/issues/124, when converting a *very* long epi scan.

It seems that:

+ dcm2niix still refuses to compress (pigz or not) niftis > 4GB
+ heudiconv does not realize the file is now `.nii` instead of `.nii.gz` and produces invalid file extensions after moving
+ we can make dcm2niix happy by supplying `dcmconfig.json` with `"compress": "n"`, but heudiconv is oblivious about that change


I added some code that tries to catch these corner cases in `convert.py`

+ it warns the user if the conversion failed to compress and changes outtype to `nii`
+ also changes the outtype to `nii` if the user supplied `dcmconfig` as stated above
+ removed some hard coded `nii.gz` file extension snippets in `bids.py` and infer the effective extension by checking if a bids_file (json) has an accompanying `nii` or `nii.gz` file

I think this should also fix #365 and #576.

Tests were only run manually with a `dcmconfig` file and without, and with source data of mixed file length (>4GB and <4GB). Conversion works fine, validator is happy and `scans.tsv` now contain `.nii` and `.nii.gz` respectively.

But I am very nervous about this, because I assume other side effects by just switch `outtype` from `nii.gz` to `nii` mid conversion.