### PR TITLE
[ENH] add MultipleLabels IntendedFor method

### DIFF
--- a/docs/heuristics.rst
+++ b/docs/heuristics.rst
@@ -184,9 +184,15 @@ The parameters that can be specified and the allowed options are defined in ``bi
    * ``'PlainAcquisitionLabel'``: similar to ``'CustomAcquisitionLabel'``, but does not change
      behavior for ``func`` modality and always bases decision on the ``_acq-`` label. Helps in
      cases when there are multiple tasks and a shared ``fmap`` for some of them.
+   * ``'MultipleLabels'``: in cases where an ``_acq-`` label is not sufficient to distinguish
+     fmap groups. Useful in scenarios where ``_rec-`` is automatically assigned. Configure the
+     list of entities to consider in the ``'parameter_opts'`` dictionary.
+     ``''``
    * ``'Force'``: forces ``heudiconv`` to consider any ``fmaps`` in the session to be
      suitable for any image, no matter what the imaging parameters are.
 
+ - ``'parameter_opts'``: Some ``'matching_parameters'`` like ``'MultipleLabels'`` can be
+   configured using this dictionary.
 
  - ``'criterion'``: Criterion to decide which of the candidate ``fmaps`` will be assigned to
    a given file, if there are more than one. Allowed values are:
@@ -195,10 +201,16 @@ The parameters that can be specified and the allowed options are defined in ``bi
    * ``'Closest'``: The closest in time to the beginning of the image acquisition.
 
 .. note::
-  Example::
+  Examples::
 
     POPULATE_INTENDED_FOR_OPTS = {
             'matching_parameters': ['ImagingVolume', 'Shims'],
+            'criterion': 'Closest'
+    }
+
+    POPULATE_INTENDED_FOR_OPTS = {
+            'matching_parameters': ['MultipleLabels'],
+            'parameter_opts': {'MultipleLabels': {'entities': ['acq', 'rec']}},
             'criterion': 'Closest'
     }
 

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -78,6 +78,7 @@ AllowedFmapParameterMatching = [
     "ModalityAcquisitionLabel",
     "CustomAcquisitionLabel",
     "PlainAcquisitionLabel",
+    "MultipleLabels",
     "Force",
 ]
 # Key info returned by get_key_info_for_fmap_assignment when
@@ -697,7 +698,9 @@ def find_fmap_groups(fmap_dir: str) -> dict[str, list[str]]:
 
 
 def get_key_info_for_fmap_assignment(
-    json_file: str, matching_parameter: str
+    json_file: str,
+    matching_parameter: str,
+    parameter_opts: dict = {},
 ) -> list[Any]:
     """
     Gets key information needed to assign fmaps to other modalities.
@@ -710,6 +713,9 @@ def get_key_info_for_fmap_assignment(
         path to the json file
     matching_parameter : str in AllowedFmapParameterMatching
         matching_parameter that will be used to match runs
+    parameter_opts : dict
+        possible options for the matching_parameter
+        default: {}
 
     Returns
     -------
@@ -762,6 +768,14 @@ def get_key_info_for_fmap_assignment(
         # always base the decision on <acq> label
         plain_label = BIDSFile.parse(op.basename(json_file))["acq"]
         key_info = [plain_label]
+    elif matching_parameter == "MultipleLabels":
+        # use a heuristic specific list of labels and match on the
+        # concatenation of their values
+        combined_labels = ""
+        for entity in parameter_opts.get("entities", []):
+            label = BIDSFile.parse(op.basename(json_file))[entity]
+            combined_labels += label or ""
+        key_info = [combined_labels or None]
     elif matching_parameter == "Force":
         # We want to force the matching, so just return some string
         # regardless of the image
@@ -774,7 +788,10 @@ def get_key_info_for_fmap_assignment(
 
 
 def find_compatible_fmaps_for_run(
-    json_file: str, fmap_groups: dict[str, list[str]], matching_parameters: list[str]
+    json_file: str,
+    fmap_groups: dict[str, list[str]],
+    matching_parameters: list[str],
+    parameter_opts: dict[str, dict] = {},
 ) -> dict[str, list[str]]:
     """
     Finds compatible fmaps for a given run, for populate_intended_for.
