### PR TITLE
Add opt-out for JSON date sanitization with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 dist/
 sample_nifti.json
 venvs/
+heudiconv/_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ build/
 dist/
 sample_nifti.json
 venvs/
-heudiconv/_version.py

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -313,25 +313,40 @@ def populate_aggregated_jsons(path: str) -> None:
         save_json(task_file, fields, sort_keys=True, pretty=True)
 
 
-def tuneup_bids_json_files(json_files: list[str]) -> None:
-    """Given a list of BIDS .json files, e.g."""
+def tuneup_bids_json_files(json_files: list[str], sanitize: bool = True) -> None:
+    """Given a list of BIDS .json files, tune them up (add HeuDiConv version, optionally remove dates).
+    
+    Parameters
+    ----------
+    json_files : list of str
+        List of paths to JSON files to tune up
+    sanitize : bool, optional
+        If True (default), remove sensitive date/time information from JSON files.
+        This includes AcquisitionDate, AcquisitionDateTime, StudyDate, StudyDateTime,
+        SeriesDate, and SeriesDateTime fields.
+    """
     if not json_files:
         return
     # Harmonize generic .json formatting
     for jsonfile in json_files:
         json_ = load_json(jsonfile)
         # sanitize!
-#        for f1 in ["Acquisition", "Study", "Series"]:
-#            for f2 in ["DateTime", "Date"]:
-#                json_.pop(f1 + f2, None)
+        if sanitize:
+            for f1 in ["Acquisition", "Study", "Series"]:
+                for f2 in ["DateTime", "Date"]:
+                    json_.pop(f1 + f2, None)
         # TODO:  should actually be placed into series file which must
         #        go under annex (not under git) and marked as sensitive
         # MG - Might want to replace with flag for data sensitivity
         # related - https://github.com/nipy/heudiconv/issues/92
-#        if "Date" in str(json_):
-            # Let's hope no word 'Date' comes within a study name or smth like
-            # that
-#            raise ValueError("There must be no dates in .json sidecar")
+            if "Date" in str(json_):
+                # Let's hope no word 'Date' comes within a study name or smth like
+                # that
+                lgr.warning(
+                    "File %s contains 'Date' in its content after sanitization. "
+                    "This might indicate sensitive information that should be removed.",
+                    jsonfile
+                )
         # Those files should not have our version field already - should have been
         # freshly produced
         assert HEUDICONV_VERSION_JSON_KEY not in json_

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -321,17 +321,17 @@ def tuneup_bids_json_files(json_files: list[str]) -> None:
     for jsonfile in json_files:
         json_ = load_json(jsonfile)
         # sanitize!
-        for f1 in ["Acquisition", "Study", "Series"]:
-            for f2 in ["DateTime", "Date"]:
-                json_.pop(f1 + f2, None)
+#        for f1 in ["Acquisition", "Study", "Series"]:
+#            for f2 in ["DateTime", "Date"]:
+#                json_.pop(f1 + f2, None)
         # TODO:  should actually be placed into series file which must
         #        go under annex (not under git) and marked as sensitive
         # MG - Might want to replace with flag for data sensitivity
         # related - https://github.com/nipy/heudiconv/issues/92
-        if "Date" in str(json_):
+#        if "Date" in str(json_):
             # Let's hope no word 'Date' comes within a study name or smth like
             # that
-            raise ValueError("There must be no dates in .json sidecar")
+#            raise ValueError("There must be no dates in .json sidecar")
         # Those files should not have our version field already - should have been
         # freshly produced
         assert HEUDICONV_VERSION_JSON_KEY not in json_

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -315,7 +315,7 @@ def populate_aggregated_jsons(path: str) -> None:
 
 def tuneup_bids_json_files(json_files: list[str], sanitize: bool = True) -> None:
     """Given a list of BIDS .json files, tune them up (add HeuDiConv version, optionally remove dates).
-    
+
     Parameters
     ----------
     json_files : list of str

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -313,15 +313,15 @@ def populate_aggregated_jsons(path: str) -> None:
         save_json(task_file, fields, sort_keys=True, pretty=True)
 
 
-def tuneup_bids_json_files(json_files: list[str], sanitize: bool = True) -> None:
+def tuneup_bids_json_files(json_files: list[str], sanitize: str = 'remove') -> None:
     """Given a list of BIDS .json files, tune them up (add HeuDiConv version, optionally remove dates).
 
     Parameters
     ----------
     json_files : list of str
         List of paths to JSON files to tune up
