### PR TITLE
Hardcode up to date list of entities for BIDS and boost specified BIDSVersion to 1.10.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -1088,6 +1088,10 @@ def save_converted_files(
             # If we have failed to modify this_prefix_basename, because it didn't fall
             #   into any of the options above, just add the suffix at the end:
             if this_prefix_basename == prefix_basename:
+                # TODO: never hit by tests! So what are the suffixes for?!
+                import pdb
+
+                pdb.set_trace()
                 this_prefix_basename += suffix
 
             # Finally, form the outname by stitching the directory and outtype:

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ exclude = .*/,build/,dist/,test/data,venv/
 hang-closing = False
 unused-arguments-ignore-stub-functions = True
 select = A,B,B902,C,E,E242,F,U100,W
-ignore = A003,B005,E203,E262,E266,E501,W503
+ignore = A003,A005,B005,E203,E262,E266,E501,W503
 
 [isort]
 atomic = True


### PR DESCRIPTION
and progress pre-commit to have more recent flake8 since otherwise forbids commit due to some false positive

TODOs
- [ ] get closure on how it operates and remove `pdb` invocation