@@ -790,6 +807,10 @@ def find_compatible_fmaps_for_run(
         value: list of all fmap paths in the group
     matching_parameters : list of str from AllowedFmapParameterMatching
         matching_parameters that will be used to match runs
+    parameter_opts : dict
+        key: matching_parameter name
+        value: dictionary of options for the matching_parameter
+        default: {}
 
     Returns
     -------
@@ -802,7 +823,8 @@ def find_compatible_fmaps_for_run(
     lgr.debug("Looking for fmaps for %s", json_file)
     json_info = {}
     for param in matching_parameters:
-        json_info[param] = get_key_info_for_fmap_assignment(json_file, param)
+        opts = parameter_opts.get(param, {})
+        json_info[param] = get_key_info_for_fmap_assignment(json_file, param, opts)
 
     compatible_fmap_groups = {}
     for fm_key, fm_group in fmap_groups.items():
@@ -810,8 +832,9 @@ def find_compatible_fmaps_for_run(
         # the fmaps in the group:
         compatible = False
         for param in matching_parameters:
+            opts = parameter_opts.get(param, {})
             json_info_1st_item = json_info[param][0]
-            fm_info = get_key_info_for_fmap_assignment(fm_group[0], param)
+            fm_info = get_key_info_for_fmap_assignment(fm_group[0], param, opts)
             # for the case in which key_info is a list of strings:
             if isinstance(json_info_1st_item, str):
                 compatible = json_info[param] == fm_info
@@ -834,7 +857,9 @@ def find_compatible_fmaps_for_run(
 
 
 def find_compatible_fmaps_for_session(
-    path_to_bids_session: str, matching_parameters: list[str]
+    path_to_bids_session: str,
+    matching_parameters: list[str],
+    parameter_opts: dict[str, dict] = {},
 ) -> Optional[dict[str, dict[str, list[str]]]]:
     """
     Finds compatible fmaps for all non-fmap runs in a session.
@@ -848,6 +873,10 @@ def find_compatible_fmaps_for_session(
         sessions).
     matching_parameters : list of str from AllowedFmapParameterMatching
         matching_parameters that will be used to match runs
+    parameter_opts : dict
+        key: matching_parameter name
+        value: dictionary of options for the matching_parameter
+        default: {}
 
     Returns
     -------
@@ -880,7 +909,9 @@ def find_compatible_fmaps_for_session(
 
     # Loop through session_jsons and find the compatible fmap_groups for each
     compatible_fmaps = {
-        j: find_compatible_fmaps_for_run(j, fmap_groups, matching_parameters)
+        j: find_compatible_fmaps_for_run(
+            j, fmap_groups, matching_parameters, parameter_opts
+        )
         for j in session_jsons
     }
     return compatible_fmaps
@@ -978,7 +1009,10 @@ def select_fmap_from_compatible_groups(
 
 
 def populate_intended_for(
-    path_to_bids_session: str, matching_parameters: str | list[str], criterion: str
+    path_to_bids_session: str,
+    matching_parameters: str | list[str],
+    criterion: str,
+    parameter_opts: dict[str, dict] = {},
 ) -> None:
     """
     Adds the 'IntendedFor' field to the fmap .json files in a session folder.
@@ -999,6 +1033,10 @@ def populate_intended_for(
         sessions).
     matching_parameters : list of str from AllowedFmapParameterMatching
         matching_parameters that will be used to match runs
+    parameter_opts : dict
+        key: matching_parameter name
+        value: dictionary of options for the matching_parameter
+        default: {}
     criterion : str in ['First', 'Closest']
         matching_parameters that will be used to decide which of the matching
         fmaps to use
@@ -1035,7 +1073,9 @@ def populate_intended_for(
         return
 
     compatible_fmaps = find_compatible_fmaps_for_session(
-        path_to_bids_session, matching_parameters=matching_parameters
+        path_to_bids_session,
+        matching_parameters=matching_parameters,
+        parameter_opts=parameter_opts,
     )
     assert compatible_fmaps is not None
     selected_fmaps = {}

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -700,7 +700,7 @@ def find_fmap_groups(fmap_dir: str) -> dict[str, list[str]]:
 def get_key_info_for_fmap_assignment(
     json_file: str,
     matching_parameter: str,
-    parameter_opts: dict = {},
+    parameter_opts: None | dict = None,
 ) -> list[Any]:
     """
     Gets key information needed to assign fmaps to other modalities.
@@ -715,7 +715,7 @@ def get_key_info_for_fmap_assignment(
         matching_parameter that will be used to match runs
     parameter_opts : dict
         possible options for the matching_parameter
-        default: {}
+        default: None
 
     Returns
     -------
@@ -723,6 +723,9 @@ def get_key_info_for_fmap_assignment(
         part of the json file that will need to match between the fmap and
         the other image
     """
+    if parameter_opts is None:
+        parameter_opts = {}
+
     if not op.exists(json_file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), json_file)
 
@@ -791,7 +794,7 @@ def find_compatible_fmaps_for_run(
     json_file: str,
     fmap_groups: dict[str, list[str]],
     matching_parameters: list[str],
-    parameter_opts: dict[str, dict] = {},
+    parameter_opts: None | dict[str, dict] = None,
 ) -> dict[str, list[str]]:
     """
     Finds compatible fmaps for a given run, for populate_intended_for.
@@ -810,7 +813,7 @@ def find_compatible_fmaps_for_run(
     parameter_opts : dict
         key: matching_parameter name
         value: dictionary of options for the matching_parameter
-        default: {}
+        default: None
 
     Returns
     -------
@@ -820,6 +823,9 @@ def find_compatible_fmaps_for_run(
         key: prefix common to the group
         value: list of all fmap paths in the group
     """
+    if parameter_opts is None:
+        parameter_opts = {}
+
     lgr.debug("Looking for fmaps for %s", json_file)
     json_info = {}
     for param in matching_parameters:
@@ -859,7 +865,7 @@ def find_compatible_fmaps_for_run(
 def find_compatible_fmaps_for_session(
     path_to_bids_session: str,
     matching_parameters: list[str],
-    parameter_opts: dict[str, dict] = {},
+    parameter_opts: None | dict[str, dict] = None,
 ) -> Optional[dict[str, dict[str, list[str]]]]:
     """
     Finds compatible fmaps for all non-fmap runs in a session.
@@ -876,13 +882,16 @@ def find_compatible_fmaps_for_session(
     parameter_opts : dict
         key: matching_parameter name
         value: dictionary of options for the matching_parameter
-        default: {}
+        default: None
 
     Returns
     -------
     compatible_fmap : dict
         Dict of compatible_fmaps_groups (values) for each non-fmap run (keys)
     """
+    if parameter_opts is None:
+        parameter_opts = {}
+
     lgr.debug("Looking for fmaps for session: %s", path_to_bids_session)
 
     # Resolve path (eliminate '..')
@@ -1012,7 +1021,7 @@ def populate_intended_for(
     path_to_bids_session: str,
     matching_parameters: str | list[str],
     criterion: str,
-    parameter_opts: dict[str, dict] = {},
+    parameter_opts: None | dict[str, dict] = None,
 ) -> None:
     """
     Adds the 'IntendedFor' field to the fmap .json files in a session folder.
@@ -1036,11 +1045,14 @@ def populate_intended_for(
     parameter_opts : dict
         key: matching_parameter name
         value: dictionary of options for the matching_parameter
-        default: {}
+        default: None
     criterion : str in ['First', 'Closest']
         matching_parameters that will be used to decide which of the matching
         fmaps to use
     """
+
+    if parameter_opts is None:
+        parameter_opts = {}
 
     if not isinstance(matching_parameters, list):
         assert isinstance(matching_parameters, str), (

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -112,6 +112,7 @@ def test_get_key_info_for_fmap_assignment(
     the seed for the random label creation.
     """
 
+    expected_key_info: str | None = None  # avoid mypy type inference
     nifti_file = op.join(TESTS_DATA_PATH, "sample_nifti.nii.gz")
     # Get the expected parameters from the NIfTI header:
     MY_HEADER = nibabel.ni1.np.loadtxt(

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -197,6 +197,30 @@ def test_get_key_info_for_fmap_assignment(
             json_name, matching_parameter="PlainAcquisitionLabel"
         )
 
+    # 8) matching_parameter = 'MultipleLabels'
+    A_LABEL = gen_rand_label(label_size, label_seed)
+    B_LABEL = gen_rand_label(label_size, label_seed)
+    BOTH = A_LABEL + B_LABEL
+    for d in ["fmap", "func", "dwi", "anat"]:
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+
+    for dirname, fname, expected_key_info in [
+        ("fmap", "sub-foo_epi.json", None),
+        ("fmap", f"sub-foo_acq-{A_LABEL}_epi.json", A_LABEL),
+        ("fmap", f"sub-foo_acq-{A_LABEL}_rec-{B_LABEL}_epi.json", BOTH),
+        ("func", f"sub-foo_task-foo_acq-{A_LABEL}_bold.json", A_LABEL),
+        ("func", f"sub-foo_task-bar_acq-{A_LABEL}_rec-{B_LABEL}_bold.json", BOTH),
+        ("dwi", f"sub-foo_acq-{A_LABEL}_dwi.json", A_LABEL),
+        ("anat", f"sub-foo_rec-{B_LABEL}_T1w.json", B_LABEL),
+    ]:
+        json_name = op.join(tmp_path, dirname, fname)
+        save_json(json_name, {SHIM_KEY: A_SHIM})
+        assert [expected_key_info] == get_key_info_for_fmap_assignment(
+            json_name,
+            matching_parameter="MultipleLabels",
+            parameter_opts={"entities": ["acq", "rec"]},
+        )
+
     # Finally: invalid matching_parameters:
     assert (
         get_key_info_for_fmap_assignment(json_name, matching_parameter="Invalid") == []


### PR DESCRIPTION
This is a suggestion for yet another IntendedFor method. We had some success using `PlainAcquisitionLabel` merged a while back, but there are a number of cases where our site-wide heuristic requires more than that.

We often get duplicated files using the prescan normalization method of our scanner. Currently we name it `rec-norm` (I'm aware of [this beast](https://github.com/bids-standard/bids-specification/pull/105), we decided to use rec to be bids valid for now). The issue with this however is that we cannot base our IntendedFor matching decision solely on `acq`, because we have two groups now:

```
fmap/sub-foo_acq-se_dir-AP_rec-norm_epi.json
fmap/sub-foo_acq-se_dir-PA_rec-norm_epi.json
fmap/sub-foo_acq-se_dir-AP_epi.json
fmap/sub-foo_acq-se_dir-PA_epi.json
```

and 

```
func/sub-foo_task-t_acq-se_rec-norm_run-01_bold.json
func/sub-foo_task-t_acq-se_rec-norm_run-02_bold.json
func/sub-foo_task-t_acq-se_run-01_bold.json
func/sub-foo_task-t_acq-se_run-02_bold.json
```

And as I understand, fmaps with `rec-norm` are intended only for the corresponding functionals with `rec-norm` .

We could introduce a second label `acq-senorm` and use that, however, the entity modification with `rec-` happens way after our protocol modifications (we heavly rely on `reproin.fix_dbic_protocol()` and a set of regexes.

---

Using a combination of `acq` and `rec`  as they key would help us out here. I decided to create a slightly more generic approach with this PR, instead of just introducing `PlainAcquisitionRecLabel` or something similar.

Using `MultipleLabels`, a heuristic user can now base the decision on one ore more entities, configurable with a new paramter `parameter_opts` in `POPULATE_INTENDED_FOR_OPTS`. (I added an example to the docs)

It's mildly invasive, because we have to carry these options along in `bids.py` - however, I tried to make sure that nothing breaks with `reproin` or any other heuristic that is unaware of this new option.