### PR TITLE
Fix RTD build: update build.os to ubuntu-24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ python:
     - method: pip
       path: .
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"
 sphinx:


### PR DESCRIPTION
## Summary

Read the Docs builds are failing with a config validation error:

> Config validation error in `build.os`. Expected one of (ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest), got type str (ubuntu-20.04).

Failing build: https://app.readthedocs.org/projects/heudiconv/builds/33830622/

`ubuntu-20.04` has been retired as a valid `build.os` value in the Read the Docs configuration schema. This updates it to the supported `ubuntu-24.04` image.

## Changes

- `.readthedocs.yaml`: `build.os` `ubuntu-20.04` → `ubuntu-24.04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln7ezvSxvknZtRuSzuaLH5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ln7ezvSxvknZtRuSzuaLH5)_