### PR TITLE
BF: support _ses-DATE as alternative to _ses-{date} for Siemens XA60

### DIFF
--- a/docs/heuristics.rst
+++ b/docs/heuristics.rst
@@ -43,7 +43,7 @@ The following details of the sequences could also be used as a ``{detail}`` in t
 
 - ``item``: an index of seqinfo (e.g., ``1``),
 - ``subject``: a subject label (e.g., ``qa``)
-- ``seqitem``: sequence item, index with a sequence/protocol name (e.g., ``3-anat-scout_ses-{date}``)
+- ``seqitem``: sequence item, index with a sequence/protocol name (e.g., ``3-anat-scout_ses-{date}`` or ``3-anat-scout_ses-DATE`` for Siemens X60 which does not allow {} in names)
 - ``subindex``: an index within the ``seqinfo`` (e.g., ``1``),
 - ``session``: empty (no session) or a session entity (along with ``ses-``, e.g., ``ses-20191216``),
 - ``bids_subject_session_prefix``: shortcut for BIDS file name prefix combining subject and optional session (e.g., ``sub-qa_ses-20191216``),

--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -74,8 +74,9 @@ _ses-<SESID> (optional)
     follow "multi-session" layout. A common practice to have a _ses specifier
     within the scout sequence name. You can either specify explicit session
     identifier (SESID) or just say to maintain, create (starts with 1).
-    You can also use _ses-{date} in case of scanning phantoms or non-human
-    subjects and wanting sessions to be coded by the acquisition date.
+    You can also use _ses-{date} (or _ses-DATE for Siemens X60 which does not
+    allow {} in names) in case of scanning phantoms or non-human subjects and
+    wanting sessions to be coded by the acquisition date.
 
 _task-<TASKID> (optional)
     a short name for a task performed during that run.  If not provided and it
@@ -124,6 +125,10 @@ generally to accommodate limitations imposed by different manufacturers/models:
 
 - We replace all ( with { and ) with } to be able e.g. to specify session {date}
 - "WIP " prefix unconditionally added by the scanner is stripped
+
+### Siemens X60
+
+- _ses-DATE is supported as an alternative to _ses-{date} since X60 does not allow {}
 """
 
 from __future__ import annotations
@@ -790,6 +795,9 @@ def infotoids(seqinfos: Iterable[SeqInfo], outdir: str) -> dict[str, Optional[st
             # there was a marker for something we could provide from our seqinfo
             # e.g. {date}
             session_ = session_.format(**s._asdict())
+        elif session_ == "DATE":
+            # Siemens X60 does not allow {} in names, so also support uppercase "DATE"
+            session_ = s.date
         if session_:
             ses_markers.append(session_)
     session: Optional[str] = None


### PR DESCRIPTION
Siemens X60 software does not allow {} characters in sequence names, so _ses-{date} cannot be used. This adds support for _ses-date (without braces) which behaves identically - resolving to the acquisition date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)