### PR TITLE
DOC: add minimal CLAUDE.md pointing at CONTRIBUTING.rst, and refresh CONTRIBUTING

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## MANDATORY: Read before making any code changes
+
+You MUST read [`CONTRIBUTING.rst`](./CONTRIBUTING.rst) before making any code changes, commits, or
+pull requests.  It contains the authoritative project conventions including:
+
+- Development environment setup and the commands to run tests, linting, and type checking
+- Code style rules (formatting, imports, type annotations, docstrings)
+- Testing requirements, including the **mandatory `@pytest.mark.ai_generated` marker on any test
+  written with AI assistance**
+- PR labeling, changelog, and release workflow
+
+Do NOT guess or assume conventions — read the file.  Additional documentation may be found under
+[`docs/`](./docs).

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,10 +107,17 @@ Note that you will likely have these will already be available on your system if
 package manager (e.g. Debian's ``apt-get``, Gentoo's ``emerge``, or simply PIP) to install the
 software.
 
-HeuDiConv also calls out to a number of external tools, most notably ``dcm2niix``, which is not
-installable from PyPI and thus must be provided by your system (e.g. via NeuroDebian, conda, or
-`its own releases <https://github.com/rordenlab/dcm2niix/releases>`_).  Some tests additionally
-require ``git-annex`` and ``datalad``.
+HeuDiConv also calls out to a number of external tools, most notably ``dcm2niix``, and some tests
+additionally need ``git-annex`` and ``datalad``.  All of them are nowadays installable from PyPI,
+so a plain virtualenv is enough to get a complete development environment::
+
+  pip install dcm2niix git-annex
+
+`dcm2niix <https://pypi.org/project/dcm2niix/>`_ and
+`git-annex <https://pypi.org/project/git-annex/>`_ are wheels bundling the corresponding binaries
+for common platforms; ``datalad`` is pulled in by the ``datalad`` (and hence ``all``) extra of
+HeuDiConv itself.  You may of course still prefer to obtain them from your system package manager
+(e.g. NeuroDebian, conda, or Homebrew) if you already have those set up.
 
 Development work might require live access to the copy of HeuDiConv which is being developed.
 If a system-wide release of HeuDiConv is already installed, or likely to be, it is best to keep
@@ -153,6 +160,12 @@ them all against the whole tree at any point with ``pre-commit run -a``, and the
 
 Beyond what the tools enforce:
 
+* **Do not duplicate code.**  Copy-pasted logic is the single most reliable way to introduce bugs
+  into this codebase: the copies inevitably diverge, a fix lands in one of them and not the others,
+  and the discrepancy is then found by users rather than by us.  If you catch yourself
+  copy-pasting, factor the common part out into a helper instead — even for two occurrences, and
+  even when the copies differ in small ways (that is what arguments are for).  This applies with
+  equal force to tests, docs, and heuristics, not just to library code.
 * HeuDiConv is fully type-annotated and ships a ``py.typed`` marker.  New functions must have
   annotated arguments and return values; ``mypy`` is run in CI and can be run locally with
   ``tox -e typing``.
@@ -177,6 +190,25 @@ The suite lives in ``heudiconv/tests/`` (plus per-submodule test files) and is b
 `pytest <https://docs.pytest.org>`_.  A number of tests need external tools (``dcm2niix``,
 ``git-annex``, ``datalad``) and will be skipped if those are unavailable, so a fully green local
 run may still cover less than CI does.
+
+The no-duplication rule above applies to tests in particular.  Whenever a set of tests differ only
+in their inputs and expected outputs, express them as a **single**
+`parametrized <https://docs.pytest.org/en/stable/how-to/parametrize.html>`_ test rather than as
+several near-identical functions::
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0.02, True),  # 2% difference - compatible
+            (0.03, True),
+            (0.10, False),
+        ],
+    )
+    def test_something(value: float, expected: bool) -> None:
+        assert check(value) is expected
+
+Adding a case then costs one line, every case is exercised by the same assertions, and a failure
+reports which case broke.  Shared setup belongs in a fixture for the same reason.
 
 To reproduce the full CI matrix of linting, type checking, and tests in one go, run ``tox``.
 
@@ -210,6 +242,14 @@ implementation's current behavior rather than the behavior we actually want, and
 asserting the wrong thing.  Being able to identify them makes it feasible to revisit them when the
 underlying behavior is questioned.  Please double-check that such tests would indeed fail without
 the accompanying change.
+
+Assistants also have a strong tendency to emit a pile of copy-pasted test functions where one
+parametrized test would do, so the no-duplication rule needs enforcing especially firmly here.
+Before submitting AI-assisted tests, read them over and collapse any near-identical functions into
+a single ``@pytest.mark.parametrize``\ d test, hoist repeated setup into a fixture, and delete the
+cases which are not actually distinct.  Reviewers will ask for this, so it is cheaper to do it up
+front — and it is a good forcing function for the understanding you are expected to have of the
+code you submit.
 
 If an assistant was used substantially for the non-test portion of a change as well, please say so
 in the pull request description.  Do not paste in code you do not understand or cannot explain in

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,6 +2,24 @@
 Contributing to HeuDiConv
 =========================
 
