### PR TITLE
Aggregate events.tsv for invalid entities (and rec)

### DIFF
--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -259,7 +259,7 @@ def populate_aggregated_jsons(path: str) -> None:
         for invalid_entity in ['chunk', 'echo', 'part']:
             # events.tsv with these entities are not specified
             if invalid_entity in parsed_fpath:
-                parsed_fpath.drop(invalid_entity, silent=True)
+                parsed_fpath.drop(invalid_entity)
         if 'rec' in parsed_fpath:
             # `rec` is technically valid for the events file, but the events
             # are independent of the reconstruction method and so we drop them
@@ -1151,10 +1151,9 @@ class BIDSFile:
     def __contains__(self, entity: object) -> bool:
         return entity in self._entities
 
-    def drop(self, entity: str, silent: bool = False) -> None:
+    def drop(self, entity: str) -> None:
         if entity not in self._entities:
-            if not silent:
-                lgr.warning("File %s does not contain entity '%s'", self.__str__(), entity)
+            lgr.warning("File %s does not contain entity '%s'", self.__str__(), entity)
             return
         self._entities.pop(entity)
 

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -1147,8 +1147,10 @@ class BIDSFile:
         return entity in self._entities
 
     def drop(self, entity: str, missing_ok: bool=False) -> None:
-        if not missing_ok and entity not in self._entities:
-            raise ValueError(f"{self} does not contain entity {entity!r}")
+        if entity not in self._entities:
+            if not missing_ok:
+                raise ValueError(f"{self} does not contain entity {entity!r}")
+            return
         self._entities.pop(entity)
 
     def set(self, entity: str, value: str, overwrite: bool = True) -> None:

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -256,15 +256,9 @@ def populate_aggregated_jsons(path: str) -> None:
 
         # specify the name of the '_events.tsv' file:
         parsed_fpath = BIDSFile.parse(op.basename(fpath))
-        for invalid_entity in ['chunk', 'echo', 'part']:
+        for events_invalid_entity in ['chunk', 'echo', 'part']:
             # events.tsv with these entities are not specified
-            if invalid_entity in parsed_fpath:
-                parsed_fpath.drop(invalid_entity)
-        if 'rec' in parsed_fpath:
-            # `rec` is technically valid for the events file, but the events
-            # are independent of the reconstruction method and so we drop them
-            # as well
-            parsed_fpath.drop('rec')
+            parsed_fpath.drop(events_invalid_entity, missing_ok=True)
         fpath = op.join(op.dirname(fpath), str(parsed_fpath))
         events_file = remove_suffix(fpath, suf) + "_events.tsv"
         # do not touch any existing thing, it may be precious

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -1076,6 +1076,7 @@ class BIDSFile:
         "mt",
         "part",
         "recording",
