### PR TITLE
DOC: fix the description of filter_files

### DIFF
--- a/docs/heuristics.rst
+++ b/docs/heuristics.rst
@@ -83,7 +83,8 @@ But it is not used directly by HeuDiConv.
 A utility function used to filter any input files.
 
 If this function is included, every file found will go through this filter. Any
-files where this function returns ``True`` will be filtered out.
+files where this function returns ``False`` will be filtered out (files where
+this function returns ``True`` will be kept).
 
 --------------------------
 ``filter_dicom(dcm_data)``

--- a/docs/heuristics.rst
+++ b/docs/heuristics.rst
@@ -85,6 +85,8 @@ A utility function used to filter any input files.
 If this function is included, every file found will go through this filter. Any
 files where this function returns ``False`` will be filtered out (files where
 this function returns ``True`` will be kept).
+Note: this function's logic is opposite to ``filter_dicom`` (see
+below). Think of it as an input for Python's built-in ``filter()``.
 
 --------------------------
 ``filter_dicom(dcm_data)``


### PR DESCRIPTION
I might be confused, but the docs say "Any files where this function returns True will be filtered out." and I am convinced that it is the opposite.

The filter_files is used in the reproin heuristic (where it always returns True), with this docstring: "Return True if a file should be kept, else False". This commit adjusts the docs to effectively state the same (it used to say the opposite).

The docstring in the heudiconv heuristic was right: filter_files is fed to `dicoms.py::group_dicoms_into_seqinfos()` as `file_filter`, where it is applied with built-in `filter()` to the to-be-processed file list; `filter()` yields items for which `function(item) == True`.

N.B. This change makes it clear that `filter_files` and `filter_dicom` have opposite logic. The latter is fed to
`dicoms.py::group_dicoms_into_seqinfos()` as `dcmfilter`; `dcmfilter` is passed into `dicoms.py::validate_dicom()`; validate_dicom returns `None` (meaning: *not valid*) if `dcmfilter(mw.dcm_data)` is `True`.

So for a file to be kept, `filter_files` must return `True`, and `filter_dicom` must return `False`. This commit changes the documentation rather than the logic, assuming that the logic has been present long enough to warrant preservation (it is also easier to only change the docs).