+Quick reference
+---------------
+
+::
+
+    pip install -e .[all]        # install HeuDiConv and all its dependencies in editable mode
+    pip install pre-commit       # then `pre-commit install` to format/lint on every commit
+
+    pytest -v heudiconv          # run the test suite
+    pytest -v -k test_name ...   # run a subset of the tests
+    pytest -v -m ai_generated .  # run only the tests marked as AI-generated
+
+    tox                          # run linting, type checking, and tests as CI would
+    tox -e lint                  # flake8 + codespell only
+    tox -e typing                # mypy only
+
+The sections below describe each of those in more detail.
+
 Files organization
 ------------------
 
@@ -13,6 +31,7 @@ Files organization
   - ``external/`` - general compatibility layers for external functions HeuDiConv depends on.
   - ``heuristics/`` - heuristic evaluators for workflows, pull requests here are particularly
     welcome.
+  - ``tests/`` - the test suite, along with the small DICOM/NIfTI samples it operates on.
 
 * `docs/ <./docs>`_ - documentation directory.
 * `utils/ <./utils>`_ - helper utilities used during development, testing, and distribution of
@@ -81,12 +100,17 @@ The following pull request labels are respected:
 Development environment
 -----------------------
 
-We support Python 3 only (>= 3.7).
+We support Python 3 only (>= 3.9), and test against all Python versions from 3.9 through 3.13.
 
-Dependencies which you will need are `listed in the repository <heudiconv/info.py>`_.
+Dependencies which you will need are listed in `heudiconv/info.py <./heudiconv/info.py>`_.
 Note that you will likely have these will already be available on your system if you used a
 package manager (e.g. Debian's ``apt-get``, Gentoo's ``emerge``, or simply PIP) to install the
 software.
+
+HeuDiConv also calls out to a number of external tools, most notably ``dcm2niix``, which is not
+installable from PyPI and thus must be provided by your system (e.g. via NeuroDebian, conda, or
+`its own releases <https://github.com/rordenlab/dcm2niix/releases>`_).  Some tests additionally
+require ``git-annex`` and ``datalad``.
 
 Development work might require live access to the copy of HeuDiConv which is being developed.
 If a system-wide release of HeuDiConv is already installed, or likely to be, it is best to keep
@@ -112,19 +136,81 @@ To build the docs locally:
  2. From the `docs/` directory, run `make html`
 
 
-Additional Hints
-----------------
+Code style
+----------
 
-It is recommended to check that your contribution complies with the following
-rules before submitting a pull request:
+Formatting and linting are automated; do not hand-tune style.  Install the hooks once::
 
+    pip install pre-commit
+    pre-commit install
+
+and every commit will then be checked with `black <https://black.readthedocs.io>`_ (formatting),
+`isort <https://pycqa.github.io/isort/>`_ (import sorting), `flake8 <https://flake8.pycqa.org>`_
+(linting), and `codespell <https://github.com/codespell-project/codespell>`_ (typos).  You can run
+them all against the whole tree at any point with ``pre-commit run -a``, and the linting subset via
+``tox -e lint``.  Their configuration lives in ``.pre-commit-config.yaml``, ``tox.ini``, and
+``.codespellrc``.
+
+Beyond what the tools enforce:
+
+* HeuDiConv is fully type-annotated and ships a ``py.typed`` marker.  New functions must have
+  annotated arguments and return values; ``mypy`` is run in CI and can be run locally with
+  ``tox -e typing``.
 * All public functions (i.e. functions whose name does not start with an underscore) should have
-  informative docstrings with sample usage presented as doctests when appropriate.
+  informative docstrings with sample usage presented as doctests when appropriate.  Note that
+  ``pytest`` is configured with ``--doctest-modules``, so doctests are collected and executed as
+  part of the test suite.
 * Docstrings are formatted in `NumPy style <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
-* Lines are no longer than 120 characters.
-* All tests still pass::
+* Line length is whatever ``black`` produces (88 columns); ``flake8`` is configured to ignore
+  ``E501``, so the occasional long URL or string literal is tolerated rather than mangled.
+
+Testing
+-------
+
+New code should be accompanied by new tests, and all tests should pass before you submit a pull
+request::
 
     cd /path/to/your/clone/of/heudiconv
-    pytest -vvs .
+    pytest -v heudiconv
 
-* New code should be accompanied by new tests.
+The suite lives in ``heudiconv/tests/`` (plus per-submodule test files) and is built on
+`pytest <https://docs.pytest.org>`_.  A number of tests need external tools (``dcm2niix``,
+``git-annex``, ``datalad``) and will be skipped if those are unavailable, so a fully green local
+run may still cover less than CI does.
+
+To reproduce the full CI matrix of linting, type checking, and tests in one go, run ``tox``.
+
+AI-assisted contributions
+-------------------------
+
+Contributions developed with the help of AI assistants (Claude Code, Copilot, etc.) are welcome,
+subject to the same review bar as any other contribution: you are the author, and you are
+responsible for understanding, verifying, and standing behind every line you submit.
+
+**Any test which was generated by an AI assistant must be marked** with the ``ai_generated``
+marker, which is registered in ``tox.ini``::
+
+    import pytest
+
+    @pytest.mark.ai_generated
+    def test_something() -> None:
+        ...
+
+Mark the test if the assistant wrote the bulk of it, even if you subsequently edited it; there is
+no need to mark a hand-written test that merely received an AI-suggested tweak.  For a
+parametrized test, place the marker on the test function alongside the ``parametrize`` decorators.
+The marker is purely informational — such tests run as part of the normal suite — but it lets us
+filter them::
+
+    pytest -v -m ai_generated .        # only AI-generated tests
+    pytest -v -m "not ai_generated" .  # everything else
+
+This matters because AI-generated tests have a characteristic failure mode: they can encode the
+implementation's current behavior rather than the behavior we actually want, and so pass while
+asserting the wrong thing.  Being able to identify them makes it feasible to revisit them when the
+underlying behavior is questioned.  Please double-check that such tests would indeed fail without
+the accompanying change.
+
+If an assistant was used substantially for the non-test portion of a change as well, please say so
+in the pull request description.  Do not paste in code you do not understand or cannot explain in
+review.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,8 +113,8 @@ so a plain virtualenv is enough to get a complete development environment::
 
   pip install dcm2niix git-annex
 
