### PR TITLE
BF: populate SeqInfo date/time from any available DICOM date/time tags

### DIFF
--- a/heudiconv/dicoms.py
+++ b/heudiconv/dicoms.py
@@ -115,6 +115,8 @@ def create_seqinfo(
     global total_files
     total_files += len(series_files)
 
+    date, time = get_datetime_strings_from_dcm(dcminfo)
+
     custom_seqinfo_data = (
         custom_seqinfo(wrapper=mw, series_files=series_files)
         if custom_seqinfo
@@ -155,9 +157,9 @@ def create_seqinfo(
         # For demographics to populate BIDS participants.tsv
         patient_age=dcminfo.get("PatientAge"),
         patient_sex=dcminfo.get("PatientSex"),
-        date=dcminfo.get("AcquisitionDate"),
+        date=date,
         series_uid=dcminfo.get("SeriesInstanceUID"),
-        time=dcminfo.get("AcquisitionTime"),
+        time=time,
         custom=custom_seqinfo_data,
     )
 
@@ -517,12 +519,12 @@ def get_reproducible_int(dicom_list: list[str]) -> int:
     )
 
 
-def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.datetime]:
+def get_datetime_from_dcm(dcm_data: dcm.Dataset) -> Optional[datetime.datetime]:
     """Extract datetime from filedataset, or return None is no datetime information found.
 
     Parameters
     ----------
-    dcm_data : dcm.FileDataset
+    dcm_data : dcm.Dataset
         DICOM with header, e.g., as ready by pydicom.dcmread.
         Objects with __getitem__ and have those keys with values properly formatted may also work
 
@@ -551,6 +553,38 @@ def get_datetime_from_dcm(dcm_data: dcm.FileDataset) -> Optional[datetime.dateti
     if check_tag("SeriesDate") and check_tag("SeriesTime"):
         return strptime_dcm_da_tm(dcm_data, "SeriesDate", "SeriesTime")
     return None
+
+
+def get_datetime_strings_from_dcm(
+    dcm_data: dcm.Dataset,
+) -> tuple[Optional[str], Optional[str]]:
+    """Get DICOM style date (YYYYMMDD) and time (HHMMSS.FFFFFF) strings
+
+    Uses AcquisitionDate and AcquisitionTime whenever both are present, and
+    otherwise falls back to whichever date/time :func:`get_datetime_from_dcm`
+    could establish (e.g. AcquisitionDateTime for XA30 enhanced DICOMs).
+
+    Parameters
+    ----------
+    dcm_data : dcm.Dataset
+        DICOM with header, e.g., as read by pydicom.dcmread.
+
+    Returns
+    -------
+    tuple of two Optional[str]
+        (date, time), each None if no corresponding information was found.
+    """
+    date = dcm_data.get("AcquisitionDate")
+    time = dcm_data.get("AcquisitionTime")
+    if date and time:
+        return str(date), str(time)
+
+    # take both from the same source so they are guaranteed to be consistent
+    datetime_ = get_datetime_from_dcm(dcm_data)
+    if datetime_ is None:
+        # nothing better to offer -- return whatever (if anything) we had
+        return (str(date) if date else None, str(time) if time else None)
+    return datetime_.strftime("%Y%m%d"), datetime_.strftime("%H%M%S.%f")
 
 
 def compress_dicoms(

--- a/heudiconv/tests/test_dicoms.py
+++ b/heudiconv/tests/test_dicoms.py
@@ -16,6 +16,7 @@ from heudiconv.dicoms import (
     dw,
     embed_dicom_and_nifti_metadata,
     get_datetime_from_dcm,
+    get_datetime_strings_from_dcm,
     get_reproducible_int,
     group_dicoms_into_seqinfos,
     parse_private_csa_header,
@@ -187,6 +188,107 @@ def test_create_seqinfo(
     mw = dw.wrapper_from_file(dcmfile)
     seqinfo = create_seqinfo(mw, [dcmfile], op.basename(dcmfile))
     assert seqinfo.sequence_name
+
+
+@pytest.mark.ai_generated
+def test_get_datetime_strings_from_dcm_acq_date_time() -> None:
+    # AcquisitionDate/AcquisitionTime are taken as is whenever both are present
+    typical_dcm = dcm.dcmread(
+        op.join(TESTS_DATA_PATH, "phantom.dcm"), stop_before_pixels=True
+    )
+    assert get_datetime_strings_from_dcm(typical_dcm) == (
+        typical_dcm.get("AcquisitionDate"),
+        typical_dcm.get("AcquisitionTime"),
+    )
+
+
+@pytest.mark.ai_generated
+def test_get_datetime_strings_from_dcm_acq_datetime() -> None:
+    # https://github.com/nipy/heudiconv/issues/537 -- some DICOMs (e.g. XA30
+    # enhanced ones) have only AcquisitionDateTime, and we should still be able
+    # to provide date and time
+    XA30_enhanced_dcm = dcm.dcmread(
+        op.join(
+            TESTS_DATA_PATH,
+            "MRI_102TD_PHA_S.MR.Chen_Matthews_1.3.1.2022.11.16.15.50.20.357.31204541.dcm",
+        ),
+        stop_before_pixels=True,
+    )
+    assert "AcquisitionDate" not in XA30_enhanced_dcm
+    assert "AcquisitionTime" not in XA30_enhanced_dcm
+
+    date, time = get_datetime_strings_from_dcm(XA30_enhanced_dcm)
+    acq_datetime = XA30_enhanced_dcm.get("AcquisitionDateTime")
+    assert date == acq_datetime[:8]
+    assert date is not None and time is not None
+    assert datetime.datetime.strptime(
+        date + time, "%Y%m%d%H%M%S.%f"
+    ) == datetime.datetime.strptime(acq_datetime, "%Y%m%d%H%M%S.%f")
+
+
+@pytest.mark.ai_generated
+def test_get_datetime_strings_from_dcm_series_date_time() -> None:
+    # fall back to SeriesDate/SeriesTime if no acquisition date/time/datetime
+    XA30_enhanced_dcm = dcm.dcmread(
+        op.join(
+            TESTS_DATA_PATH,
+            "MRI_102TD_PHA_S.MR.Chen_Matthews_1.3.1.2022.11.16.15.50.20.357.31204541.dcm",
+        ),
+        stop_before_pixels=True,
+    )
+    del XA30_enhanced_dcm.AcquisitionDateTime
+    date, time = get_datetime_strings_from_dcm(XA30_enhanced_dcm)
+    assert date == XA30_enhanced_dcm.get("SeriesDate")
+    assert date is not None and time is not None
+    assert datetime.datetime.strptime(
+        date + time, "%Y%m%d%H%M%S.%f"
+    ) == datetime.datetime.strptime(
+        XA30_enhanced_dcm.get("SeriesDate") + XA30_enhanced_dcm.get("SeriesTime"),
+        "%Y%m%d%H%M%S.%f",
+    )
+
+
+@pytest.mark.ai_generated
+def test_get_datetime_strings_from_dcm_wo_dt() -> None:
+    # no date/time information whatsoever (e.g. after anonymization) -- no error
+    XA30_enhanced_dcm = dcm.dcmread(
+        op.join(
+            TESTS_DATA_PATH,
+            "MRI_102TD_PHA_S.MR.Chen_Matthews_1.3.1.2022.11.16.15.50.20.357.31204541.dcm",
+        ),
+        stop_before_pixels=True,
+    )
+    del XA30_enhanced_dcm.AcquisitionDateTime
+    del XA30_enhanced_dcm.SeriesDate
+    del XA30_enhanced_dcm.SeriesTime
+    assert get_datetime_strings_from_dcm(XA30_enhanced_dcm) == (None, None)
+
+
+@pytest.mark.ai_generated
+def test_get_datetime_strings_from_dcm_partial() -> None:
+    # if only a date is known and nothing else -- return it with time being None
+    typical_dcm = dcm.dcmread(
+        op.join(TESTS_DATA_PATH, "phantom.dcm"), stop_before_pixels=True
+    )
+    acq_date = typical_dcm.get("AcquisitionDate")
+    del typical_dcm.AcquisitionTime
+    del typical_dcm.SeriesDate
+    del typical_dcm.SeriesTime
+    assert get_datetime_strings_from_dcm(typical_dcm) == (acq_date, None)
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize("dcmfile", TEST_DICOM_PATHS)
+def test_create_seqinfo_date_time(dcmfile: str) -> None:
+    # all our test DICOMs do carry some date/time information, and seqinfo
+    # should expose it regardless of which tags it comes from
+    mw = dw.wrapper_from_file(dcmfile)
+    seqinfo = create_seqinfo(mw, [dcmfile], op.basename(dcmfile))
+    assert seqinfo.date is not None
+    assert seqinfo.time is not None
+    assert datetime.datetime.strptime(
+        seqinfo.date + seqinfo.time, "%Y%m%d%H%M%S.%f"
+    ) == get_datetime_from_dcm(mw.dcm_data)
 
 
 @pytest.mark.parametrize("dcmfile", TEST_DICOM_PATHS)


### PR DESCRIPTION
Addresses https://github.com/nipy/heudiconv/issues/537 (in particular https://github.com/nipy/heudiconv/issues/537#issuecomment-5198647517).

## Problem

`SeqInfo.date` / `SeqInfo.time` were taken verbatim from `AcquisitionDate` (0008,0022) and `AcquisitionTime` (0008,0032):

```python
date=dcminfo.get("AcquisitionDate"),
time=dcminfo.get("AcquisitionTime"),
```

Those tags are optional, so both fields ended up `None` in `dicominfo.tsv` and in heuristics for

- XA30 enhanced DICOMs, which carry only `AcquisitionDateTime` (0008,002A) — the case reported in the linked comment;
- de-identified data where only `SeriesDate`/`SeriesTime` survived.

`heudiconv.dicoms.get_datetime_from_dcm()` already knows how to pick a datetime out of all three sources, but it was only used for tarball reproducibility (`get_reproducible_int`) and for BIDS `AcquisitionDateTime`, not when filling `SeqInfo`.

## Changes

- New `heudiconv.dicoms.get_datetime_strings_from_dcm()` returning `(date, time)` DICOM-style strings:
  - returns `AcquisitionDate`/`AcquisitionTime` as is whenever both are present (no change in behavior/format for the common case);
  - otherwise formats whatever `get_datetime_from_dcm()` establishes (`AcquisitionDateTime`, then `SeriesDate`+`SeriesTime`) as `%Y%m%d` / `%H%M%S.%f`. Both values come from the same source, so they cannot become mutually inconsistent;
  - returns `None` for whatever is unknown — no exception when the header was stripped, as requested in the issue discussion.
- `create_seqinfo()` uses it for the `date` and `time` fields.
- `get_datetime_from_dcm()` annotation widened from `dcm.FileDataset` to `dcm.Dataset` (it only needs `__contains__`/`__getitem__`; docstring already said so).

A side benefit: reproin's `session=DATE`/`{date}` support now works for scanners which only provide `AcquisitionDateTime`.

## Tests

Added to `heudiconv/tests/test_dicoms.py`, all marked `@pytest.mark.ai_generated`:

- `test_get_datetime_strings_from_dcm_acq_date_time` — plain `AcquisitionDate`/`AcquisitionTime` passed through unchanged;
- `test_get_datetime_strings_from_dcm_acq_datetime` — XA30 enhanced DICOM (no `AcquisitionDate`/`AcquisitionTime`) yields date and time matching `AcquisitionDateTime`;
- `test_get_datetime_strings_from_dcm_series_date_time` — fallback to `SeriesDate`/`SeriesTime`;
- `test_get_datetime_strings_from_dcm_wo_dt` — nothing available → `(None, None)`, no exception;
- `test_get_datetime_strings_from_dcm_partial` — only a date available → `(date, None)`;
- `test_create_seqinfo_date_time` — parametrized over all test DICOMs: `seqinfo.date`/`seqinfo.time` are populated and agree with `get_datetime_from_dcm()`.

Test run: `python -m pytest heudiconv --ignore=heudiconv/tests/test_regression.py` → 205 passed, 14 skipped, 1 failed. The single failure is `test_heuristics.py::test_partial_xa_conversion`, which fails identically on the unmodified base commit in this container (older `dcm2niix` 1.0.20220720). `mypy heudiconv` reports only the one pre-existing error in `heudiconv/heuristics/test_reproin.py`; `black`/`flake8` are clean on the changed hunks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KA6v8mxbBXjUQwDmpSpg2R)_