-    sanitize : bool, optional
-        If True (default), remove sensitive date/time information from JSON files.
+    sanitize : str, optional
+        If 'remove' (default), discard sensitive date/time information from JSON files.
         This includes AcquisitionDate, AcquisitionDateTime, StudyDate, StudyDateTime,
         SeriesDate, and SeriesDateTime fields.
     """
@@ -331,7 +331,7 @@ def tuneup_bids_json_files(json_files: list[str], sanitize: bool = True) -> None
     for jsonfile in json_files:
         json_ = load_json(jsonfile)
         # sanitize!
-        if sanitize:
+        if sanitize == 'remove':
             for f1 in ["Acquisition", "Study", "Series"]:
                 for f2 in ["DateTime", "Date"]:
                     json_.pop(f1 + f2, None)

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -188,6 +188,14 @@ def get_parser() -> ArgumentParser:
         help="Exclude dcmstack meta information in sidecar jsons.",
     )
     parser.add_argument(
+        "--no-sanitize-jsons",
+        action="store_true",
+        dest="no_sanitize_jsons",
+        help="Disable removal of sensitive date/time information from JSON sidecar files. "
+        "By default, AcquisitionDate, AcquisitionDateTime, StudyDate, StudyDateTime, "
+        "SeriesDate, and SeriesDateTime fields are removed from JSON files.",
+    )
+    parser.add_argument(
         "--random-seed", type=int, default=None, help="Random seed to initialize RNG."
     )
     parser.add_argument(

--- a/heudiconv/cli/run.py
+++ b/heudiconv/cli/run.py
@@ -168,7 +168,6 @@ def get_parser() -> ArgumentParser:
             "heuristic-info",
             "ls",
             "populate-templates",
-            "sanitize-jsons",
             "treat-jsons",
             "populate-intended-for",
         ),
@@ -188,10 +187,10 @@ def get_parser() -> ArgumentParser:
         help="Exclude dcmstack meta information in sidecar jsons.",
     )
     parser.add_argument(
-        "--no-sanitize-jsons",
-        action="store_true",
-        dest="no_sanitize_jsons",
-        help="Disable removal of sensitive date/time information from JSON sidecar files. "
+        "--sanitize-dates",
+        choices=("remove", "nothing", "shift"),
+        default="remove",
+        help="Removal of sensitive date/time information from JSON sidecar files. "
         "By default, AcquisitionDate, AcquisitionDateTime, StudyDate, StudyDateTime, "
         "SeriesDate, and SeriesDateTime fields are removed from JSON files.",
     )

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -130,6 +130,7 @@ def prep_conversion(
     overwrite: bool,
     dcmconfig: Optional[str],
     grouping: str,
+    no_sanitize_jsons: bool = False,
 ) -> None:
     if dicoms:
         lgr.info("Processing %d dicoms", len(dicoms))
@@ -643,7 +644,7 @@ def convert(
                     if bids_options is not None:
                         save_scans_key(item, bids_outfiles)
                     # Fix up and unify BIDS files
-                    tuneup_bids_json_files(bids_outfiles)
+                    tuneup_bids_json_files(bids_outfiles, sanitize=not no_sanitize_jsons)
 
                     if prov_file:
                         prov_files.append(prov_file)

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -269,6 +269,7 @@ def prep_conversion(
             min_meta=min_meta,
             overwrite=overwrite,
             dcmconfig=dcmconfig,
+            no_sanitize_jsons=no_sanitize_jsons,
         )
 
     for item_dicoms in filegroup.values():
@@ -536,6 +537,7 @@ def convert(
     prov_file: Optional[str] = None,
     dcmconfig: Optional[str] = None,
     populate_intended_for_opts: Optional[PopulateIntendedForOpts] = None,
+    no_sanitize_jsons: bool = False,
 ) -> None:
     """Perform actual conversion (calls to converter etc) given info from
     heuristic's `infotodict`

--- a/heudiconv/convert.py
+++ b/heudiconv/convert.py
@@ -130,7 +130,7 @@ def prep_conversion(
     overwrite: bool,
     dcmconfig: Optional[str],
     grouping: str,
-    no_sanitize_jsons: bool = False,
+    sanitize_dates: str,
 ) -> None:
     if dicoms:
         lgr.info("Processing %d dicoms", len(dicoms))
@@ -269,7 +269,7 @@ def prep_conversion(
             min_meta=min_meta,
             overwrite=overwrite,
             dcmconfig=dcmconfig,
-            no_sanitize_jsons=no_sanitize_jsons,
+            sanitize_dates=sanitize_dates,
         )
 
     for item_dicoms in filegroup.values():
