### PR TITLE
Ensure all IntendedFor matching params must match

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -826,7 +826,7 @@ def find_compatible_fmaps_for_run(
                     for x, y in zip(json_info[param], fm_info)
                 )
             if not compatible:
-                continue  # don't bother checking more params
+                break  # don't bother checking more params
         if compatible:
             compatible_fmap_groups[fm_key] = fm_group
 

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -1112,6 +1112,83 @@ def test_find_compatible_fmaps_for_run(
             assert compatible_fmaps == expected_compatible_fmaps[json_file]
 
 
+def test_find_compatible_fmaps_for_run_union(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Test find_compatible_fmaps_for_run with multiple parameters.
+
+    This tests the behavior of find_compatible_fmaps_for_run when it
+    is given more than one parameter to match on. Expects multiple
+    parameters to be treated as a union (AND).
+    """
+
+    def mock_get_key_info_for_fmap_assignment(
+        json_file: str, matching_parameter: str
+    ) -> list[Any]:
+        """
+        Mock matching parameters
+
+        Mock a situation where we have three custom acquisition labels
+        and two sets of shims - but only one pairing where both match.
+
+        The names are bids-like but not quite bids - this should not
+        matter since we are testing general logic.
+        """
+        shims1 = [1, 2, 3, 4]
+        shims2 = [5, 6, 7, 8]
+        mock_info = {
+            "sub-01/func/sub-01_task-foo.json": {
+                "ShimSetting": shims1,
+                "CustomAcquisitionLabel": "foo",
+            },
+            "sub-01/func/sub-01_task-bar.json": {
+                "ShimSetting": shims1,
+                "CustomAcquisitionLabel": "bar",
+            },
+            "sub-01/func/sub-01_task-baz.json": {
+                "ShimSetting": shims1,
+                "CustomAcquisitionLabel": "baz",
+            },
+            "sub-01/fmap/sub-01_acq-foo.json": {
+                "ShimSetting": shims1,
+                "CustomAcquisitionLabel": "foo",
+            },
+            "sub-01/fmap/sub-01_acq-bar.json": {
+                "ShimSetting": shims2,
+                "CustomAcquisitionLabel": "bar",
+            },
+        }
+        return [mock_info[json_file][matching_parameter]]
+
+    monkeypatch.setattr(
+        "heudiconv.bids.get_key_info_for_fmap_assignment",
+        mock_get_key_info_for_fmap_assignment,
+    )
+
+    fmap_groups = {
+        "foo": ["sub-01/fmap/sub-01_acq-foo.json"],
+        "bar": ["sub-01/fmap/sub-01_acq-bar.json"],
+    }
+    param_union = ["ShimSetting", "CustomAcquisitionLabel"]
+
+    # for task-foo, one fmap matches by label and shims
+    x = find_compatible_fmaps_for_run(
+        "sub-01/func/sub-01_task-foo.json", fmap_groups, param_union
+    )
+    assert "foo" in x.keys() and len(x) == 1
+
+    # for task-bar, we have either shims or label, but not both
+    x = find_compatible_fmaps_for_run(
+        "sub-01/func/sub-01_task-bar.json", fmap_groups, param_union
+    )
+    assert len(x) == 0
+
+    # for task-baz we have matching shims, but not label
+    x = find_compatible_fmaps_for_run(
+        "sub-01/func/sub-01_task-baz.json", fmap_groups, param_union
+    )
+    assert len(x) == 0
+
+
 @pytest.mark.ai_generated
 @pytest.mark.parametrize(
     "rel_diff,should_match",


### PR DESCRIPTION
The list of `matching_parameters` specified in `POPULATE_INTENDED_FOR_OPTS` can have multiple values. If I'm not mistaken, the code would test all of them, but then act only on the result of the *last test*, which seems unintended.

This assumes that `matching_parameters` are to be interpreted as `all()`, and makes the check behave accordingly.

It seems that the matching functions have so far only been tested with a single parameter. This PR adds a test for `find_compatible_fmaps_for_run_union` being called with two parameters, and a set of files for which there is one pairing which matches both, but more which match just one. The assumption for the test is that the desired operation is `all()`, which seems the more logical alternative to me.

Fixes #859 