-`dcm2niix <https://pypi.org/project/dcm2niix/>`_ and
-`git-annex <https://pypi.org/project/git-annex/>`_ are wheels bundling the corresponding binaries
+`dcm2niix <https://pypi.org/project/dcm2niix/>`__ and
+`git-annex <https://pypi.org/project/git-annex/>`__ are wheels bundling the corresponding binaries
 for common platforms; ``datalad`` is pulled in by the ``datalad`` (and hence ``all``) extra of
 HeuDiConv itself.  You may of course still prefer to obtain them from your system package manager
 (e.g. NeuroDebian, conda, or Homebrew) if you already have those set up.


### PR DESCRIPTION
Draft for discussion.

## `CLAUDE.md` (new, 19 lines)

Follows the pattern used in [`datalad/datalad`](https://github.com/datalad/datalad/blob/master/CLAUDE.md): rather than duplicating conventions into a second file that will drift, it just tells the assistant to go read the project's contributing guide, and lists what it will find there. Note heudiconv's guide is `CONTRIBUTING.rst`, not `.md`, so the pointer references the `.rst`; no rename was done.

## `CONTRIBUTING.rst`

The pointer is only useful if the guide actually carries the conventions it defers to, so this brings it up to date:

**Corrections**
- "We support Python 3 only (>= 3.7)" → `>= 3.9`, per `heudiconv/info.py`; also notes the CI matrix is 3.9–3.13.
- "Lines are no longer than 120 characters" → line length is whatever `black` produces (88), since `flake8` is configured to ignore `E501`. The old number matched neither the formatter nor the linter.
- Fixed the broken relative link to `heudiconv/info.py` (it was written as link text pointing at a bare path).

**Previously undocumented tooling** — the guide told contributors to run `pytest` and nothing else, despite `.pre-commit-config.yaml`, `mypy.ini`, and `tox.ini` all being in the tree:
- New "Quick reference" block at the top with the handful of commands one actually needs.
- New "Code style" section covering `pre-commit` (black / isort / flake8 / codespell) and the fact that the codebase is fully type-annotated with `mypy` run in CI (`tox -e typing`).
- New "Testing" section: where the tests live, that `--doctest-modules` is on so doctests are executed, that some tests skip without `dcm2niix` / `git-annex` / `datalad` (so a green local run covers less than CI), and that `tox` reproduces the CI matrix.
- Mentioned the external tools HeuDiConv shells out to under "Development environment".

**AI-assisted contributions (new section)**
Requires `@pytest.mark.ai_generated` on any test written by an AI assistant. The marker is already registered in `tox.ini` and already in use at `heudiconv/tests/test_bids.py:1192` — it just was never written down anywhere a contributor would look. The section spells out when to apply it (assistant wrote the bulk of it, even if subsequently edited), how to filter on it (`pytest -m ai_generated` / `-m "not ai_generated"`), and *why* we care: AI-generated tests tend to encode current behavior rather than intended behavior, so they can pass while asserting the wrong thing — being able to find them again later is the point. Also asks contributors to disclose substantial AI use on the non-test parts in the PR description.

## Checks

- `CONTRIBUTING.rst` parses cleanly through docutils (no warnings at level 2+).
- `codespell` clean on both files.
- Docs-only change; no code touched.

## Open questions for reviewers

- Should the `ai_generated` requirement be stronger (e.g. a CI check), or is documenting it enough for now?
- Worth converting `CONTRIBUTING.rst` → `CONTRIBUTING.md` for consistency with `CHANGELOG.md` and the datalad layout? Deliberately left out of this PR to keep the diff reviewable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJ7SjBsZeYo7zzCmf69Vzs)_