@@ -537,7 +537,7 @@ def convert(
     prov_file: Optional[str] = None,
     dcmconfig: Optional[str] = None,
     populate_intended_for_opts: Optional[PopulateIntendedForOpts] = None,
-    no_sanitize_jsons: bool = False,
+    sanitize_dates: str = 'remove',
 ) -> None:
     """Perform actual conversion (calls to converter etc) given info from
     heuristic's `infotodict`
@@ -646,7 +646,7 @@ def convert(
                     if bids_options is not None:
                         save_scans_key(item, bids_outfiles)
                     # Fix up and unify BIDS files
-                    tuneup_bids_json_files(bids_outfiles, sanitize=not no_sanitize_jsons)
+                    tuneup_bids_json_files(bids_outfiles, sanitize=sanitize_dates)
 
                     if prov_file:
                         prov_files.append(prov_file)

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -128,7 +128,7 @@ def process_extra_commands(
     elif command == "sanitize-jsons":
         ensure_has_files()
         assert files is not None  # for mypy now
-        tuneup_bids_json_files(files)
+        tuneup_bids_json_files(files, sanitize=not no_sanitize_jsons)
     elif command == "heuristics":
         from .utils import get_known_heuristics_with_descriptions
 
@@ -235,6 +235,7 @@ def workflow(
     dcmconfig: Optional[str] = None,
     queue: Optional[str] = None,
     queue_args: Optional[str] = None,
+    no_sanitize_jsons: bool = False,
 ) -> None:
     """Run the HeuDiConv conversion workflow.
 
