### PR TITLE
[ENH] filter dicoms earlier to avoid nibabel crash with XA ill-formed mutli-planar localizer dicoms

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -169,6 +169,9 @@ def validate_dicom(
     Parse DICOM attributes. Returns None if not valid.
     """
     mw = dw.wrapper_from_file(fl, force=True, stop_before_pixels=True)
+    if dcmfilter is not None and dcmfilter(mw.dcm_data):
+        lgr.warning("Ignoring %s because of DICOM filter", fl)
+        return None
     # clean series signature
     for sig in ("iop", "ICE_Dims", "SequenceName"):
         try:
@@ -188,9 +191,6 @@ def validate_dicom(
         series_id = (int(mw.dcm_data.SeriesNumber), protocol_name)
     except AttributeError as e:
         lgr.warning('Ignoring %s since not quite a "normal" DICOM: %s', fl, e)
-        return None
-    if dcmfilter is not None and dcmfilter(mw.dcm_data):
-        lgr.warning("Ignoring %s because of DICOM filter", fl)
         return None
     if mw.dcm_data[0x0008, 0x0016].repval in (
         "Raw Data Storage",

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -183,6 +183,9 @@ def validate_dicom(
     except AttributeError as e:
         lgr.warning('Ignoring %s since not quite a "normal" DICOM: %s', fl, e)
         return None
+    if dcmfilter is not None and dcmfilter(mw.dcm_data):
+        lgr.warning("Ignoring %s because of DICOM filter", fl)
+        return None
     if mw.dcm_data[0x0008, 0x0016].repval in (
         "Raw Data Storage",
         "GrayscaleSoftcopyPresentationStateStorage",
@@ -194,9 +197,6 @@ def validate_dicom(
     except AttributeError:
         lgr.info("File {} is missing any StudyInstanceUID".format(fl))
         file_studyUID = None
-    if dcmfilter is not None and dcmfilter(mw.dcm_data):
-        lgr.warning("Ignoring %s because of DICOM filter", fl)
-        return None
     # clean series signature
     for sig in ("iop", "ICE_Dims", "SequenceName"):
         try:

--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -169,15 +169,6 @@ def validate_dicom(
     Parse DICOM attributes. Returns None if not valid.
     """
     mw = dw.wrapper_from_file(fl, force=True, stop_before_pixels=True)
-    if dcmfilter is not None and dcmfilter(mw.dcm_data):
-        lgr.warning("Ignoring %s because of DICOM filter", fl)
-        return None
-    # clean series signature
-    for sig in ("iop", "ICE_Dims", "SequenceName"):
-        try:
-            del mw.series_signature[sig]
-        except KeyError:
-            pass
     # Workaround for protocol name in private siemens csa header
     if not getattr(mw.dcm_data, "ProtocolName", "").strip():
         mw.dcm_data.ProtocolName = (
@@ -203,6 +194,15 @@ def validate_dicom(
     except AttributeError:
         lgr.info("File {} is missing any StudyInstanceUID".format(fl))
         file_studyUID = None
+    if dcmfilter is not None and dcmfilter(mw.dcm_data):
+        lgr.warning("Ignoring %s because of DICOM filter", fl)
+        return None
+    # clean series signature
+    for sig in ("iop", "ICE_Dims", "SequenceName"):
+        try:
+            del mw.series_signature[sig]
+        except KeyError:
+            pass
     return mw, series_id, file_studyUID
 
 

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -226,7 +226,7 @@ def _delete_chars(from_str: str, deletechars: str) -> str:
 
 def filter_dicom(dcmdata: dcm.dataset.Dataset) -> bool:
     """Return True if a DICOM dataset should be filtered out, else False"""
-    return True if dcmdata.get("StudyInstanceUID") in dicoms2skip else False
+    return True if dcmdata.StudyInstanceUID in dicoms2skip else False
 
 
 def filter_files(_fn: str) -> bool:

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -226,7 +226,7 @@ def _delete_chars(from_str: str, deletechars: str) -> str:
 
 def filter_dicom(dcmdata: dcm.dataset.Dataset) -> bool:
     """Return True if a DICOM dataset should be filtered out, else False"""
-    return True if dcmdata.StudyInstanceUID in dicoms2skip else False
+    return True if dcmdata.get("StudyInstanceUID") in dicoms2skip else False
 
 
 def filter_files(_fn: str) -> bool:
@@ -406,7 +406,11 @@ def infotodict(
         # XXX: skip derived sequences, we don't store them to avoid polluting
         # the directory, unless it is the motion corrected ones
         # (will get _rec-moco suffix)
-        if skip_derived and curr_seqinfo.is_derived and not curr_seqinfo.is_motion_corrected:
+        if (
+            skip_derived
+            and curr_seqinfo.is_derived
+            and not curr_seqinfo.is_motion_corrected
+        ):
             skipped.append(curr_seqinfo.series_id)
             lgr.debug("Ignoring derived data %s", curr_seqinfo.series_id)
             continue
@@ -552,7 +556,10 @@ def infotodict(
                         # XXX if we have a known earlier study, we need to always
                         # increase the run counter for phasediff because magnitudes
                         # were not acquired
-                        if get_study_hash([curr_seqinfo]) == "9d148e2a05f782273f6343507733309d":
+                        if (
+                            get_study_hash([curr_seqinfo])
+                            == "9d148e2a05f782273f6343507733309d"
+                        ):
                             current_run += 1
                         else:
                             raise RuntimeError(


### PR DESCRIPTION
see https://github.com/nipy/nibabel/issues/1392#issuecomment-2508066687

Apparently some of the validation of the dicom triggers nibabel.nicom that crashes on ill-formed dicoms.
Moving the dicom filter a bit before, allow to easily filter these with the heuristics `filter_dicom`. 
I should not change anything to the results. 