+        "chunk",
     ]
 
     def __init__(

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -1145,10 +1145,9 @@ class BIDSFile:
     def __contains__(self, entity: object) -> bool:
         return entity in self._entities
 
-    def drop(self, entity: str) -> None:
-        if entity not in self._entities:
-            lgr.warning("File %s does not contain entity '%s'", self.__str__(), entity)
-            return
+    def drop(self, entity: str, missing_ok: bool=False) -> None:
+        if not missing_ok and entity not in self._entities:
+            raise ValueError(f"{self} does not contain entity {entity!r}")
         self._entities.pop(entity)
 
     def set(self, entity: str, value: str, overwrite: bool = True) -> None:

--- a/heudiconv/bids.py
+++ b/heudiconv/bids.py
@@ -253,27 +253,19 @@ def populate_aggregated_jsons(path: str) -> None:
         # create a stub onsets file for each one of those
         suf = "_bold.json"
         assert fpath.endswith(suf)
-        # specify the name of the '_events.tsv' file:
-        if "_echo-" in fpath:
-            # multi-echo sequence: bids (1.1.0) specifies just one '_events.tsv'
-            #   file, common for all echoes.  The name will not include _echo-.
-            # TODO: RF to use re.match for better readability/robustness
-            # So, find out the echo number:
-            fpath_split = fpath.split("_echo-", 1)  # split fpath using '_echo-'
-            fpath_split_2 = fpath_split[1].split(
-                "_", 1
-            )  # split the second part of fpath_split using '_'
-            echoNo = fpath_split_2[0]  # get echo number
-            if echoNo == "1":
-                if len(fpath_split_2) != 2:
-                    raise ValueError("Found no trailer after _echo-")
-                # we modify fpath to exclude '_echo-' + echoNo:
-                fpath = fpath_split[0] + "_" + fpath_split_2[1]
-            else:
-                # for echoNo greater than 1, don't create the events file, so go to
-                #   the next for loop iteration:
-                continue
 
+        # specify the name of the '_events.tsv' file:
+        parsed_fpath = BIDSFile.parse(op.basename(fpath))
+        for invalid_entity in ['chunk', 'echo', 'part']:
+            # events.tsv with these entities are not specified
+            if invalid_entity in parsed_fpath:
+                parsed_fpath.drop(invalid_entity, silent=True)
+        if 'rec' in parsed_fpath:
+            # `rec` is technically valid for the events file, but the events
+            # are independent of the reconstruction method and so we drop them
+            # as well
+            parsed_fpath.drop('rec')
+        fpath = op.join(op.dirname(fpath), str(parsed_fpath))
         events_file = remove_suffix(fpath, suf) + "_events.tsv"
         # do not touch any existing thing, it may be precious
         if not op.lexists(events_file):
@@ -1155,6 +1147,16 @@ class BIDSFile:
         self, entity: str, value: str
     ) -> None:  # would puke with some exception if already known
         return self.set(entity, value, overwrite=False)
+
+    def __contains__(self, entity: object) -> bool:
+        return entity in self._entities
+
+    def drop(self, entity: str, silent: bool = False) -> None:
+        if entity not in self._entities:
+            if not silent:
+                lgr.warning("File %s does not contain entity '%s'", self.__str__(), entity)
+            return
+        self._entities.pop(entity)
 
     def set(self, entity: str, value: str, overwrite: bool = True) -> None:
         if entity not in self._entities:

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -1583,10 +1583,10 @@ def test_BIDSFile(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.WARNING)
     # test previously dropped entity and entirely non-existing
     for entity in ['dir', 'not_existing']:
-        caplog.clear()
-        my_bids_file.drop(entity)
-        assert len(caplog.records) == 1
-        assert f"does not contain entity '{entity}'" in caplog.records[0].message
+        with pytest.raises(ValueError, match=f"does not contain entity {entity!r}"):
+            my_bids_file.drop(entity)
+        # implicitly assert that no exception is thrown when using missing_ok
+        my_bids_file.drop(entity, missing_ok=True)
 
 
 def test_populate_aggregated_jsons_events(tmp_path: Path) -> None:

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -1591,14 +1591,14 @@ def test_BIDSFile(caplog: pytest.LogCaptureFixture) -> None:
 
 def test_populate_aggregated_jsons_events(tmp_path: Path) -> None:
     """A single _events.tsv is generated for files differing only in
-    entities the events are independent of (here: 'rec' and 'part')."""
+    entities the events are independent of ('chunk', 'echo', and 'part') """
     func_path = tmp_path / "sub-01" / "func"
     bold_json = {"RepetitionTime": 1.0, "TaskName": "rest"}
     create_tree(
         str(func_path),
         {
             f"sub-01_task-rest_{entity}_bold.json": dict(bold_json)
-            for entity in ["rec-A", "rec-B", "part-mag", "part-phase"]
+            for entity in ["chunk-1", "chunk-2", "echo-1", "echo-2", "part-mag", "part-phase"]
         },
     )
 

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 from glob import glob
 import itertools
+import logging
 import os
 import os.path as op
 from pathlib import Path
@@ -31,6 +32,7 @@ from heudiconv.bids import (
     get_key_info_for_fmap_assignment,
     get_shim_setting,
     maybe_na,
+    populate_aggregated_jsons,
     populate_intended_for,
     sanitize_label,
     select_fmap_from_compatible_groups,
@@ -1506,7 +1508,7 @@ def test_populate_intended_for(
                 assert "IntendedFor" not in data.keys()
 
 
-def test_BIDSFile() -> None:
+def test_BIDSFile(caplog: pytest.LogCaptureFixture) -> None:
     """Tests for the BIDSFile class"""
 
     # define entities in the correct order:
@@ -1573,6 +1575,40 @@ def test_BIDSFile() -> None:
     # -for an existing entity, you can overwrite it with "set":
     my_bids_file.set("echo", "2")
     assert my_bids_file["echo"] == "2"
+
+    # Test drop method
+    my_bids_file.drop("dir")
+    assert "dir" not in my_bids_file
+    # dropping an entity which is not set only logs a warning:
+    caplog.set_level(logging.WARNING)
+    caplog.clear()
+    my_bids_file.drop('dir')
+    assert len(caplog.records) == 1
+    assert "does not contain entity 'dir'" in caplog.records[0].message
+    caplog.clear()
+    my_bids_file.drop('not_existing', silent=True)
+    assert len(caplog.records) == 0
+
+
+def test_populate_aggregated_jsons_events(tmp_path: Path) -> None:
+    """A single _events.tsv is generated for files differing only in
+    entities the events are independent of (here: 'rec' and 'part')."""
+    func_path = tmp_path / "sub-01" / "func"
+    bold_json = {"RepetitionTime": 1.0, "TaskName": "rest"}
+    create_tree(
+        str(func_path),
+        {
+            f"sub-01_task-rest_{entity}_bold.json": dict(bold_json)
+            for entity in ["rec-A", "rec-B", "part-mag", "part-phase"]
+        },
+    )
+
+    populate_aggregated_jsons(str(tmp_path))
+
+    events_files = sorted(func_path.glob("*_events.tsv"))
+    assert events_files == [func_path / "sub-01_task-rest_events.tsv"]
+    # and nothing got written elsewhere in the dataset:
+    assert sorted(tmp_path.rglob("*_events.tsv")) == events_files
 
 
 @pytest.mark.skipif(not have_datalad, reason="no datalad")

--- a/heudiconv/tests/test_bids.py
+++ b/heudiconv/tests/test_bids.py
@@ -1579,15 +1579,14 @@ def test_BIDSFile(caplog: pytest.LogCaptureFixture) -> None:
     # Test drop method
     my_bids_file.drop("dir")
     assert "dir" not in my_bids_file
-    # dropping an entity which is not set only logs a warning:
+    # dropping an entity which is not set only logs a warning
     caplog.set_level(logging.WARNING)
-    caplog.clear()
-    my_bids_file.drop('dir')
-    assert len(caplog.records) == 1
-    assert "does not contain entity 'dir'" in caplog.records[0].message
-    caplog.clear()
-    my_bids_file.drop('not_existing', silent=True)
-    assert len(caplog.records) == 0
+    # test previously dropped entity and entirely non-existing
+    for entity in ['dir', 'not_existing']:
+        caplog.clear()
+        my_bids_file.drop(entity)
+        assert len(caplog.records) == 1
+        assert f"does not contain entity '{entity}'" in caplog.records[0].message
 
 
 def test_populate_aggregated_jsons_events(tmp_path: Path) -> None:


### PR DESCRIPTION
We currently get two (empty) events.tsv files for our `rec-norm` and `rec-raw` bold pairs. This is redundant and should be aggregated into an events file without a rec entity altogether (the spec allows it, but I would argue that events are independent of reconstruction methods, right?).

I had a look at the code and cleaned it up a little to utilize `BIDSFile.parse()` instead of manual splits around `_echo`. I also realized that there are other entities valid for the bold, but invalid for the corresponding events.tsv and remove them. For that I added a `drop()` and a trivial `__contains__()` method to BIDSFile to easily remove an entity from the filename and have concise tests.

This should also fix #849 

---

I believe the `__contains__`  is an intuitive add-on, but it might lead to confusion with code like this:

```python
bidsfile = BIDSFile.parse(bold)
if 'rec' in bidsfile:
  ...
```

Under the hood it will now check if `rec` is in the `_entities` dictionary, but it might read as: *Is `rec` literally in the string representation of the filename?* I'm not sure if you want to avoid this little trap.