@@ -322,6 +323,10 @@ def workflow(
     queue_args : str or None, optional
         Additional queue arguments passed as single string of space-separated
         Argument=Value pairs. Default is None.
+    no_sanitize_jsons : bool, optional
+        Disable removal of sensitive date/time information from JSON sidecar files.
+        By default, AcquisitionDate, AcquisitionDateTime, StudyDate, StudyDateTime,
+        SeriesDate, and SeriesDateTime fields are removed from JSON files. Default is False.
 
     Notes
     -----
@@ -493,6 +498,7 @@ def workflow(
             overwrite=overwrite,
             dcmconfig=dcmconfig,
             grouping=grouping,
+            no_sanitize_jsons=no_sanitize_jsons,
         )
 
         lgr.info(

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -61,6 +61,7 @@ def process_extra_commands(
     session: Optional[str],
     subjs: Optional[list[str]],
     grouping: str,
+    no_sanitize_jsons: bool = False,
 ) -> None:
     """
     Perform custom command instead of regular operations. Supported commands:
@@ -82,6 +83,8 @@ def process_extra_commands(
         List of subject identifiers
     grouping : {'studyUID', 'accession_number', 'all', 'custom'}
         How to group dicoms.
+    no_sanitize_jsons : bool, optional
+        Disable removal of sensitive date/time information from JSON sidecar files.
     """
 
     def ensure_has_files() -> None:
@@ -389,6 +392,7 @@ def workflow(
             session,
             subjs,
             grouping,
+            no_sanitize_jsons,
         )
         return
     #

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -61,7 +61,6 @@ def process_extra_commands(
     session: Optional[str],
     subjs: Optional[list[str]],
     grouping: str,
-    no_sanitize_jsons: bool = False,
 ) -> None:
     """
     Perform custom command instead of regular operations. Supported commands:
@@ -83,8 +82,6 @@ def process_extra_commands(
         List of subject identifiers
     grouping : {'studyUID', 'accession_number', 'all', 'custom'}
         How to group dicoms.
-    no_sanitize_jsons : bool, optional
-        Disable removal of sensitive date/time information from JSON sidecar files.
     """
 
     def ensure_has_files() -> None:
@@ -128,10 +125,6 @@ def process_extra_commands(
         heuristic_mod = load_heuristic(heuristic)
         for fname in files:
             populate_bids_templates(fname, getattr(heuristic_mod, "DEFAULT_FIELDS", {}))
-    elif command == "sanitize-jsons":
-        ensure_has_files()
-        assert files is not None  # for mypy now
-        tuneup_bids_json_files(files, sanitize=not no_sanitize_jsons)
     elif command == "heuristics":
         from .utils import get_known_heuristics_with_descriptions
 
@@ -238,7 +231,7 @@ def workflow(
     dcmconfig: Optional[str] = None,
     queue: Optional[str] = None,
     queue_args: Optional[str] = None,
-    no_sanitize_jsons: bool = False,
+    sanitize_dates: str,
 ) -> None:
     """Run the HeuDiConv conversion workflow.
 
@@ -326,8 +319,8 @@ def workflow(
     queue_args : str or None, optional
         Additional queue arguments passed as single string of space-separated
         Argument=Value pairs. Default is None.
-    no_sanitize_jsons : bool, optional
-        Disable removal of sensitive date/time information from JSON sidecar files.
+    sanitize_dates : str, optional, {'remove', 'nothing', 'shift'}
+        Removal of sensitive date/time information from JSON sidecar files.
         By default, AcquisitionDate, AcquisitionDateTime, StudyDate, StudyDateTime,
         SeriesDate, and SeriesDateTime fields are removed from JSON files. Default is False.
 
@@ -392,7 +385,6 @@ def workflow(
             session,
             subjs,
             grouping,
-            no_sanitize_jsons,
         )
         return
     #
@@ -502,7 +494,7 @@ def workflow(
             overwrite=overwrite,
             dcmconfig=dcmconfig,
             grouping=grouping,
-            no_sanitize_jsons=no_sanitize_jsons,
+            sanitize_dates=sanitize_dates,
         )
 
         lgr.info(

--- a/heudiconv/main.py
+++ b/heudiconv/main.py
@@ -231,7 +231,7 @@ def workflow(
     dcmconfig: Optional[str] = None,
     queue: Optional[str] = None,
     queue_args: Optional[str] = None,
-    sanitize_dates: str,
+    sanitize_dates: Optional[str] = 'remove',
 ) -> None:
     """Run the HeuDiConv conversion workflow.
 

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -1424,11 +1424,11 @@ def test_tuneup_bids_json_files_sanitization(tmp_path: Path) -> None:
         "RepetitionTime": 2.0,
     }
     save_json(str(test_json_path), test_data)
-    
+
     # Test with sanitization enabled (default)
     tuneup_bids_json_files([str(test_json_path)], sanitize=True)
     result = load_json(str(test_json_path))
-    
+
     # Check that date/time fields were removed
     assert "AcquisitionDate" not in result
     assert "AcquisitionDateTime" not in result
@@ -1436,21 +1436,21 @@ def test_tuneup_bids_json_files_sanitization(tmp_path: Path) -> None:
     assert "StudyDateTime" not in result
     assert "SeriesDate" not in result
     assert "SeriesDateTime" not in result
-    
+
     # Check that other fields were preserved
     assert result["EchoTime"] == 0.03
     assert result["RepetitionTime"] == 2.0
-    
+
     # Check that HeudiconvVersion was added
     assert "HeudiconvVersion" in result
-    
+
     # Recreate the file for the second test
     save_json(str(test_json_path), test_data)
-    
+
     # Test with sanitization disabled
     tuneup_bids_json_files([str(test_json_path)], sanitize=False)
     result = load_json(str(test_json_path))
-    
+
     # Check that date/time fields were preserved
     assert result["AcquisitionDate"] == "20231015"
     assert result["AcquisitionDateTime"] == "20231015120000"
@@ -1458,10 +1458,10 @@ def test_tuneup_bids_json_files_sanitization(tmp_path: Path) -> None:
     assert result["StudyDateTime"] == "20231015120000"
     assert result["SeriesDate"] == "20231015"
     assert result["SeriesDateTime"] == "20231015120000"
-    
+
     # Check that other fields were preserved
     assert result["EchoTime"] == 0.03
     assert result["RepetitionTime"] == 2.0
-    
+
     # Check that HeudiconvVersion was added
     assert "HeudiconvVersion" in result

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -1426,7 +1426,7 @@ def test_tuneup_bids_json_files_sanitization(tmp_path: Path) -> None:
     save_json(str(test_json_path), test_data)
 
     # Test with sanitization enabled (default)
-    tuneup_bids_json_files([str(test_json_path)], sanitize=True)
+    tuneup_bids_json_files([str(test_json_path)], sanitize = 'remove' )
     result = load_json(str(test_json_path))
 
     # Check that date/time fields were removed
@@ -1448,7 +1448,7 @@ def test_tuneup_bids_json_files_sanitization(tmp_path: Path) -> None:
     save_json(str(test_json_path), test_data)
 
     # Test with sanitization disabled
-    tuneup_bids_json_files([str(test_json_path)], sanitize=False)
+    tuneup_bids_json_files([str(test_json_path)], sanitize = 'nothing')
     result = load_json(str(test_json_path))
 
     # Check that date/time fields were preserved


### PR DESCRIPTION
**Summary**

This PR introduces an explicit opt-out mechanism for JSON date sanitization, allowing users to preserve original metadata when needed while keeping existing sanitization behavior as the default.

**Key changes**

Adds a --sanitize-dates CLI option to control date sanitization behavior
Threads the sanitize_dates flag through the relevant function chain
Adds targeted tests for tuneup_bids_json_files to validate sanitization behavior
Cleans up related linting issues

**Testing**

- Added necessary unit tests 
- Existing test suite passes