### PR TITLE
remove bval bvecs files generated for SBRef on XA60/CMRR/dcm2niix

### DIFF
--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -896,7 +896,7 @@ def save_converted_files(
         bvals, bvecs = res.outputs.bvals, res.outputs.bvecs
         bvals = list(bvals) if isinstance(bvals, TraitListObject) else bvals
         bvecs = list(bvecs) if isinstance(bvecs, TraitListObject) else bvecs
-        if prefix_dirname.endswith("dwi"):
+        if prefix.endswith("dwi"):
             outname_bvecs, outname_bvals = prefix + ".bvec", prefix + ".bval"
             safe_movefile(bvecs, outname_bvecs, overwrite)
             safe_movefile(bvals, outname_bvals, overwrite)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -61,9 +61,7 @@ if TYPE_CHECKING:
 
 
 LOCKFILE = "heudiconv.lock"
-DW_IMAGE_IN_FMAP_FOLDER_WARNING = (
-    "Diffusion-weighted image saved in non dwi folder ({folder})"
-)
+DW_IMAGE_WRONG_SUFFIX_WARNING = "Diffusion-weighted image saved as non dwi ({prefix})"
 lgr = logging.getLogger(__name__)
 
 
@@ -907,9 +905,7 @@ def save_converted_files(
                     os.remove(ftr)
                 lgr.debug("%s and %s were removed since not dwi", bvecs, bvals)
             else:
-                lgr.warning(
-                    DW_IMAGE_IN_FMAP_FOLDER_WARNING.format(folder=prefix_dirname)
-                )
+                lgr.warning(DW_IMAGE_WRONG_SUFFIX_WARNING.format(prefix=prefix))
                 lgr.warning(
                     ".bvec and .bval files will be generated. This is NOT BIDS compliant"
                 )

--- a/heudiconv/tests/test_convert.py
+++ b/heudiconv/tests/test_convert.py
@@ -13,7 +13,7 @@ from heudiconv.bids import BIDSError
 from heudiconv.cli.run import main as runner
 import heudiconv.convert
 from heudiconv.convert import (
-    DW_IMAGE_IN_FMAP_FOLDER_WARNING,
+    DW_IMAGE_WRONG_SUFFIX_WARNING,
     bvals_are_zero,
     update_complex_name,
     update_multiecho_name,
@@ -170,8 +170,8 @@ def test_b0dwi_for_fmap(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> Non
 
     # assert that it raised a warning that the fmap directory will contain
     # bvec and bval files.
-    expected_msg = DW_IMAGE_IN_FMAP_FOLDER_WARNING.format(
-        folder=op.join(tmp_path, f"sub-{subID}", "fmap")
+    expected_msg = DW_IMAGE_WRONG_SUFFIX_WARNING.format(
+        prefix=op.join(tmp_path, f"sub-{subID}", "fmap", f"sub-{subID}_acq-b0dwi_epi")
     )
     assert any(expected_msg in c.message for c in caplog.records)
 


### PR DESCRIPTION
Weirdly XA60 data that I got recently started to produce bvals/bvecs files for SBRef from dcm2niix.
I don't know where the changes originates, so better filter more aggressively here, as the only files allowed to have such sidefiles are `_dwi`  suffixed ones. 
