### PR TITLE
Fix fmap rec dir ordering

### DIFF
--- a/heudiconv/heuristics/reproin.py
+++ b/heudiconv/heuristics/reproin.py
@@ -596,15 +596,6 @@ def infotodict(
             # if there is no _run -- no run label added
             run_label = None
 
-        # yoh: had a wrong assumption
-        # if curr_seqinfo.is_motion_corrected:
-        #     assert curr_seqinfo.is_derived, "Motion corrected images must be 'derived'"
-
-        if curr_seqinfo.is_motion_corrected and "rec-" in series_info.get("bids", ""):
-            raise NotImplementedError(
-                "want to add _rec-moco but there is _rec- already"
-            )
-
         def from_series_info(name: str) -> Optional[str]:
             """A little helper to provide _name-value if series_info knows it
 
@@ -615,6 +606,19 @@ def infotodict(
             else:
                 return None
 
+        # yoh: had a wrong assumption
+        # if curr_seqinfo.is_motion_corrected:
+        #     assert curr_seqinfo.is_derived, "Motion corrected images must be 'derived'"
+
+        if curr_seqinfo.is_motion_corrected:
+            if from_series_info("rec"):
+                raise NotImplementedError(
+                    "want to add _rec-moco but there is _rec- already"
+                )
+            # But we want to add an indicator in case it was motion corrected
+            # in the magnet. ref sample  /2017/01/03/qa
+            series_info["rec"] = "moco"
+
         # TODO: get order from schema, do not hardcode. ATM could be checked at
         # https://bids-specification.readthedocs.io/en/stable/99-appendices/04-entity-table.html
         # https://github.com/bids-standard/bids-specification/blob/HEAD/src/schema/rules/entities.yaml
@@ -623,9 +627,7 @@ def infotodict(
         filename_suffix_parts = [
             from_series_info("task"),
             from_series_info("acq"),
-            # But we want to add an indicator in case it was motion corrected
-            # in the magnet. ref sample  /2017/01/03/qa
-            None if not curr_seqinfo.is_motion_corrected else "rec-moco",
+            from_series_info("rec"),
             from_series_info("dir"),
             series_info.get("bids"),
             run_label,
@@ -948,7 +950,7 @@ def parse_series_spec(series_spec: str) -> dict[str, str]:
             .replace(")", "}")
         )  # for Philips
 
-        if key in ["ses", "run", "task", "acq", "dir"]:
+        if key in ["ses", "run", "task", "acq", "rec", "dir"]:
             # those we care about explicitly
             regd[{"ses": "session"}.get(key, key)] = sanitize_str(value)
         else:

--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -245,6 +245,20 @@ def test_parse_series_spec() -> None:
         "dir": "AP",
     }
 
+    assert pdpn("func-bold_rec-norm_dir-AP") == {
+        "datatype": "func",
+        "datatype_suffix": "bold",
+        "rec": "norm",
+        "dir": "AP",
+    }
+
+    assert pdpn("fmap_rec-norm_dir-AP_acq-3mm") == {
+        "datatype": "fmap",
+        "rec": "norm",
+        "dir": "AP",
+        "acq": "3mm",
+    }
+
 
 def test_get_unique() -> None:
     accession_number = "A003"
@@ -314,3 +328,52 @@ def test_infotoids_ses_date(ses_spec: str, expected_session: str) -> None:
     result = infotoids([seqinfo], "/dev/null/output")
 
     assert result["session"] == expected_session
+
+
+def test_infotodict_entity_ordering() -> None:
+    """Test that entities in the generated filename follow BIDS ordering
+    (task, acq, rec, dir, run, suffix) regardless of input order."""
+    # Deliberately scramble entity order in the protocol name
+    scrambled = "func-bold_dir-AP_run-1_rec-norm_task-rest_acq-mb4"
+    seqinfo = SeqInfo(
+        total_files_till_now=1,
+        example_dcm_file="/path/to/dcm",
+        series_id=f"1-{scrambled}",
+        dcm_dir_name=f"1-{scrambled}",
+        series_files=1,
+        unspecified="",
+        dim1=64,
+        dim2=64,
+        dim3=40,
+        dim4=100,
+        TR=2.0,
+        TE=30.0,
+        protocol_name=scrambled,
+        is_motion_corrected=False,
+        is_derived=False,
+        patient_id="sub01",
+        study_description="PI^study",
+        referring_physician_name="",
+        series_description=scrambled,
+        sequence_name="",
+        image_type=("ORIGINAL", "PRIMARY", "FMRI"),
+        accession_number="A001",
+        patient_age="030Y",
+        patient_sex="M",
+        date="20240115",
+        series_uid="1.2.3.4",
+        time="120000",
+        custom=None,
+    )
+
+    result = reproin.infotodict([seqinfo])
+    templates = [key[0] for key in result]
+    assert len(templates) == 1
+    template = templates[0]
+
+    # Verify entities appear in BIDS order in the generated filename
+    expected_order = ["task-rest", "acq-mb4", "rec-norm", "dir-AP", "run-01", "bold"]
+    positions = [template.index(e) for e in expected_order]
+    assert positions == sorted(positions), (
+        f"Entities not in BIDS order in {template!r}"
+    )

--- a/heudiconv/heuristics/test_reproin.py
+++ b/heudiconv/heuristics/test_reproin.py
@@ -330,11 +330,13 @@ def test_infotoids_ses_date(ses_spec: str, expected_session: str) -> None:
     assert result["session"] == expected_session
 
 
-def test_infotodict_entity_ordering() -> None:
+@pytest.mark.parametrize("moco", [True, False])
+@pytest.mark.parametrize("additional_rec", ["_rec-norm", ""])
+def test_infotodict_entity_ordering(moco: bool, additional_rec: str) -> None:
     """Test that entities in the generated filename follow BIDS ordering
     (task, acq, rec, dir, run, suffix) regardless of input order."""
     # Deliberately scramble entity order in the protocol name
-    scrambled = "func-bold_dir-AP_run-1_rec-norm_task-rest_acq-mb4"
+    scrambled = f"func-bold_dir-AP_run-1{additional_rec}_task-rest_acq-mb4"
     seqinfo = SeqInfo(
         total_files_till_now=1,
         example_dcm_file="/path/to/dcm",
@@ -349,7 +351,7 @@ def test_infotodict_entity_ordering() -> None:
         TR=2.0,
         TE=30.0,
         protocol_name=scrambled,
-        is_motion_corrected=False,
+        is_motion_corrected=moco,
         is_derived=False,
         patient_id="sub01",
         study_description="PI^study",
@@ -366,14 +368,39 @@ def test_infotodict_entity_ordering() -> None:
         custom=None,
     )
 
-    result = reproin.infotodict([seqinfo])
-    templates = [key[0] for key in result]
-    assert len(templates) == 1
-    template = templates[0]
+    if moco and additional_rec == '':
+        result = reproin.infotodict([seqinfo])
+        templates = [key[0] for key in result]
+        assert len(templates) == 1
+        template = templates[0]
 
-    # Verify entities appear in BIDS order in the generated filename
-    expected_order = ["task-rest", "acq-mb4", "rec-norm", "dir-AP", "run-01", "bold"]
-    positions = [template.index(e) for e in expected_order]
-    assert positions == sorted(positions), (
-        f"Entities not in BIDS order in {template!r}"
-    )
+        # Verify rec-moco has been added in the generated filename
+        expected_order = ["task-rest", "acq-mb4", "rec-moco", "dir-AP", "run-01", "bold"]
+        positions = [template.index(e) for e in expected_order]
+        assert positions == sorted(positions), (
+            f"Entities not in BIDS order in {template!r} or rec-moco missing"
+        )
+        pass
+
+    if moco and additional_rec != '':
+        with pytest.raises(NotImplementedError) as ce:
+            reproin.infotodict([seqinfo])
+            # "want to add _rec-moco but there is _rec- already"
+        assert str(ce.value) == "want to add _rec-moco but there is _rec- already"
+
+    if not moco and additional_rec == '':
+        # nothing new to test for this combination
+        return
+
+    if not moco and additional_rec != '':
+        result = reproin.infotodict([seqinfo])
+        templates = [key[0] for key in result]
+        assert len(templates) == 1
+        template = templates[0]
+
+        # Verify entities appear in BIDS order in the generated filename
+        expected_order = ["task-rest", "acq-mb4", "rec-norm", "dir-AP", "run-01", "bold"]
+        positions = [template.index(e) for e in expected_order]
+        assert positions == sorted(positions), (
+            f"Entities not in BIDS order in {template!r}"
+        )


### PR DESCRIPTION
In some of our converted datasets the bids-validator is complaining about files like this:

```
sub-01/ses-01/fmap/sub-01_ses-01_dir-PA_rec-norm_epi.nii.gz
```

It turns out that this is actually what the reproin heuristic returns right now and it is invalid because of the incorrect position of `rec` ([must be followed](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#case-4-multiple-phase-encoded-directions-pepolar) by `dir`).
It used to be invalid anyway (rec- not part of fmap) and might have slipped that way for PEpolar fmaps.

The PR is slightly refactoring the `rec-moco` workaround, but not touching it's logic. I also added tests (using claude).